### PR TITLE
Matplotlib tests fix

### DIFF
--- a/data/base.py
+++ b/data/base.py
@@ -1923,11 +1923,11 @@ class Base(object):
 
     def _matplotlibBackendHandleing(self, outPath, plotter, **kwargs):
         if outPath is None:
-            if matplotlib.get_backend() == 'Agg':
-                warnings.warn(
-                    'Running non interactive session. '
-                    'Providing a path to save plots recommended. '
-                    'Agg matplotlib backend is being use (not plots displayed).')
+            if matplotlib.get_backend() == 'agg':
+                import matplotlib.pyplot as plt
+                plt.switch_backend('TkAgg')
+                plotter(**kwargs)
+                plt.switch_backend('agg')
             else:
                 plotter(**kwargs)
             p = Process(target=lambda: None)


### PR DESCRIPTION
After examining the tests, plot functions were calling. I realize that the related processes were exiting with code = -11 (SYSSEGV). This made me suspect that the problem wasn't entirely related to the virtual env not being able to correctly interact with OSX through the native GUI frameworks but it was also related to the multiprocessing library. I found this [Segfault when using multiprocessing issue](https://github.com/matplotlib/matplotlib/issues/8795) reported in the matplotlib repository.

The actual reason why I wasn't evidencing the problems in Python3 was that in base.py, when importing matplotlib, it was set to use 'Agg' backend. I made the change so in the case of Python2 was also set to use 'Agg' backend and the failing tests stopped being a problem.

However, I noticed in the case of not providing and 'outPath' there was going to be a problem with calls to matplotlib .show() method. This because of the use of no-GUI 'Agg' backend. Tests for cases calling .show() having been implemented and I didn't add them yet because I haven't put too much thought into how would I test this functionality. I think this case would be of use most of the time when using UML interactively, e.g., via a notebook. How it was set with 'agg' for Python3 <base object>.plot() was not going to show a plot because 'agg' usage was forced even in interactive sessions. It wouldn't produce any error or warning. It'd just execute without giving any output. I tried to change this behavior.

I thought for this case it was important to differentiate when the library was being used in an interactive session, or inside a script, another library, meaning a non-interactive way. 

Once I include this distinction. For non-interactive cases I set the use of 'Agg', assuming in this cases the user is interested in saving the plots on certain location as opposed to wanting the plots to pop-up. In the interactive cases, I don't force the use of 'agg' but I let the backend been chosen by default, for instance, in the case of Jupyter the default backend is: 'inline' and changes from the default would be possible, in this case from Jupyter 'scope'.

In the case of a non-interactive session. If .show() would be called in a method. A warning message recommending to provide a path for saving the plots is provided and the function continues, no plot is open in any GUI.

This was happening in three methods of Base Class. I abstracted the behaviour of them to handle this backend issue as best as possible.