### PR TITLE
Validate insertable data condition adjustment

### DIFF
--- a/data/base.py
+++ b/data/base.py
@@ -2452,11 +2452,17 @@ class Base(object):
         if axis == 'point':
             toAdd = self._alignNames('feature', toAdd)
             self._addPoints_implementation(toAdd, insertBefore)
-            self._setAddedCountAndNames('point', toAdd, insertBefore)
+            if not self._pointNamesCreated() and not toAdd._pointNamesCreated():
+                self._setpointCount(self.points + toAdd.points)
+            else:
+                self._setAddedCountAndNames('point', toAdd, insertBefore)
         else:
             toAdd = self._alignNames('point', toAdd)
             self._addFeatures_implementation(toAdd, insertBefore)
-            self._setAddedCountAndNames('feature', toAdd, insertBefore)
+            if not self._featureNamesCreated() and not toAdd._featureNamesCreated():
+                self._setfeatureCount(self.features + toAdd.features)
+            else:
+                self._setAddedCountAndNames('feature', toAdd, insertBefore)
 
         self.validate()
 
@@ -5392,17 +5398,11 @@ class Base(object):
     def _setAddedCountAndNames(self, axis, addedObj, insertedBefore):
         self._validateAxis(axis)
         if axis == 'point':
-            if not self._pointNamesCreated() and not addedObj._pointNamesCreated():
-                self._setpointCount(self.points + addedObj.points)
-                return
             selfNames = self.getPointNames()
             insertedNames = addedObj.getPointNames()
             setSelfNames = self.setPointNames
             self._setpointCount(self.points + addedObj.points)
         else:
-            if not self._featureNamesCreated() and not addedObj._featureNamesCreated():
-                self._setfeatureCount(self.features + addedObj.features)
-                return
             selfNames = self.getFeatureNames()
             insertedNames = addedObj.getFeatureNames()
             setSelfNames = self.setFeatureNames


### PR DESCRIPTION
Changes to _validateInsertableData so that unnecessary calls to the validation functions are avoided when dealing with certain cases of non-assigned names. These changes make sense to me, but seem to have far reaching consequences in the seemingly unrelated space of View arithmetic. 

Please check:
1) are these changes actually sensible
2) If yes - what is going on that causes these particular tests for fail?