### PR TITLE
Interface versions

### DIFF
--- a/interfaces/custom_learner_interface.py
+++ b/interfaces/custom_learner_interface.py
@@ -305,3 +305,6 @@ class CustomLearnerInterface(UniversalInterface):
 
         """
         return []
+
+    def version(self):
+        pass

--- a/interfaces/keras_interface.py
+++ b/interfaces/keras_interface.py
@@ -635,3 +635,5 @@ class Keras(UniversalInterface):
 
         return None
 
+    def version(self):
+        return self.keras.__version__

--- a/interfaces/mlpy_interface.py
+++ b/interfaces/mlpy_interface.py
@@ -646,6 +646,8 @@ class Mlpy(UniversalInterface):
         (newArgs, newDefaults) = self._removeFromTailMatchedLists(ret[0], ret[3], ignore)
         return (newArgs, ret[1], ret[2], newDefaults)
 
+    def version(self):
+        return self.mlpy.__version__
 
 class _Kmeans(object):
     def __init__(self, k, plus=False, seed=0):

--- a/interfaces/scikit_learn_interface.py
+++ b/interfaces/scikit_learn_interface.py
@@ -51,9 +51,8 @@ class SciKitLearn(UniversalInterface):
             warnings.filterwarnings("ignore",category=DeprecationWarning)
             self.skl = importlib.import_module('sklearn')
 
-        version = self.skl.__version__
-        self._version = version
-        self._versionSplit = list(map(int,version.split('.')))
+        version = self.version()
+        self._versionSplit = list(map(int, version.split('.')))
 
         from sklearn.utils.testing import all_estimators
         all_estimators = all_estimators()
@@ -354,9 +353,9 @@ class SciKitLearn(UniversalInterface):
         TAKES name of learner, transformed arguments
         RETURNS an in package object to be wrapped by a TrainedLearner object
         """
-        msg = "UML was tested using sklearn 0.19 and above, we cannot be "
-        msg += "sure of success for version {0}".format(self._version)
         if self._versionSplit[1] < 19:
+            msg = "UML was tested using sklearn 0.19 and above, we cannot be "
+            msg += "sure of success for version {0}".format(self.version())
             warnings.warn(msg)
 
         # get parameter names
@@ -482,7 +481,6 @@ class SciKitLearn(UniversalInterface):
 
     # fit_transform
 
-
     def _predict(self, learner, testX, arguments, customDict):
         """
         Wrapper for the underlying predict function of a scikit-learn learner object
@@ -495,6 +493,8 @@ class SciKitLearn(UniversalInterface):
         """
         return learner.transform(testX)
 
+    def version(self):
+        return self.skl.__version__
 
     ###############
     ### HELPERS ###

--- a/interfaces/tests/keras_interface_test.py
+++ b/interfaces/tests/keras_interface_test.py
@@ -5,10 +5,16 @@ Unit tests for keras_interface.py
 
 from __future__ import absolute_import
 
+import numpy as np
+from keras import __version__ as kerasVersion
+
 import UML
 from UML import createData
+from UML.interfaces.keras_interface import Keras
 
-import numpy as np
+def test_Keras_version():
+    interface = Keras()
+    assert interface.version() == kerasVersion
 
 def testKerasAPI():
     """

--- a/interfaces/tests/mlpy_interface_test.py
+++ b/interfaces/tests/mlpy_interface_test.py
@@ -8,10 +8,15 @@ import UML
 
 from nose.tools import *
 import numpy.testing
+from mlpy import __version__ as mlpyVersion
 
 from UML.exceptions import ArgumentException
+from UML.interfaces.mlpy_interface import Mlpy
 from .test_helpers import checkLabelOrderingAndScoreAssociations
 
+def test_Mlpy_version():
+    interface = Mlpy()
+    assert interface.version() == mlpyVersion
 
 def testMlpyHandmadeSVMClassification():
     """ Test mlpy() by calling on SVM classification with handmade output """

--- a/interfaces/tests/scikit_learn_interface_test.py
+++ b/interfaces/tests/scikit_learn_interface_test.py
@@ -4,18 +4,19 @@ Unit tests for scikit_learn_interface.py
 """
 
 from __future__ import absolute_import
-import numpy.testing
-from nose.plugins.attrib import attr
-from nose.tools import raises
 import importlib
 import inspect
 import tempfile
 
-import UML
+import numpy.testing
+from nose.plugins.attrib import attr
+from nose.tools import raises
+from sklearn import __version__ as sklVersion
+from sklearn.metrics import mean_squared_error
 
+import UML
 from UML import loadTrainedLearner
 from UML.interfaces.tests.test_helpers import checkLabelOrderingAndScoreAssociations
-
 from UML.randomness import numpyRandom
 from UML.randomness import generateSubsidiarySeed
 from UML.exceptions import ArgumentException
@@ -27,12 +28,13 @@ from UML.calculate.loss import rootMeanSquareError
 from UML.interfaces.scikit_learn_interface import SciKitLearn
 from UML.interfaces.universal_interface import UniversalInterface
 
-from sklearn.metrics import mean_squared_error
-
 scipy = UML.importModule('scipy.sparse')
 
 packageName = 'sciKitLearn'
 
+def test_SciKitLearn_version():
+    interface = SciKitLearn()
+    assert interface.version() == sklVersion
 
 def toCall(learner):
     return packageName + '.' + learner

--- a/interfaces/tests/universal_test.py
+++ b/interfaces/tests/universal_test.py
@@ -130,6 +130,9 @@ class TestInterface(UniversalInterface):
     def _incrementalTrainer(self, learner, trainX, trainY, arguments, customDict):
         pass
 
+    def version(self):
+        return "0.0.0"
+
     def exposedOne(self):
         return 1
 
@@ -218,6 +221,14 @@ def test__validateArgumentDistributionInstantiableArgWithDefaultValue():
     ret = TestObject._validateArgumentDistribution(learner, arguments)
     assert ret == {'estimator': 'initable', 'initable': {'C': .11, 'thresh': 15}}
 
+
+###############
+### version ###
+###############
+
+def test_version():
+    ret = TestObject.version()
+    assert ret == "0.0.0"
 
 #########################
 ### exposed functions ###

--- a/interfaces/universal_interface.py
+++ b/interfaces/universal_interface.py
@@ -972,6 +972,13 @@ class UniversalInterface(six.with_metaclass(abc.ABCMeta, object)):
         """
         pass
 
+    @abc.abstractmethod
+    def version(self):
+        """
+        Return a string of the version of this interface.
+        """
+        pass
+
 ##################
 # TrainedLearner #
 ##################


### PR DESCRIPTION
Added abstract method version() to UniversalInterface.  Implemented and tested for keras, mlpy, and sklearn interfaces.  Added version() to CustomLearnerInterface but it currently returns None.  Shogun was ignored, however, the current implementation does contain a version function.