### PR TITLE
UML funcs and axis ordering for calculate

### DIFF
--- a/UML/data/dataHelpers.py
+++ b/UML/data/dataHelpers.py
@@ -7,6 +7,7 @@ from __future__ import division
 from __future__ import absolute_import
 import copy
 import math
+import numbers
 import inspect
 import re
 from functools import wraps
@@ -32,6 +33,22 @@ DEFAULT_PREFIX_LENGTH = len(DEFAULT_PREFIX)
 DEFAULT_NAME_PREFIX = "OBJECT_#"
 
 defaultObjectNumber = 0
+
+def isAllowedSingleElement(x):
+    """
+    This function is to determine if an element is an allowed single
+    element.
+    """
+    if isinstance(x, (numbers.Number, six.string_types)):
+        return True
+
+    if hasattr(x, '__len__'):#not a single element
+        return False
+
+    if x is None or x != x:#None and np.NaN are allowed
+        return True
+
+    return
 
 def nextDefaultObjectName():
     """

--- a/UML/data/features.py
+++ b/UML/data/features.py
@@ -1014,7 +1014,7 @@ class Features(object):
 
         See Also
         --------
-        calculate : return a new object instead of performing inplace
+        calculate
 
         Examples
         --------
@@ -1093,7 +1093,7 @@ class Features(object):
 
         See also
         --------
-        transform : calculate inplace
+        transform
 
         Examples
         --------
@@ -1127,14 +1127,16 @@ class Features(object):
 
         Apply calculation to a subset of features.
 
-        >>> data = UML.ones('Matrix', 3, 5)
+        >>> ftNames = ['f1', 'f2', 'f3']
+        >>> data = UML.identity('Matrix', 3, featureNames=ftNames)
         >>> calc = data.features.calculate(lambda ft: ft + 6,
-        ...                                features=[1, 3])
+        ...                                features=[2, 0])
         >>> calc
         Matrix(
-            [[1.000 7.000 1.000 7.000 1.000]
-             [1.000 7.000 1.000 7.000 1.000]
-             [1.000 7.000 1.000 7.000 1.000]]
+            [[6.000 7.000]
+             [6.000 6.000]
+             [7.000 6.000]]
+            featureNames={'f3':0, 'f1':1}
             )
         """
         if UML.logger.active.position == 0:

--- a/UML/data/list.py
+++ b/UML/data/list.py
@@ -23,26 +23,10 @@ from .listPoints import ListPoints, ListPointsView
 from .listFeatures import ListFeatures, ListFeaturesView
 from .listElements import ListElements, ListElementsView
 from .dataHelpers import DEFAULT_PREFIX
+from .dataHelpers import isAllowedSingleElement
 
 scipy = UML.importModule('scipy.io')
 pd = UML.importModule('pandas')
-
-allowedItemType = (numbers.Number, six.string_types)
-def isAllowedSingleElement(x):
-    """
-    This function is to determine if an element is an allowed single
-    element
-    """
-    if isinstance(x, allowedItemType):
-        return True
-
-    if hasattr(x, '__len__'):#not a single element
-        return False
-
-    if x is None or x != x:#None and np.NaN are allowed
-        return True
-
-    return
 
 @inheritDocstringsFactory(Base)
 class List(Base):

--- a/UML/data/points.py
+++ b/UML/data/points.py
@@ -1006,7 +1006,7 @@ class Points(object):
 
         See Also
         --------
-        calculate : return a new object instead of performing inplace
+        calculate
 
         Examples
         --------
@@ -1085,7 +1085,7 @@ class Points(object):
 
         See also
         --------
-        transform : calculate inplace
+        transform
 
         Examples
         --------
@@ -1119,14 +1119,15 @@ class Points(object):
 
         Transform a subset of points.
 
-        >>> data = UML.ones('Matrix', 3, 5)
+        >>> ptNames = ['p1', 'p2', 'p3']
+        >>> data = UML.identity('Matrix', 3, pointNames=ptNames)
         >>> calc = data.points.calculate(lambda pt: pt + 6,
-        ...                              points=[0, 2])
+        ...                              points=[2, 0])
         >>> calc
         Matrix(
-            [[7.000 7.000 7.000 7.000 7.000]
-             [1.000 1.000 1.000 1.000 1.000]
-             [7.000 7.000 7.000 7.000 7.000]]
+            [[6.000 6.000 7.000]
+             [7.000 6.000 6.000]]
+            pointNames={'p3':0, 'p1':1}
             )
         """
         if UML.logger.active.position == 0:

--- a/UML/helpers.py
+++ b/UML/helpers.py
@@ -31,7 +31,7 @@ from UML.exceptions import InvalidArgumentValue, InvalidArgumentType
 from UML.exceptions import InvalidArgumentValueCombination, PackageException
 from UML.exceptions import FileFormatException
 from UML.data import Base
-from UML.data.list import isAllowedSingleElement
+from UML.data.dataHelpers import isAllowedSingleElement
 from UML.data.sparse import removeDuplicatesNative
 from UML.randomness import pythonRandom
 from UML.randomness import numpyRandom

--- a/tests/data/high_level_backend.py
+++ b/tests/data/high_level_backend.py
@@ -137,6 +137,32 @@ class HighLevelDataSafe(DataTestObject):
 
         origObj.points.calculate(emitLower)
 
+    @raises(InvalidArgumentValue)
+    def test_points_calculate_functionReturns2D(self):
+        featureNames = {'number': 0, 'centi': 2, 'deci': 1}
+        pointNames = {'zero': 0, 'one': 1, 'two': 2, 'three': 3}
+        origData = [[1, 0.1, 0.01], [1, 0.1, 0.02], [1, 0.1, 0.03], [1, 0.2, 0.02]]
+        toTest = self.constructor(deepcopy(origData), pointNames=pointNames,
+                                  featureNames=featureNames)
+
+        def return2D(point):
+            return [[val for val in point]]
+
+        calc = toTest.points.calculate(return2D)
+
+    @raises(InvalidArgumentValue)
+    def test_points_calculate_functionReturnsInvalidObj(self):
+        featureNames = {'number': 0, 'centi': 2, 'deci': 1}
+        pointNames = {'zero': 0, 'one': 1, 'two': 2, 'three': 3}
+        origData = [[1, 0.1, 0.01], [1, 0.1, 0.02], [1, 0.1, 0.03], [1, 0.2, 0.02]]
+        toTest = self.constructor(deepcopy(origData), pointNames=pointNames,
+                                  featureNames=featureNames)
+
+        def returnInvalidObj(point):
+            return int
+
+        calc = toTest.points.calculate(returnInvalidObj)
+
     @raises(CalledFunctionException)
     @mock.patch('UML.data.axis.constructIndicesList', side_effect=calledException)
     def test_points_calculate_calls_constructIndicesList(self, mockFunc):
@@ -159,6 +185,25 @@ class HighLevelDataSafe(DataTestObject):
         exp = self.constructor(expectedOut, pointNames=pointNames)
 
         assert lowerCounts.isIdentical(exp)
+
+    def test_points_calculate_functionReturnsUMLObject(self):
+        featureNames = {'number': 0, 'centi': 2, 'deci': 1}
+        pointNames = {'zero': 0, 'one': 1, 'two': 2, 'three': 3}
+        origData = [[1, 0.1, 0.01], [1, 0.1, 0.02], [1, 0.1, 0.03], [1, 0.2, 0.02]]
+        toTest = self.constructor(deepcopy(origData), pointNames=pointNames,
+                                  featureNames=featureNames)
+
+        def returnUMLObj(point):
+            ret = point * 2
+            assert isinstance(ret, UML.data.Base)
+            return ret
+
+        calc = toTest.points.calculate(returnUMLObj)
+
+        expData = [[2, 0.2, 0.02], [2, 0.2, 0.04], [2, 0.2, 0.06], [2, 0.4, 0.04]]
+        exp = self.constructor(expData, pointNames=pointNames)
+
+        assert calc.isIdentical(exp)
 
     def test_points_calculate_NamePathPreservation(self):
         featureNames = {'number': 0, 'centi': 2, 'deci': 1}
@@ -193,11 +238,30 @@ class HighLevelDataSafe(DataTestObject):
 
         lowerCounts = origObj.points.calculate(emitLower, points=['three', 2])
 
-        expectedOut = [[0.1], [0.2]]
-        expPnames = ['two', 'three']
+        expectedOut = [[0.2], [0.1]]
+        expPnames = ['three', 'two']
         exp = self.constructor(expectedOut, pointNames=expPnames)
 
         assert lowerCounts.isIdentical(exp)
+
+    def test_points_calculate_functionReturnsUMLObject_limited(self):
+        featureNames = {'number': 0, 'centi': 2, 'deci': 1}
+        pointNames = {'zero': 0, 'one': 1, 'two': 2, 'three': 3}
+        origData = [[1, 0.1, 0.01], [1, 0.1, 0.02], [1, 0.1, 0.03], [1, 0.2, 0.02]]
+        toTest = self.constructor(deepcopy(origData), pointNames=pointNames,
+                                  featureNames=featureNames)
+
+        def returnUMLObj(point):
+            ret = point * 2
+            assert isinstance(ret, UML.data.Base)
+            return ret
+
+        calc = toTest.points.calculate(returnUMLObj, points=['two', 'zero'])
+
+        expData = [[2, 0.2, 0.06], [2, 0.2, 0.02]]
+        exp = self.constructor(expData, pointNames=['two', 'zero'])
+
+        assert calc.isIdentical(exp)
 
     def test_points_calculate_nonZeroItAndLen(self):
         origData = [[1, 1, 1], [1, 0, 2], [1, 1, 0], [0, 2, 0]]
@@ -258,6 +322,32 @@ class HighLevelDataSafe(DataTestObject):
         origObj = self.constructor(deepcopy(origData), featureNames=featureNames)
         origObj.features.calculate(None)
 
+    @raises(InvalidArgumentValue)
+    def test_features_calculate_functionReturns2D(self):
+        featureNames = {'number': 0, 'centi': 2, 'deci': 1}
+        pointNames = {'zero': 0, 'one': 1, 'two': 2, 'three': 3}
+        origData = [[1, 0.1, 0.01], [1, 0.1, 0.02], [1, 0.1, 0.03], [1, 0.2, 0.02]]
+        toTest = self.constructor(deepcopy(origData), pointNames=pointNames,
+                                  featureNames=featureNames)
+
+        def return2D(feature):
+            return [[val for val in feature]]
+
+        calc = toTest.features.calculate(return2D)
+
+    @raises(InvalidArgumentValue)
+    def test_features_calculate_functionReturnsInvalidObj(self):
+        featureNames = {'number': 0, 'centi': 2, 'deci': 1}
+        pointNames = {'zero': 0, 'one': 1, 'two': 2, 'three': 3}
+        origData = [[1, 0.1, 0.01], [1, 0.1, 0.02], [1, 0.1, 0.03], [1, 0.2, 0.02]]
+        toTest = self.constructor(deepcopy(origData), pointNames=pointNames,
+                                  featureNames=featureNames)
+
+        def returnInvalidObj(feature):
+            return int
+
+        calc = toTest.features.calculate(returnInvalidObj)
+
     @raises(CalledFunctionException)
     @mock.patch('UML.data.axis.constructIndicesList', side_effect=calledException)
     def test_features_calculate_calls_constructIndicesList(self, mockFunc):
@@ -282,6 +372,25 @@ class HighLevelDataSafe(DataTestObject):
         expectedOut = [[1, 0, 0]]
         exp = self.constructor(expectedOut, featureNames=featureNames)
         assert lowerCounts.isIdentical(exp)
+
+    def test_features_calculate_functionReturnsUMLObject(self):
+        featureNames = {'number': 0, 'centi': 2, 'deci': 1}
+        pointNames = {'zero': 0, 'one': 1, 'two': 2, 'three': 3}
+        origData = [[1, 0.1, 0.01], [1, 0.1, 0.02], [1, 0.1, 0.03], [1, 0.2, 0.02]]
+        toTest = self.constructor(deepcopy(origData), pointNames=pointNames,
+                                  featureNames=featureNames)
+
+        def returnUMLObj(feature):
+            ret = feature * 2
+            assert isinstance(ret, UML.data.Base)
+            return ret
+
+        calc = toTest.features.calculate(returnUMLObj)
+
+        expData = [[2, 0.2, 0.02], [2, 0.2, 0.04], [2, 0.2, 0.06], [2, 0.4, 0.04]]
+        exp = self.constructor(expData, featureNames=featureNames)
+
+        assert calc.isIdentical(exp)
 
     def test_features_calculate_NamePath_preservation(self):
         featureNames = {'number': 0, 'centi': 2, 'deci': 1}
@@ -327,6 +436,25 @@ class HighLevelDataSafe(DataTestObject):
         expFNames = ['number', 'centi']
         exp = self.constructor(expectedOut, featureNames=expFNames)
         assert lowerCounts.isIdentical(exp)
+
+    def test_features_calculate_functionReturnsUMLObject_limited(self):
+        featureNames = {'number': 0, 'centi': 2, 'deci': 1}
+        pointNames = {'zero': 0, 'one': 1, 'two': 2, 'three': 3}
+        origData = [[1, 0.1, 0.01], [1, 0.1, 0.02], [1, 0.1, 0.03], [1, 0.2, 0.02]]
+        toTest = self.constructor(deepcopy(origData), pointNames=pointNames,
+                                  featureNames=featureNames)
+
+        def returnUMLObj(feature):
+            ret = feature * 2
+            assert isinstance(ret, UML.data.Base)
+            return ret
+
+        calc = toTest.features.calculate(returnUMLObj, features=['deci', 'number'])
+
+        expData = [[0.2, 2], [0.2, 2], [0.2, 2], [0.4, 2]]
+        exp = self.constructor(expData, featureNames=['deci', 'number'])
+
+        assert calc.isIdentical(exp)
 
     def test_features_calculate_nonZeroIterAndLen(self):
         origData = [[1, 1, 1], [1, 0, 2], [1, 1, 0], [0, 2, 0]]


### PR DESCRIPTION
Changed the processing of the return of the users function in calculate() to allow for UML objects.  This was not working because UML objects do not have an __iter__ method.  Instead, I used the isAllowedSingleElement function to analyze the result.  This function was found in data/list.py, but since it is also used in helpers.py and now used in data/axis.py I relocated it to data/dataHelpers.py. 

Additionally, I noticed that when limiting to the operation to certain points/features using a list, the resulting object did not return the points/features in the same order as the list.  I believe that is inconsistent with other objects, I remember discussing this concept with Spencer regarding something else at one point though I do not recall which function.  

Lastly, I added some additional tests covering the changes above and updated the documentation for calculate in points/features and tested using doctest.