### PR TITLE
lazy names in structural and isIdentical

### DIFF
--- a/data/axis.py
+++ b/data/axis.py
@@ -171,10 +171,11 @@ class Axis(object):
     def _copy(self, toCopy, start, end, number, randomize):
         ret = self._genericStructuralFrontend('copy', toCopy, start, end,
                                               number, randomize)
+        source = self._source
         if isinstance(self, Points):
-            ret.features.setNames(self._source.features.getNames())
+            ret.features.setNames(source.features._getNamesNoGeneration())
         else:
-            ret.points.setNames(self._source.points.getNames())
+            ret.points.setNames(source.points._getNamesNoGeneration())
 
         ret._absPath = self._source.absolutePath
         ret._relPath = self._source.relativePath
@@ -1123,6 +1124,15 @@ class Axis(object):
         if structure == 'count':
             return len(targetList)
         return self._structuralBackend_implementation(structure, targetList)
+
+    def _getStructuralNames(self, targetList):
+        nameList = None
+        if self._namesCreated():
+            nameList = [self._getName(i) for i in targetList]
+        if isinstance(self, Points):
+            return nameList, self._source.features._getNamesNoGeneration()
+        else:
+            return self._source.points._getNamesNoGeneration(), nameList
 
     def _adjustCountAndNames(self, other):
         """

--- a/data/base.py
+++ b/data/base.py
@@ -3826,14 +3826,14 @@ class Base(object):
     def _equalPointNames(self, other):
         if other is None or not isinstance(other, Base):
             return False
-        return self._equalNames(self.points.getNames(),
-                                other.points.getNames())
+        return self._equalNames(self.points._getNamesNoGeneration(),
+                                other.points._getNamesNoGeneration())
 
     def _equalFeatureNames(self, other):
         if other is None or not isinstance(other, Base):
             return False
-        return (self._equalNames(self.features.getNames(),
-                                 other.features.getNames()))
+        return (self._equalNames(self.features._getNamesNoGeneration(),
+                                 other.features._getNamesNoGeneration()))
 
     def _equalNames(self, selfNames, otherNames):
         """
@@ -3843,6 +3843,16 @@ class Base(object):
         and uniquely positioned (if a non default name is present in
         both, then it is in the same position in both).
         """
+        if selfNames is None and otherNames is None:
+            return True
+        if (selfNames is None
+                and all(n.startswith(DEFAULT_PREFIX) for n in otherNames)):
+            return True
+        if (otherNames is None
+                and all(n.startswith(DEFAULT_PREFIX) for n in selfNames)):
+            return True
+        if selfNames is None or otherNames is None:
+            return False
         if len(selfNames) != len(otherNames):
             return False
 

--- a/data/dataframeAxis.py
+++ b/data/dataframeAxis.py
@@ -66,20 +66,13 @@ class DataFrameAxis(Axis):
         """
         df = self._source.data
 
+        pointNames, featureNames = self._getStructuralNames(targetList)
         if isinstance(self, Points):
             ret = df.iloc[targetList, :]
             axis = 0
-            name = 'pointNames'
-            nameList = [self._getName(i) for i in targetList]
-            otherName = 'featureNames'
-            otherNameList = self._source.features.getNames()
         else:
             ret = df.iloc[:, targetList]
             axis = 1
-            name = 'featureNames'
-            nameList = [self._getName(i) for i in targetList]
-            otherName = 'pointNames'
-            otherNameList = self._source.points.getNames()
 
         if structure.lower() != "copy":
             df.drop(targetList, axis=axis, inplace=True)
@@ -89,8 +82,8 @@ class DataFrameAxis(Axis):
         else:
             df.columns = numpy.arange(len(df.columns), dtype=df.columns.dtype)
 
-        return UML.data.DataFrame(ret, **{name: nameList,
-                                          otherName: otherNameList})
+        return UML.data.DataFrame(ret, pointNames=pointNames,
+                                  featureNames=featureNames)
 
     def _sort_implementation(self, sortBy, sortHelper):
         if isinstance(sortHelper, list):

--- a/data/features.py
+++ b/data/features.py
@@ -971,10 +971,10 @@ class Features(object):
         self._splitByParsing_implementation(featureIndex, splitList,
                                             numRetFeatures, numResultingFts)
 
-        self._source._featureCount = numRetFeatures
         fNames = self.getNames()[:featureIndex]
         fNames.extend(resultingNames)
         fNames.extend(self.getNames()[featureIndex + 1:])
+        self._source._featureCount = numRetFeatures
         self.setNames(fNames)
 
         self._source.validate()

--- a/data/listAxis.py
+++ b/data/listAxis.py
@@ -42,10 +42,9 @@ class ListAxis(Axis):
         process how each function handles the returned value, these are
         managed separately by each frontend function.
         """
-        pnames = []
-        fnames = []
         data = numpy.matrix(self._source.data, dtype=object)
 
+        pointNames, featureNames = self._getStructuralNames(targetList)
         if isinstance(self, Points):
             keepList = []
             for idx in range(len(self)):
@@ -55,10 +54,6 @@ class ListAxis(Axis):
             if structure != 'copy':
                 keep = data[keepList, :]
                 self._source.data = keep.tolist()
-
-            for index in targetList:
-                pnames.append(self._getName(index))
-            fnames = self._source.features.getNames()
 
         else:
             if self._source.data == []:
@@ -76,16 +71,12 @@ class ListAxis(Axis):
                 keep = data[:, keepList]
                 self._source.data = keep.tolist()
 
-            for index in targetList:
-                fnames.append(self._getName(index))
-            pnames = self._source.points.getNames()
-
             if structure != 'copy':
                 remainingFts = self._source._numFeatures - len(targetList)
                 self._source._numFeatures = remainingFts
 
-        return UML.data.List(satisfying, pointNames=pnames,
-                             featureNames=fnames, reuseData=True)
+        return UML.data.List(satisfying, pointNames=pointNames,
+                             featureNames=featureNames, reuseData=True)
 
     def _sort_implementation(self, sortBy, sortHelper):
         if isinstance(sortHelper, list):

--- a/data/matrixAxis.py
+++ b/data/matrixAxis.py
@@ -40,25 +40,17 @@ class MatrixAxis(Axis):
         process how each function handles the returned value, these are
         managed separately by each frontend function.
         """
-        nameList = []
+        pointNames, featureNames = self._getStructuralNames(targetList)
         if isinstance(self, Points):
             axisVal = 0
             ret = self._source.data[targetList]
-            pointNames = nameList
-            featureNames = self._source.features.getNames()
         else:
             axisVal = 1
             ret = self._source.data[:, targetList]
-            featureNames = nameList
-            pointNames = self._source.points.getNames()
 
         if structure != 'copy':
             self._source.data = numpy.delete(self._source.data,
                                              targetList, axisVal)
-
-        # construct nameList
-        for index in targetList:
-            nameList.append(self._getName(index))
 
         return UML.data.Matrix(ret, pointNames=pointNames,
                                featureNames=featureNames)

--- a/data/tests/structure_backend.py
+++ b/data/tests/structure_backend.py
@@ -607,11 +607,19 @@ class StructureDataSafe(StructureShared):
         """ Test points.copy() against handmade output when copying one point """
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         toTest = self.constructor(data)
-        ext1 = toTest.points.copy(0)
+        copy1 = toTest.points.copy(0)
         exp1 = self.constructor([[1, 2, 3]])
-        assert ext1.isIdentical(exp1)
+        assert copy1.isIdentical(exp1)
         expEnd = self.constructor(data)
         assert toTest.isIdentical(expEnd)
+
+        # View objects utilize point and feature names, so we ignore this check
+        if not isinstance(toTest, BaseView):
+            # Check that names have not been generated unnecessarily
+            assert not toTest.points._namesCreated()
+            assert not toTest.features._namesCreated()
+            assert not copy1.points._namesCreated()
+            assert not copy1.features._namesCreated()
 
     def test_points_copy_index_NamePath_Preserve(self):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
@@ -874,7 +882,7 @@ class StructureDataSafe(StructureShared):
 
 
     def test_points_copy_handmadeRangeRand_FM(self):
-        """ Test points.copy() for correct sizes when using randomized range extraction and featureNames """
+        """ Test points.copy() for correct sizes when using randomized range and featureNames """
         featureNames = ["one", "two", "three"]
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         toTest = self.constructor(data, featureNames=featureNames)
@@ -1370,12 +1378,20 @@ class StructureDataSafe(StructureShared):
         """ Test features.copy() against handmade output when copying one feature """
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         toTest = self.constructor(data)
-        ext1 = toTest.features.copy(0)
+        copy1 = toTest.features.copy(0)
         exp1 = self.constructor([[1], [4], [7]])
 
-        assert ext1.isIdentical(exp1)
+        assert copy1.isIdentical(exp1)
         expEnd = self.constructor(data)
         assert toTest.isIdentical(expEnd)
+
+        # View objects utilize point and feature names, so we ignore this check
+        if not isinstance(toTest, BaseView):
+            # Check that names have not been generated unnecessarily
+            assert not toTest.points._namesCreated()
+            assert not toTest.features._namesCreated()
+            assert not copy1.points._namesCreated()
+            assert not copy1.features._namesCreated()
 
     def test_features_copy_List_NamePath_Preserve(self):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
@@ -1454,12 +1470,12 @@ class StructureDataSafe(StructureShared):
 
     def test_features_copy_List_trickyOrdering(self):
         data = [0, 1, 1, 1, 0, 0, 0, 0, 1, 0]
-        toExtract = [6, 5, 3, 9]
-        #		toExtract = [3,5,6,9]
+        toCopy = [6, 5, 3, 9]
+        #		toCopy = [3,5,6,9]
 
         toTest = self.constructor(data)
 
-        ret = toTest.features.copy(toExtract)
+        ret = toTest.features.copy(toCopy)
 
         expRaw = [0, 0, 1, 0]
         expRet = self.constructor(expRaw)
@@ -3403,6 +3419,12 @@ class StructureModifying(StructureShared):
         expEnd = self.constructor([[4, 5, 6], [7, 8, 9]])
         assert toTest.isIdentical(expEnd)
 
+        # Check that names have not been generated unnecessarily
+        assert not toTest.points._namesCreated()
+        assert not toTest.features._namesCreated()
+        assert not ext1.points._namesCreated()
+        assert not ext1.features._namesCreated()
+
     def test_points_extract_index_NamePath_Preserve(self):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         toTest = self.constructor(data)
@@ -4183,6 +4205,12 @@ class StructureModifying(StructureShared):
         expEnd = self.constructor([[2, 3], [5, 6], [8, 9]])
         assert toTest.isIdentical(expEnd)
 
+        # Check that names have not been generated unnecessarily
+        assert not toTest.points._namesCreated()
+        assert not toTest.features._namesCreated()
+        assert not ext1.points._namesCreated()
+        assert not ext1.features._namesCreated()
+
     def test_features_extract_List_NamePath_Preserve(self):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         toTest = self.constructor(data)
@@ -4849,6 +4877,10 @@ class StructureModifying(StructureShared):
         expEnd = self.constructor([[4, 5, 6], [7, 8, 9]])
         assert toTest.isIdentical(expEnd)
 
+        # Check that names have not been generated unnecessarily
+        assert not toTest.points._namesCreated()
+        assert not toTest.features._namesCreated()
+
     def test_points_delete_index_NamePath_Preserve(self):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         toTest = self.constructor(data)
@@ -5486,6 +5518,10 @@ class StructureModifying(StructureShared):
         expEnd = self.constructor([[2, 3], [5, 6], [8, 9]])
         assert toTest.isIdentical(expEnd)
 
+        # Check that names have not been generated unnecessarily
+        assert not toTest.points._namesCreated()
+        assert not toTest.features._namesCreated()
+
     def test_features_delete_List_NamePath_Preserve(self):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
         toTest = self.constructor(data)
@@ -6028,6 +6064,10 @@ class StructureModifying(StructureShared):
         toTest.points.retain(0)
         exp1 = self.constructor([[1, 2, 3]])
         assert toTest.isIdentical(exp1)
+
+        # Check that names have not been generated unnecessarily
+        assert not toTest.points._namesCreated()
+        assert not toTest.features._namesCreated()
 
     def test_points_retain_index_NamePath_Preserve(self):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
@@ -6710,6 +6750,10 @@ class StructureModifying(StructureShared):
         exp1 = self.constructor([[1], [4], [7]])
 
         assert toTest.isIdentical(exp1)
+
+        # Check that names have not been generated unnecessarily
+        assert not toTest.points._namesCreated()
+        assert not toTest.features._namesCreated()
 
     def test_features_retain_List_NamePath_Preserve(self):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]


### PR DESCRIPTION
Names were being generated unnecessarily in the _structuralBackend_implementation() for each axis subobject.  I created a helper function to continue the lazy name generation and since this process was identical for all subobjects, the helper is located in axis.py.  

To verify that names are not generated, I added checks in the structure_backend tests.  This indicated that isIdentical() in Base was also generating names unnecessarily.  I modified the name equality checking functions to generate names and validate name equality when one or both of the objects do not have names generated.

While most of the structural type functions are data modifying, copy() is not, which means it can be used with View objects. However, View objects utilize point and feature names, so the name generation assertions in the tests are ignored in those cases.