### PR TITLE
remove unneeded code after fill module updates

### DIFF
--- a/data/dataframeFeatures.py
+++ b/data/dataframeFeatures.py
@@ -49,12 +49,6 @@ class DataFrameFeatures(DataFrameAxis, Features):
             if limitTo is not None and j not in limitTo:
                 continue
             currRet = function(f)
-            # currRet might return an InvalidArgumentValue with a message which
-            # needs to be formatted with the axis and current index before
-            # being raised
-            if isinstance(currRet, InvalidArgumentValue):
-                currRet.value = currRet.value.format('feature', j)
-                raise currRet
             if len(currRet) != len(self._source.points):
                 msg = "function must return an iterable with as many elements "
                 msg += "as points in this object"

--- a/data/dataframePoints.py
+++ b/data/dataframePoints.py
@@ -51,12 +51,6 @@ class DataFramePoints(DataFrameAxis, Points):
             if limitTo is not None and i not in limitTo:
                 continue
             currRet = function(p)
-            # currRet might return an InvalidArgumentValue with a message which
-            # needs to be formatted with the axis and current index before
-            # being raised
-            if isinstance(currRet, InvalidArgumentValue):
-                currRet.value = currRet.value.format('point', i)
-                raise currRet
             if len(currRet) != len(self._source.features):
                 msg = "function must return an iterable with as many elements "
                 msg += "as features in this object"

--- a/data/listFeatures.py
+++ b/data/listFeatures.py
@@ -46,12 +46,6 @@ class ListFeatures(ListAxis, Features):
             if limitTo is not None and j not in limitTo:
                 continue
             currRet = function(f)
-            # currRet might return an InvalidArgumentValue with a message which
-            # needs to be formatted with the axis and current index before
-            # being raised
-            if isinstance(currRet, InvalidArgumentValue):
-                currRet.value = currRet.value.format('feature', j)
-                raise currRet
             if len(currRet) != len(self._source.points):
                 msg = "function must return an iterable with as many elements "
                 msg += "as points in this object"

--- a/data/listPoints.py
+++ b/data/listPoints.py
@@ -55,12 +55,6 @@ class ListPoints(ListAxis, Points):
             if limitTo is not None and i not in limitTo:
                 continue
             currRet = function(p)
-            # currRet might return an InvalidArgumentValue with a message which
-            # needs to be formatted with the axis and current index before
-            # being raised
-            if isinstance(currRet, InvalidArgumentValue):
-                currRet.value = currRet.value.format('point', i)
-                raise currRet
             if len(currRet) != len(self._source.features):
                 msg = "function must return an iterable with as many elements "
                 msg += "as features in this object"

--- a/data/matrixFeatures.py
+++ b/data/matrixFeatures.py
@@ -44,12 +44,6 @@ class MatrixFeatures(MatrixAxis, Features):
             if limitTo is not None and j not in limitTo:
                 continue
             currRet = function(f)
-            # currRet might return an InvalidArgumentValue with a message which
-            # needs to be formatted with the axis and current index before
-            # being raised
-            if isinstance(currRet, InvalidArgumentValue):
-                currRet.value = currRet.value.format('feature', j)
-                raise currRet
             if len(currRet) != len(self._source.points):
                 msg = "function must return an iterable with as many elements "
                 msg += "as points in this object"

--- a/data/matrixPoints.py
+++ b/data/matrixPoints.py
@@ -46,12 +46,6 @@ class MatrixPoints(MatrixAxis, Points):
             if limitTo is not None and i not in limitTo:
                 continue
             currRet = function(p)
-            # currRet might return an InvalidArgumentValue with a message which
-            # needs to be formatted with the axis and current index before
-            # being raised
-            if isinstance(currRet, InvalidArgumentValue):
-                currRet.value = currRet.value.format('point', i)
-                raise currRet
             if len(currRet) != len(self._source.features):
                 msg = "function must return an iterable with as many elements "
                 msg += "as features in this object"

--- a/data/sparseAxis.py
+++ b/data/sparseAxis.py
@@ -113,12 +113,6 @@ class SparseAxis(Axis):
                 currOut = list(view)
             else:
                 currOut = function(view)
-                # currRet might return an InvalidArgumentValue with a message
-                # which needs to be formatted with the axis and current index
-                # before being raised
-                if isinstance(currOut, InvalidArgumentValue):
-                    currOut.value = currOut.value.format(self._axis, viewID)
-                    raise currOut
 
             # easy way to reuse code if we have a singular return
             if not hasattr(currOut, '__iter__'):


### PR DESCRIPTION
The fill module was reworked so that it did not return Exceptions which needed to be formatted. However, in that PR, I forgot to delete the code that did the formatting when that was the case.