### PR TITLE
Test updates for scikitlearn interface

### DIFF
--- a/interfaces/tests/scikit_learn_interface_test.py
+++ b/interfaces/tests/scikit_learn_interface_test.py
@@ -315,7 +315,8 @@ def testSciKitLearnPredictAndTransformLearners():
                'StandardScaler', 'LabelBinarizer', 'LabelEncoder',
                'DummyClassifier', 'DictVectorizer', 'CountVectorizer',
                'TfidfVectorizer', 'MultiLabelBinarizer', 'SparseRandomProjection',
-               'GaussianRandomProjection', 'LinearDiscriminantAnalysis']
+               'GaussianRandomProjection', 'LinearDiscriminantAnalysis',
+               'Normalizer', 'ZeroEstimator', 'ScaledLogOddsEstimator']
 
     for learner in learners:
         if learner not in exclude:
@@ -337,7 +338,10 @@ def testSciKitLearnPredictAndTransformLearners():
                 trainY = cTrainY.data
                 testX = cTestX.data
 
-            args, _, _, _  = inspect.getargspec(sklObj)
+            try:
+                args, _, _, _  = inspect.getargspec(sklObj)
+            except TypeError:
+                args, _, _, _ = inspect.getargspec(sklObj.__init__)
             uml_kwds = {}
             uml_kwds['trainX'] = trainXObj
             uml_kwds['trainY'] = trainYObj


### PR DESCRIPTION
Added tests to compare that output from UML matches the output from scikitlearn. Most are tested in a single function, with multitask learners requiring a separate test.  129/153 learners are included in these tests. 

Of the learners that are excluded, 7 do not have a 'predict' or 'transform' method, which we currently cannot handle in scikit_learn_interface.py. The other 17 are failing for various reasons, most are feature extraction or preprocessing functions. These excluded learners will require additional testing and possibly adjustments to the interface.