### PR TITLE
Guarantee no missing values

### DIFF
--- a/data/list.py
+++ b/data/list.py
@@ -647,18 +647,44 @@ class List(Base):
                         self.data[i][j] = arguments
             else:
                 raise ArgumentException(msg)
-        elif method == 'forward fill':
-            for tmpItem in missingIdxDictFeature.items():
-                    j = tmpItem[0]
-                    for i in tmpItem[1]:
-                        if i > 0:
-                            self.data[i][j] = self.data[i-1][j]
-        elif method == 'backward fill':
-            for tmpItem in missingIdxDictFeature.items():
-                    j = tmpItem[0]
-                    for i in sorted(tmpItem[1], reverse=True):
-                        if i < self.points - 1:
-                            self.data[i][j] = self.data[i+1][j]
+        elif method == 'forward fill' or method == 'backward fill':
+            if method == 'forward fill':
+                initial = 'first'
+                missingFromInitialPoint = missingIdxDictPoint[0]
+                def sortMissing(lst):
+                    return lst
+                def referenceIdx(idx):
+                    return idx - 1
+            else:
+                initial = 'last'
+                missingFromInitialPoint = missingIdxDictPoint[self.points - 1]
+                def sortMissing(lst):
+                    return sorted(lst, reverse=True)
+                def referenceIdx(idx):
+                    return idx + 1
+            if len(missingFromInitialPoint) == 0:
+                for tmpItem in missingIdxDictFeature.items():
+                        j = tmpItem[0]
+                        for i in sortMissing(tmpItem[1]):
+                            if i > 0:
+                                self.data[i][j] = self.data[referenceIdx(i)][j]
+            else:
+                # the initial point has one or more missing values, but we will
+                # also check if any of those features contain all missing values
+                allMissingValuesFeatureIndices = []
+                for feature in missingFromInitialPoint:
+                    if len(missingIdxDictFeature[feature]) == self.points:
+                        allMissingValuesFeatureIndices.append(feature)
+                msg = "Cannot remove all missing values using {0}. ".format(method)
+                if len(allMissingValuesFeatureIndices) == 0:
+                    msg += "The {0} point has missing values ".format(initial)
+                    msg += "at indices {0}.".format(missingFromInitialPoint)
+                    raise ArgumentException(msg)
+                else:
+                    msg += "The features at indices "
+                    msg += "{0} ".format(allMissingValuesFeatureIndices)
+                    msg += "contain only missing values"
+                    raise ArgumentException(msg)
         elif method == 'interpolate':
             for tmpItem in missingIdxDictFeature.items():
                 j = tmpItem[0]

--- a/data/sparse.py
+++ b/data/sparse.py
@@ -1103,6 +1103,44 @@ class Sparse(Base):
                         self.fillWith(arguments, i, j, i, j)
             else:
                 raise ArgumentException(msg)
+        elif method == 'forward fill' or method == 'backward fill':
+            if method == 'forward fill':
+                initial = 'first'
+                missingFromInitialPoint = missingIdxDictPoint[0]
+                def sortMissing(lst):
+                    return lst
+                def referenceIdx(idx):
+                    return idx - 1
+            else:
+                initial = 'last'
+                missingFromInitialPoint = missingIdxDictPoint[self.points - 1]
+                def sortMissing(lst):
+                    return sorted(lst, reverse=True)
+                def referenceIdx(idx):
+                    return idx + 1
+            if len(missingFromInitialPoint) == 0:
+                for tmpItem in missingIdxDictFeature.items():
+                        j = tmpItem[0]
+                        for i in sortMissing(tmpItem[1]):
+                            if i > 0:
+                                self.fillWith(self[referenceIdx(i), j], i, j, i, j)
+            else:
+                # the initial point has one or more missing values, but we will
+                # also check if any of those features contain all missing values
+                allMissingValuesFeatureIndices = []
+                for feature in missingFromInitialPoint:
+                    if len(missingIdxDictFeature[feature]) == self.points:
+                        allMissingValuesFeatureIndices.append(feature)
+                msg = "Cannot remove all missing values using {0}. ".format(method)
+                if len(allMissingValuesFeatureIndices) == 0:
+                    msg += "The {0} point has missing values ".format(initial)
+                    msg += "at indices {0}.".format(missingFromInitialPoint)
+                    raise ArgumentException(msg)
+                else:
+                    msg += "The features at indices "
+                    msg += "{0} ".format(allMissingValuesFeatureIndices)
+                    msg += "contain only missing values"
+                    raise ArgumentException(msg)
         elif method == 'forward fill':
             for tmpItem in missingIdxDictFeature.items():
                     j = tmpItem[0]

--- a/data/tests/high_level_backend.py
+++ b/data/tests/high_level_backend.py
@@ -1759,6 +1759,11 @@ class HighLevelModifying(DataTestObject):
         assert expAlsoL == alsoLess
         assert expAlsoM == alsoMore
 
+
+    #########################
+    # handleMissingValues() #
+    #########################
+
     def test_handleMissingValues_remove_points(self):
         obj0 = self.constructor([[1, 2, 3], [None, 11, None], [7, 11, None], [7, 8, 9]], featureNames=['a', 'b', 'c'])
 
@@ -1890,7 +1895,7 @@ class HighLevelModifying(DataTestObject):
         ret3.setFeatureNames(['a', 'b', 'c', 'a_missing', 'b_missing', 'c_missing'])
         assert obj3 == ret3
 
-    def test_handleMissingValues_forward_fill(self):
+    def test_handleMissingValues_forward_fill_simple(self):
         obj0 = self.constructor([[1, 2, 3], [None, 11, None], [7, 11, None], [7, 8, 9]], featureNames=['a', 'b', 'c'])
 
         obj3 = obj0.copy()
@@ -1899,7 +1904,21 @@ class HighLevelModifying(DataTestObject):
         ret3.setFeatureNames(['a', 'b', 'c', 'a_missing', 'b_missing', 'c_missing'])
         assert obj3 == ret3
 
-    def test_handleMissingValues_backward_fill(self):
+    @raises(ArgumentException)
+    def test_handleMissingValues_forward_fill_firstPointContainsMissing(self):
+        obj0 = self.constructor([[1, None, 3], [None, 11, None], [7, 11, None], [7, 8, 9]], featureNames=['a', 'b', 'c'])
+
+        obj1 = obj0.copy()
+        obj1.handleMissingValues(method='forward fill')
+
+    @raises(ArgumentException)
+    def test_handleMissingValues_forward_fill_allMissingFeature(self):
+        obj0 = self.constructor([[1, None, 3], [None, 11, None], [None, 11, 9], [7, 11, 9]], featureNames=['a', 'b', 'c'])
+
+        obj1 = obj0.copy()
+        obj1.handleMissingValues(method='forward fill', alsoTreatAsMissing=[11])
+
+    def test_handleMissingValues_backward_fill_simple(self):
         obj0 = self.constructor([[1, 2, 3], [None, 11, None], [7, 11, None], [7, 8, 9]], featureNames=['a', 'b', 'c'])
 
         obj3 = obj0.copy()
@@ -1907,6 +1926,20 @@ class HighLevelModifying(DataTestObject):
         ret3 = self.constructor([[1, 2, 3, False, False, False], [7, 8, 9, True, True, True], [7, 8, 9, False, True, True], [7, 8, 9, False, False, False]])
         ret3.setFeatureNames(['a', 'b', 'c', 'a_missing', 'b_missing', 'c_missing'])
         assert obj3 == ret3
+
+    @raises(ArgumentException)
+    def test_handleMissingValues_backward_fill_lastPointContainsMissing(self):
+        obj0 = self.constructor([[1, None, 3], [None, 11, None], [7, 11, None], [7, None, 9]], featureNames=['a', 'b', 'c'])
+
+        obj1 = obj0.copy()
+        obj1.handleMissingValues(method='backward fill')
+
+    @raises(ArgumentException)
+    def test_handleMissingValues_backward_fill_allMissingFeature(self):
+        obj0 = self.constructor([[1, None, 3], [None, 11, None], [None, 11, 9], [7, 11, 9]], featureNames=['a', 'b', 'c'])
+
+        obj1 = obj0.copy()
+        obj1.handleMissingValues(method='backward fill', alsoTreatAsMissing=[11])
 
     def test_handleMissingValues_interpolate(self):
         obj0 = self.constructor([[1, 2, 3], [None, 11, None], [7, 11, None], [7, 8, 9]], featureNames=['a', 'b', 'c'])
@@ -1916,6 +1949,7 @@ class HighLevelModifying(DataTestObject):
         ret3 = self.constructor([[1, 2, 3, False, False, False], [4, 11, 5, True, False, True], [7, 11, 7, False, False, True], [7, 8, 9, False, False, False]])
         ret3.setFeatureNames(['a', 'b', 'c', 'a_missing', 'b_missing', 'c_missing'])
         assert obj3 == ret3
+
 
 class HighLevelAll(HighLevelDataSafe, HighLevelModifying):
     pass


### PR DESCRIPTION
Raise an exception when using forward fill or backward fill for handleMissingValues, when the initial point (first point for forward fill, last point of backward fill) has missing values.

There are two different exception messages. Typically, the message will provide the indices of the features which are missing in the initial point. However, a check of each of those features also runs to see if the entire feature contains only missing values. If this is the case, the message indicates the indices of any features with only missing values.