### PR TITLE
efficiency improvements replaceFeatureWithBinary

### DIFF
--- a/data/base.py
+++ b/data/base.py
@@ -431,46 +431,34 @@ class Base(object):
             raise ImproperActionException(msg)
 
         index = self.features.getIndex(featureToReplace)
-        # extract col.
-        toConvert = self.features.extract([index])
 
-        # MR to get list of values
-        def getValue(point):
-            return [(point[0], 1)]
+        replace = self.features.extract([index])
 
-        def simpleReducer(identifier, valuesList):
-            return (identifier, 0)
+        binaryFts = replace._replaceFeatureWithBinaryFeatures_implementation()
 
-        values = toConvert.points.mapReduce(getValue, simpleReducer)
-        values.features.setName(0, 'values')
-        values = values.features.extract([0])
+        toFill = numpy.zeros((len(replace.points), len(binaryFts)))
+        prefix = replace.features.getName(0) + "="
+        ftNames = []
+        for idx, (name, locations) in enumerate(binaryFts.items()):
+            ftNames.append(prefix + str(name))
+            toFill[locations, idx] = 1
 
-        # Convert to List, so we can have easy access
-        values = values.copyAs(format="List")
+        if self.points._namesCreated():
+            ptNames = self.points.getNames()
+        else:
+            ptNames='automatic'
+        binaryObj = UML.createData(self.getTypeString(), toFill,
+                                   pointNames=ptNames, featureNames=ftNames,
+                                   treatAsMissing=None)
 
-        # for each value run points.calculate to produce a category
-        # point for each value
-        def makeFunc(value):
-            def equalTo(point):
-                if point[0] == value:
-                    return 1
-                return 0
+        # by default, put back in same place
+        insertBefore = index
+        # if extracted last feature, None will append
+        if insertBefore == len(self.features):
+            insertBefore = None
+        self.features.add(binaryObj, insertBefore=insertBefore)
 
-            return equalTo
-
-        varName = toConvert.features.getName(0)
-
-        for point in values.data:
-            value = point[0]
-            ret = toConvert.points.calculate(makeFunc(value))
-            ret.features.setName(0, varName + "=" + str(value).strip())
-            toConvert.features.add(ret)
-
-        # remove the original feature, and combine with self
-        toConvert.features.extract([varName])
-        self.features.add(toConvert)
-
-        return toConvert.features.getNames()
+        return ftNames
 
     def transformFeatureToIntegers(self, featureToConvert, useLog=None):
         """

--- a/data/dataframe.py
+++ b/data/dataframe.py
@@ -249,7 +249,6 @@ class DataFrame(Base):
 
     def _merge_implementation(self, other, point, feature, onFeature,
                               matchingFtIdx):
-
         if point == 'union':
             point = 'outer'
         elif point == 'intersection':
@@ -323,6 +322,14 @@ class DataFrame(Base):
         self._featureCount = (numColsL + len(tmpDfR.columns)
                               - len(matchingFtIdx[1]))
         self._pointCount = len(self.data.index)
+
+    def _replaceFeatureWithBinaryFeatures_implementation(self):
+        binaryFts = {}
+        for idx, val in enumerate(self.data.values):
+            if val[0] not in binaryFts:
+                binaryFts[val[0]] = []
+            binaryFts[val[0]].append(idx)
+        return binaryFts
 
     def _getitem_implementation(self, x, y):
         # return self.data.ix[x, y]

--- a/data/list.py
+++ b/data/list.py
@@ -541,6 +541,14 @@ class List(Base):
 
         self.data = merged
 
+    def _replaceFeatureWithBinaryFeatures_implementation(self):
+        binaryFts = {}
+        for idx, val in enumerate(self.data):
+            if val[0] not in binaryFts:
+                binaryFts[val[0]] = []
+            binaryFts[val[0]].append(idx)
+        return binaryFts
+
     def _getitem_implementation(self, x, y):
         return self.data[x][y]
 

--- a/data/matrix.py
+++ b/data/matrix.py
@@ -406,8 +406,15 @@ class Matrix(Base):
             merged = [row[1:] for row in merged]
             self._featureCount -= 1
 
-
         self.data = numpy.matrix(merged, dtype=numpy.object_)
+
+    def _replaceFeatureWithBinaryFeatures_implementation(self):
+        binaryFts = {}
+        for idx, val in enumerate(self.data):
+            if val[0, 0] not in binaryFts:
+                binaryFts[val[0, 0]] = []
+            binaryFts[val[0, 0]].append(idx)
+        return binaryFts
 
     def _getitem_implementation(self, x, y):
         return self.data[x, y]

--- a/data/sparse.py
+++ b/data/sparse.py
@@ -721,6 +721,14 @@ class Sparse(Base):
 
         self._sorted = None
 
+    def _replaceFeatureWithBinaryFeatures_implementation(self):
+        binaryFts = {}
+        for idx, val in zip(self.data.row, self.data.data):
+            if val not in binaryFts:
+                binaryFts[val] = []
+            binaryFts[val].append(idx)
+        return binaryFts
+
     def _getitem_implementation(self, x, y):
         """
         currently, we sort the data first and then do binary search

--- a/data/tests/high_level_backend.py
+++ b/data/tests/high_level_backend.py
@@ -1253,7 +1253,7 @@ class HighLevelModifying(DataTestObject):
         featureNames = ['col']
         toTest = self.constructor(data, featureNames=featureNames)
         getNames = self.constructor(data, featureNames=featureNames)
-        ret = toTest.replaceFeatureWithBinaryFeatures(0) # RET CHECK
+        ret = toTest.replaceFeatureWithBinaryFeatures(0)
 
         expData = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
         expFeatureNames = []
@@ -1263,6 +1263,25 @@ class HighLevelModifying(DataTestObject):
 
         assert toTest.isIdentical(exp)
         assert ret == expFeatureNames
+
+    def test_replaceFeatureWithBinaryFeatures_insertLocation(self):
+        """ Test replaceFeatureWithBinaryFeatures() replaces at same index """
+        data = [['a', 1, 'a'], ['b', 2, 'b'], ['c', 3, 'c']]
+        featureNames = ['stay1', 'replace', 'stay2']
+        toTest = self.constructor(data, featureNames=featureNames)
+        getNames = self.constructor(data, featureNames=featureNames)
+        ret = toTest.replaceFeatureWithBinaryFeatures(1)
+
+        expData = [['a', 1, 0, 0, 'a'], ['b', 0, 1, 0, 'b'], ['c', 0, 0, 1, 'c']]
+        expFeatureNames = []
+        for point in getNames.points:
+            expFeatureNames.append('replace=' + str(point[1]))
+        expFeatureNames.insert(0, 'stay1')
+        expFeatureNames.append('stay2')
+        exp = self.constructor(expData, featureNames=expFeatureNames)
+
+        assert toTest.isIdentical(exp)
+        assert ret == expFeatureNames[1: -1]
 
     def test_replaceFeatureWithBinaryFeatures_NamePath_preservation(self):
         data = [[1], [2], [3]]


### PR DESCRIPTION
Efficiency improvements for replaceFeatureWithBinary() features. According to the profiling, it appears most of the time was spent in the calculate() function, which has been eliminated.  I stopped trying to run the current function after just over 3 minutes, this implementation completed in about 8.5 seconds for the same operation.

The function now also replaces the data at the same index the feature.  A quick timeit test did not show that this has a significant impact speed vs always appending.

Another test ensuring that the replacing at the current index was added as well.