### PR TITLE
Python 3 examples/fullPipelineExample.py error

### DIFF
--- a/interfaces/universal_interface.py
+++ b/interfaces/universal_interface.py
@@ -177,7 +177,7 @@ class UniversalInterface(six.with_metaclass(abc.ABCMeta, object)):
                 # labels and get predictions on the test set.
                 trainedLearners = []
                 for label in labelSet:
-                    relabeler.func_defaults = (label,)
+                    relabeler.__defaults__ = (label,)
                     trainLabels = trainY.points.calculate(relabeler)
                     trainedLearner = self._train(learnerName, trainX, trainLabels, arguments=arguments, \
                                                        timer=timer)


### PR DESCRIPTION
Fixed the bug preventing fullPipelineExample.py from running correctly in python3.  The defaults for a helper function called `relabeler` were being set for each iteration using `relabeler.func_defaults`.  This is only a valid attribute in Python 2.  Starting in Python 2.6, `__defaults__` was added for python 3 forward compatability.  If we want to support python < 2.6, we could instead do:
```
if hasattr(relabeler, '__defaults__'):
    relabeler.__defaults__ = (label,)
else:
    relabeler.func_defaults = (label,)
```