### PR TITLE
Getargspec update

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -338,7 +338,7 @@ class SessionConfiguration(object):
             if not hasattr(toCall, '__call__'):
                 msg = 'toCall must be callable (function, method, etc) or None'
                 raise ArgumentException(msg)
-            if len(UML.helpers._parseSignature(toCall)[0]) != 1:
+            if len(UML.helpers.inspectArguments(toCall)[0]) != 1:
                 msg = 'toCall may only take one argument'
                 raise ArgumentException(msg)
 

--- a/customLearners/custom_learner.py
+++ b/customLearners/custom_learner.py
@@ -5,7 +5,7 @@ import numpy
 import six
 from six.moves import range
 
-from UML.helpers import _parseSignature
+from UML.helpers import inspectArguments
 
 
 class CustomLearner(six.with_metaclass(abc.ABCMeta, object)):
@@ -37,9 +37,9 @@ class CustomLearner(six.with_metaclass(abc.ABCMeta, object)):
                     accepted))
 
         # check train / apply params
-        trainInfo = _parseSignature(check.train)
-        incInfo = _parseSignature(check.incrementalTrain)
-        applyInfo = _parseSignature(check.apply)
+        trainInfo = inspectArguments(check.train)
+        incInfo = inspectArguments(check.incrementalTrain)
+        applyInfo = inspectArguments(check.apply)
         if trainInfo[0][0] != 'self' or trainInfo[0][1] != 'trainX' or trainInfo[0][2] != 'trainY':
             raise TypeError(
                 "The train method of a CustomLearner must have 'trainX' and 'trainY' as its first two (non 'self') parameters")
@@ -69,7 +69,7 @@ class CustomLearner(six.with_metaclass(abc.ABCMeta, object)):
         # getScores has same params as apply if overridden
         getScoresImplemented = overridden('getScores')
         if getScoresImplemented:
-            getScoresInfo = _parseSignature(check.getScores)
+            getScoresInfo = inspectArguments(check.getScores)
             if getScoresInfo != applyInfo:
                 raise TypeError("The signature for the getScores() method must be the same as the apply() method")
 
@@ -82,7 +82,7 @@ class CustomLearner(six.with_metaclass(abc.ABCMeta, object)):
                 raise TypeError("The classmethod options must return a list of stings")
 
         # check that we can instantiate this subclass
-        initInfo = _parseSignature(check.__init__)
+        initInfo = inspectArguments(check.__init__)
         if len(initInfo[0]) > 1 or initInfo[0][0] != 'self':
             raise TypeError("The __init__() method for this class must only have self as an argument")
 
@@ -113,7 +113,7 @@ class CustomLearner(six.with_metaclass(abc.ABCMeta, object)):
         Class method used to determine the parameters of only the train
         method.
         """
-        info = _parseSignature(cls.train)
+        info = inspectArguments(cls.train)
         return info[0][2:]
 
     @classmethod
@@ -122,7 +122,7 @@ class CustomLearner(six.with_metaclass(abc.ABCMeta, object)):
         Class method used to determine the default values of only the train
         method.
         """
-        info = _parseSignature(cls.train)
+        info = inspectArguments(cls.train)
         (objArgs, v, k, d) = info
         ret = {}
         if d is not None:
@@ -136,7 +136,7 @@ class CustomLearner(six.with_metaclass(abc.ABCMeta, object)):
         Class method used to determine the parameters of only the apply
         method.
         """
-        info = _parseSignature(cls.apply)
+        info = inspectArguments(cls.apply)
         return info[0][1:]
 
     @classmethod
@@ -145,7 +145,7 @@ class CustomLearner(six.with_metaclass(abc.ABCMeta, object)):
         Class method used to determine the default values of only the apply
         method.
         """
-        info = _parseSignature(cls.apply)
+        info = inspectArguments(cls.apply)
         (objArgs, v, k, d) = info
         ret = {}
         if d is not None:

--- a/data/tests/high_level_backend.py
+++ b/data/tests/high_level_backend.py
@@ -1546,7 +1546,7 @@ class HighLevelModifying(DataTestObject):
             d = func.__func__.__defaults__
             assert (d is None) or (d == (None, None, None))
         else:#if it is a normal python function
-            a, va, vk, d = UML.helpers._parseSignature(func)
+            a, va, vk, d = UML.helpers.inspectArguments(func)
             assert d == (None, None, None)
 
         if axis == 'point':

--- a/data/tests/randomized_sequence_test.py
+++ b/data/tests/randomized_sequence_test.py
@@ -20,7 +20,7 @@ import UML
 from UML.data import Base
 from UML.data import BaseView
 from UML.exceptions import ArgumentException
-from UML.helpers import _parseSignature
+from UML.helpers import inspectArguments
 from UML.randomness import pythonRandom
 from six.moves import range
 
@@ -599,7 +599,7 @@ untested = ['dropFeaturesContainingType', # how can you choose the type?
 def makeParams(funcName, dataObj, seed):
     random.seed(seed)
     generatorList = generators[funcName]
-    (args, varargs, keywords, defaults) = _parseSignature(getattr(dataObj, funcName))
+    (args, varargs, keywords, defaults) = inspectArguments(getattr(dataObj, funcName))
 
     #	if funcName.startswith('appendFeatures'):
     #		pdb.set_trace()
@@ -665,7 +665,7 @@ def TODO_GeneratorListSandC():
     for funcName in generators.keys():
         # test that there are generators for each possible argument
         # (except self)
-        (a, v, k, d) = _parseSignature(getattr(dobj, funcName))
+        (a, v, k, d) = inspectArguments(getattr(dobj, funcName))
         assert (len(a) - 1) == len(generators[funcName])
 
         assert funcName in testable
@@ -679,7 +679,7 @@ def TODO_MakeParamsExclusivity():
         # random trials
         for i in range(50):
             genArgs = makeParams(funcName, dobj, UML.randomness.pythonRandom.random())
-            (args, v, k, defaults) = _parseSignature(getattr(dobj, funcName))
+            (args, v, k, defaults) = inspectArguments(getattr(dobj, funcName))
             seenNonDefault = False
             for ex in mutuallyExclusiveParams[funcName]:
                 if isinstance(ex, tuple):

--- a/helpers.py
+++ b/helpers.py
@@ -3654,7 +3654,7 @@ def trainAndTestOneVsOne(learnerName, trainX, trainY, testX, testY, arguments={}
                                 arguments=arguments, performanceFunction=performanceFunction, useLog=useLog, **kwarguments)
 
 
-def _parseSignature(func):
+def inspectArguments(func):
     """
     To be used in place of inspect.getargspec for Python3 compatibility.
     Return is the tuple (args, varargs, keywords, defaults)

--- a/interfaces/keras_interface.py
+++ b/interfaces/keras_interface.py
@@ -18,7 +18,7 @@ import UML
 from UML.exceptions import ArgumentException
 from UML.interfaces.interface_helpers import PythonSearcher
 from UML.interfaces.interface_helpers import collectAttributes
-from UML.helpers import _parseSignature
+from UML.helpers import inspectArguments
 from six.moves import range
 
 # Contains path to keras root directory
@@ -572,7 +572,7 @@ class Keras(UniversalInterface):
             return ([], None, None, None)
 
         try:
-            (args, v, k, d) = _parseSignature(namedModule)
+            (args, v, k, d) = inspectArguments(namedModule)
             (args, d) = self._removeFromTailMatchedLists(args, d, ignore)
             if 'random_state' in args:
                 index = args.index('random_state')
@@ -581,7 +581,7 @@ class Keras(UniversalInterface):
             return (args, v, k, d)
         except TypeError:
             try:
-                (args, v, k, d) = _parseSignature(namedModule.__init__)
+                (args, v, k, d) = inspectArguments(namedModule.__init__)
                 (args, d) = self._removeFromTailMatchedLists(args, d, ignore)
                 if 'random_state' in args:
                     index = args.index('random_state')

--- a/interfaces/mlpy_interface.py
+++ b/interfaces/mlpy_interface.py
@@ -31,7 +31,7 @@ locationCache = {}
 
 from UML.interfaces.universal_interface import UniversalInterface
 from UML.interfaces.interface_helpers import PythonSearcher
-from UML.helpers import _parseSignature
+from UML.helpers import inspectArguments
 
 
 class Mlpy(UniversalInterface):
@@ -511,7 +511,7 @@ class Mlpy(UniversalInterface):
         namedModule = self._searcher.findInPackage(parent, name)
 
         # for python 3
-        # in python 3, _parseSignature(mlpy.KNN.__init__) works, but returns back wrong arguments. we need to purposely run
+        # in python 3, inspectArguments(mlpy.KNN.__init__) works, but returns back wrong arguments. we need to purposely run
         # self._paramQueryHardCoded(name, parent, ignore) for KNN, PCA...
         excludeList = ['libsvm', 'knn', 'liblinear', 'maximumlikelihoodc', 'KernelAdatron'.lower(), 'ClassTree'.lower(), 'MFastHCluster'.lower(), 'kmeans']
         if sys.version_info.major > 2 and 'kernel' not in name.lower():
@@ -520,7 +520,7 @@ class Mlpy(UniversalInterface):
 
         if not namedModule is None:
             try:
-                (args, v, k, d) = _parseSignature(namedModule)
+                (args, v, k, d) = inspectArguments(namedModule)
                 (args, d) = self._removeFromTailMatchedLists(args, d, ignore)
                 if 'seed' in args:
                     index = args.index('seed')
@@ -529,7 +529,7 @@ class Mlpy(UniversalInterface):
                 return (args, v, k, d)
             except TypeError:
                 try:
-                    (args, v, k, d) = _parseSignature(namedModule.__init__)
+                    (args, v, k, d) = inspectArguments(namedModule.__init__)
                     (args, d) = self._removeFromTailMatchedLists(args, d, ignore)
                     if 'seed' in args:
                         index = args.index('seed')

--- a/interfaces/scikit_learn_interface.py
+++ b/interfaces/scikit_learn_interface.py
@@ -20,7 +20,7 @@ import UML
 from UML.exceptions import ArgumentException
 from UML.interfaces.interface_helpers import PythonSearcher
 from UML.interfaces.interface_helpers import collectAttributes
-from UML.helpers import _parseSignature
+from UML.helpers import inspectArguments
 from six.moves import range
 
 # Contains path to sciKitLearn root directory
@@ -568,6 +568,6 @@ class SciKitLearn(UniversalInterface):
         elif not hasattr(namedModule, name):
             return None
         else:
-            (args, v, k, d) = _parseSignature(getattr(namedModule, name))
+            (args, v, k, d) = inspectArguments(getattr(namedModule, name))
             (args, d) = self._removeFromTailMatchedLists(args, d, ignore)
             return (args, d)

--- a/interfaces/tests/scikit_learn_interface_test.py
+++ b/interfaces/tests/scikit_learn_interface_test.py
@@ -22,7 +22,7 @@ from UML.exceptions import ArgumentException
 from UML.helpers import generateClassificationData
 from UML.helpers import generateRegressionData
 from UML.helpers import generateClusteredPoints
-from UML.helpers import _parseSignature
+from UML.helpers import inspectArguments
 from UML.calculate.loss import rootMeanSquareError
 from UML.interfaces.scikit_learn_interface import SciKitLearn
 from UML.interfaces.universal_interface import UniversalInterface

--- a/interfaces/universal_interface.py
+++ b/interfaces/universal_interface.py
@@ -25,7 +25,7 @@ from UML.interfaces.interface_helpers import checkClassificationStrategy
 from UML.interfaces.interface_helpers import cacheWrapper
 from UML.logger import Stopwatch
 
-from UML.helpers import _mergeArguments, generateAllPairs, countWins, _parseSignature
+from UML.helpers import _mergeArguments, generateAllPairs, countWins, inspectArguments
 import six
 from six.moves import range
 import warnings
@@ -98,7 +98,7 @@ class UniversalInterface(six.with_metaclass(abc.ABCMeta, object)):
                 raise TypeError(
                     "Improper implementation of _exposedFunctions, each member of the return must have __name__ attribute")
             # takes self as attribute
-            (args, varargs, keywords, defaults) = _parseSignature(exposed)
+            (args, varargs, keywords, defaults) = inspectArguments(exposed)
             if args[0] != 'self':
                 raise TypeError(
                     "Improper implementation of _exposedFunctions each member's first argument must be 'self', interpreted as a TrainedLearner")
@@ -722,7 +722,7 @@ class UniversalInterface(six.with_metaclass(abc.ABCMeta, object)):
             exposedFunctions = self.interface._exposedFunctions()
             for exposed in exposedFunctions:
                 methodName = getattr(exposed, '__name__')
-                (args, varargs, keywords, defaults) = _parseSignature(exposed)
+                (args, varargs, keywords, defaults) = inspectArguments(exposed)
                 if 'trainedLearner' in args:
                     wrapped = functools.partial(exposed, trainedLearner=self)
                     wrapped.__doc__ = 'Wrapped version of the ' + methodName + ' function where the "trainedLearner" parameter has been fixed as this object, and the "self" parameter has been fixed to be ' + str(

--- a/tests/testHelpers.py
+++ b/tests/testHelpers.py
@@ -25,7 +25,7 @@ from UML.helpers import trainAndApplyOneVsOne
 from UML.helpers import trainAndApplyOneVsAll
 from UML.helpers import _mergeArguments
 from UML.helpers import computeMetrics
-from UML.helpers import _parseSignature
+from UML.helpers import inspectArguments
 from UML.calculate import rootMeanSquareError
 from UML.calculate import meanAbsoluteError
 from UML.calculate import fractionIncorrect
@@ -640,12 +640,12 @@ def testGenerateAllPairs():
     testPairs2 = generateAllPairs(testList2)
     assert testPairs2 is None
 
-def test__parseSignature():
+def test_inspectArguments():
 
     def checkSignature(a, b, c, d=False, e=True, f=None, *sigArgs, **sigKwargs):
         pass
 
-    a, v, k, d = _parseSignature(checkSignature)
+    a, v, k, d = inspectArguments(checkSignature)
 
     assert a == ['a', 'b', 'c', 'd', 'e', 'f']
     assert v == 'sigArgs'


### PR DESCRIPTION
Created a function inspectArguments() in helpers.py which will use inspect.getfullargspec for python3 and return the first 4 indices of the returned tuple to match the output of inspect.getargspec which will still be used for python2.

Replaced all instances of getargspec with _parseSignature and added a test in testHelpers.py