### PR TITLE
List indices helper

### DIFF
--- a/data/base.py
+++ b/data/base.py
@@ -49,6 +49,8 @@ from multiprocessing import Process
 
 import UML
 
+pd = UML.importModule('pandas')
+
 cython = UML.importModule('cython')
 if cython is None or not cython.compiled:
     from math import sin, cos
@@ -5095,6 +5097,11 @@ class Base(object):
         if isinstance(values, (int, numpy.integer, six.string_types)):
             values = self._getIndex(values, axis)
             return [values]
+        if pd and isinstance(values, pd.DataFrame):
+            msg = "A pandas DataFrame object is not a valid input "
+            msg += "for '{0}s'. ".format(axis)
+            msg += "Only one-dimensional objects are accepted."
+            raise ArgumentException(msg)
         valuesList = []
         try:
             for val in values:

--- a/data/tests/low_level_backend.py
+++ b/data/tests/low_level_backend.py
@@ -1313,6 +1313,10 @@ class LowLevelBackend(object):
         self._constructIndicesList_backend(lambda lst: numpy.matrix(lst))
 
     @raises(ArgumentException)
+    def test_constructIndicesList_pandasDataFrame(self):
+        self._constructIndicesList_backend(lambda lst: pandas.DataFrame(lst))
+
+    @raises(ArgumentException)
     def test_constructIndicesList_handmade2DOne(self):
         pointNames = ['p1','p2','p3']
         featureNames = ['f1', 'f2', 'f3']


### PR DESCRIPTION
Helper function _constructIndicesList(), to convert various inputs into a list of indices.  

The code first checks if a single integer or string were input. If so, it returns a list with that input. Otherwise, it attempts to iterate through the input. There are two possible points of failure:
1. Iteration cannot occur, raising a TypeError
    - This raises an ArgumentException with message: "The argument '{argName}' is not iterable"
2. The value passed to _getIndex is invalid, raising an ArgumentException.
    - This is either because the value is another iterable (container is not one-dimensional) or the value is a float, index that is out of range, or string that is not a valid name.
    - This will raise a new ArgumentException which states "Invalid index value for the argument {argName}" then adds the more descriptive exception message from _getIndex
