### PR TITLE
doctests fixes

### DIFF
--- a/UML/data/axis_view.py
+++ b/UML/data/axis_view.py
@@ -5,6 +5,7 @@ base class for read only axis views of data objects.
 
 from __future__ import absolute_import
 
+import UML
 from UML.docHelpers import inheritDocstringsFactory
 from .axis import Axis
 from .points import Points

--- a/UML/data/base.py
+++ b/UML/data/base.py
@@ -446,19 +446,18 @@ class Base(object):
         --------
         TODO - outstanding PR, will need an update.
 
-        >>> raw = [[1, 'a', 1], [2, 'b', 2], [3, 'c', 3]]
-        >>> featureNames = ['keep1', 'replace', 'keep2']
+        >>> raw = [['a'], ['b'], ['c']]
         >>> data = UML.createData('Matrix', raw,
-        ...                       featureNames=featureNames)
+        ...                       featureNames=['replace'])
         >>> replaced = data.replaceFeatureWithBinaryFeatures('replace')
         >>> replaced
         ['replace=a', 'replace=b', 'replace=c']
-        >>> data #doctest: +ELLIPSIS
+        >>> data
         Matrix(
-            [[1 1.000 0.000 0.000 1]
-             [2 0.000 1.000 0.000 2]
-             [3 0.000 0.000 1.000 3]]
-            featureNames={'keep1':0, 'replace=a':1, ... 'keep2':4}
+            [[1.000 0.000 0.000]
+             [0.000 1.000 0.000]
+             [0.000 0.000 1.000]]
+            featureNames={'replace=a':0, 'replace=b':1, 'replace=c':2}
             )
         """
         if UML.logger.active.position == 0:
@@ -488,7 +487,7 @@ class Base(object):
         if self.points._namesCreated():
             ptNames = self.points.getNames()
         else:
-            ptNames='automatic'
+            ptNames = 'automatic'
         binaryObj = UML.createData(self.getTypeString(), toFill,
                                    pointNames=ptNames, featureNames=ftNames,
                                    treatAsMissing=None)
@@ -911,6 +910,8 @@ class Base(object):
     def featureReport(self, maxFeaturesToCover=50, displayDigits=2,
                       useLog=None):
         """
+        Report containing a summary and statistics for each feature.
+
         Produce a report, in a string formatted as a table, containing
         summary and statistical information about each feature in the
         data set, up to 50 features.  If there are more than 50
@@ -930,10 +931,12 @@ class Base(object):
 
     def summaryReport(self, displayDigits=2, useLog=None):
         """
-        Produce a report, in a string formatted as a table, containing summary
-        information about the data set contained in this object.  Includes
-        proportion of missing values, proportion of zero values, total # of
-        points, and number of features.
+        Report containing information regarding the data in this object.
+
+        Produce a report, in a string formatted as a table, containing
+        summary information about the data set contained in this object.
+        Includes proportion of missing values, proportion of zero
+        values, total # of points, and number of features.
         """
         logger = UML.logger.active
         logger.position += 1
@@ -1212,7 +1215,7 @@ class Base(object):
 
         >>> sales = office[[3, 1], :]
         >>> print(sales)
-                id  age department salary gender
+                  id  age department salary gender
 
         dwight   4211  45   sales    33000    m
            jim   4434  26   sales    26000    m
@@ -1275,8 +1278,8 @@ class Base(object):
            pam   28000  administration
         angela   43500    accounting
 
-        Note: list orders retained; 'pam' precedes 'angela' and index 3
-        ('salary') precedes index 2 ('department')
+        *Note: list orders retained; 'pam' precedes 'angela' and index 3
+        ('salary') precedes index 2 ('department')*
 
         >>> first3Ages = office[:2, 'age']
         >>> print(first3Ages)
@@ -1685,11 +1688,13 @@ class Base(object):
                          + len(''.join([str(i) for i
                                         in range(self._featureCount)])))
             numCols = int(min(1, maxW / float(strLength)) * self._featureCount)
-        # because of how dataHelers.indicesSplit works, we need this to be plus
-        # one in some cases this means one extra feature name is displayed. But
+        # because of how dataHelpers.indicesSplit works, we need this to be
+        # +1 in some cases this means one extra feature name is displayed. But
         # that's acceptable
         if numCols <= self._featureCount:
             numCols += 1
+        elif numCols > self._featureCount:
+            numCols = self._featureCount
         ret += dataHelpers.makeNamesLines(
             indent, maxW, numCols, self._featureCount,
             self.features.getNames(), 'featureNames')
@@ -2242,31 +2247,25 @@ class Base(object):
 
         Examples
         --------
-        >>> ptNames = ['0', '1', '2', '3', '4']
-        >>> ftNames = ['a', 'b', 'c', 'd', 'e']
-        >>> data = UML.identity('Matrix', 5, pointNames=ptNames,
+        >>> ptNames = ['0', '1']
+        >>> ftNames = ['a', 'b']
+        >>> data = UML.identity('Matrix', 2, pointNames=ptNames,
         ...                     featureNames=ftNames)
         >>> asDataFrame = data.copyAs('DataFrame')
         >>> asDataFrame
         DataFrame(
-            [[1.000 0.000 0.000 0.000 0.000]
-             [0.000 1.000 0.000 0.000 0.000]
-             [0.000 0.000 1.000 0.000 0.000]
-             [0.000 0.000 0.000 1.000 0.000]
-             [0.000 0.000 0.000 0.000 1.000]]
-            pointNames={'0':0, '1':1, '2':2, '3':3, '4':4}
-            featureNames={'a':0, 'b':1, 'c':2, 'd':3, 'e':4}
+            [[1.000 0.000]
+             [0.000 1.000]]
+            pointNames={'0':0, '1':1}
+            featureNames={'a':0, 'b':1}
             )
         >>> asNumpyArray = data.copyAs('numpy array')
         >>> asNumpyArray
-        array([[1., 0., 0., 0., 0.],
-               [0., 1., 0., 0., 0.],
-               [0., 0., 1., 0., 0.],
-               [0., 0., 0., 1., 0.],
-               [0., 0., 0., 0., 1.]])
+        array([[1., 0.],
+               [0., 1.]])
         >>> asListOfDict = data.copyAs('list of dict')
-        >>> asListOfDict #doctest: +ELLIPSIS
-        [{'a': 1.0, 'b': 0.0, 'c': 0.0, 'd': 0.0, 'e': 0.0}, ...]
+        >>> asListOfDict
+        [{'a': 1.0, 'b': 0.0}, {'a': 0.0, 'b': 1.0}]
         """
         #make lower case, strip out all white space and periods, except if
         # format is one of the accepted UML data types
@@ -2653,19 +2652,18 @@ class Base(object):
 
         Examples
         --------
-        >>> raw = [[1, 2, 3],
-        ...        [4, 5, 6],
-        ...        [7, 8, 9]]
-        >>> ptNames = ['1', '4', '7']
-        >>> ftNames = ['a', 'b', 'c']
+        >>> raw = [[1, 2],
+        ...        [3, 4]]
+        >>> ptNames = ['1', '4']
+        >>> ftNames = ['a', 'b']
         >>> data = UML.createData('Matrix', raw, pointNames=ptNames,
         ...                       featureNames=ftNames)
         >>> data.flattenToOnePoint()
-        >>> data #doctest: +ELLIPSIS
+        >>> data
         Matrix(
-            [[1.000 2.000 3.000 4.000 5.000 6.000 7.000 8.000 9.000]]
+            [[1.000 2.000 3.000 4.000]]
             pointNames={'Flattened':0}
-            featureNames={'a | 1':0, 'b | 1':1, ... 'c | 7':8}
+            featureNames={'a | 1':0, 'b | 1':1, 'a | 4':2, 'b | 4':3}
             )
         """
         if UML.logger.active.position == 0:
@@ -2720,26 +2718,20 @@ class Base(object):
 
         Examples
         --------
-        >>> raw = [[1, 2, 3],
-        ...        [4, 5, 6],
-        ...        [7, 8, 9]]
-        >>> ptNames = ['1', '4', '7']
-        >>> ftNames = ['a', 'b', 'c']
+        >>> raw = [[1, 2],
+        ...        [3, 4]]
+        >>> ptNames = ['1', '4']
+        >>> ftNames = ['a', 'b']
         >>> data = UML.createData('Matrix', raw, pointNames=ptNames,
         ...                       featureNames=ftNames)
         >>> data.flattenToOneFeature()
-        >>> data #doctest: +ELLIPSIS
+        >>> data
         Matrix(
             [[1.000]
-             [4.000]
-             [7.000]
-             [2.000]
-             [5.000]
-             [8.000]
              [3.000]
-             [6.000]
-             [9.000]]
-            pointNames={'1 | a':0, '4 | a':1, '7 | a':2, ... '7 | c':8}
+             [2.000]
+             [4.000]]
+            pointNames={'1 | a':0, '4 | a':1, '1 | b':2, '4 | b':3}
             featureNames={'Flattened':0}
             )
         """
@@ -3523,7 +3515,7 @@ class Base(object):
 
         Parameters
         ----------
-        pseudoInverse: bool
+        pseudoInverse : bool
             Whether to compute pseudoInverse or multiplicative inverse.
         """
 
@@ -3540,11 +3532,12 @@ class Base(object):
 
        Parameters
        ----------
-       b: UML Base object.
+       b : UML Base object.
         Vector shaped object.
-       solveFuction: str
-        'solve' assumes square matrix.
-        'least squares' Computes object x such that 2-norm |b - Ax| is minimized.
+       solveFuction : str
+        * 'solve' - assumes square matrix.
+        * 'least squares' - Computes object x such that 2-norm |b - Ax|
+          is minimized.
         """
         if not isinstance(b, UML.data.Base):
             msg = "b must be an instance of Base."
@@ -3552,12 +3545,12 @@ class Base(object):
 
         msg = "Valid methods are: 'solve' and 'least squares'."
 
-        if not isinstance (solveFunction, str):
+        if not isinstance(solveFunction, str):
             raise InvalidArgumentType(msg)
         elif solveFunction == 'solve':
-                return UML.calculate.solve(self, b)
+            return UML.calculate.solve(self, b)
         elif solveFunction == 'least squares':
-                return UML.calculate.leastSquaresSolution(self, b)
+            return UML.calculate.leastSquaresSolution(self, b)
         else:
             raise InvalidArgumentValue(msg)
 

--- a/UML/data/base_view.py
+++ b/UML/data/base_view.py
@@ -7,6 +7,7 @@ from __future__ import division
 from __future__ import absolute_import
 import copy
 
+import UML
 from UML.docHelpers import inheritDocstringsFactory
 from .base import Base
 from .dataHelpers import readOnlyException

--- a/UML/data/elements.py
+++ b/UML/data/elements.py
@@ -273,10 +273,8 @@ class Elements(object):
         ...                                features=[0, 2])
         >>> calc
         List(
-            [[2.000 1.000 2.000 1.000]
-             [2.000 1.000 2.000 1.000]
-             [1.000 1.000 1.000 1.000]
-             [1.000 1.000 1.000 1.000]]
+            [[2.000 2.000]
+             [2.000 2.000]]
             )
 
         Calculating with None return values. With the ``addTenToEvens``
@@ -466,7 +464,7 @@ class Elements(object):
         >>> data = UML.identity('Matrix', 5)
         >>> unique = data.elements.countUnique()
         >>> unique
-        {0.0: 20, 1.0: 5}
+        {1.0: 5, 0.0: 20}
 
         Count for a subset of elements.
 
@@ -474,7 +472,7 @@ class Elements(object):
         >>> unique = data.elements.countUnique(points=0,
         ...                                    features=[0, 1, 2])
         >>> unique
-        {0.0: 2, 1.0: 1}
+        {1.0: 1, 0.0: 2}
         """
         uniqueCount = {}
         if points is None:

--- a/UML/data/elements_view.py
+++ b/UML/data/elements_view.py
@@ -5,6 +5,7 @@ base class for read only elements views of data objects.
 
 from __future__ import absolute_import
 
+import UML
 from UML.docHelpers import inheritDocstringsFactory
 from .elements import Elements
 from .dataHelpers import readOnlyException

--- a/UML/data/features_view.py
+++ b/UML/data/features_view.py
@@ -5,6 +5,7 @@ base class for read only axis views of data objects.
 
 from __future__ import absolute_import
 
+import UML
 from UML.docHelpers import inheritDocstringsFactory
 from .features import Features
 from .dataHelpers import readOnlyException

--- a/UML/data/points_view.py
+++ b/UML/data/points_view.py
@@ -5,6 +5,7 @@ base class for read only axis views of data objects.
 
 from __future__ import absolute_import
 
+import UML
 from UML.docHelpers import inheritDocstringsFactory
 from .points import Points
 from .dataHelpers import readOnlyException

--- a/UML/fill/fill.py
+++ b/UML/fill/fill.py
@@ -63,7 +63,7 @@ def factory(match, fill, **kwarguments):
     >>> data = UML.createData('Matrix', raw)
     >>> transform = factory(match.zero, backwardFill)
     >>> transform(data)
-    [1, 3, 3, 5, 5]
+    [1.0, 3.0, 3.0, 5.0, 5.0]
     """
     match = convertMatchToFunction(match)
     if not hasattr(fill, '__call__'):
@@ -124,7 +124,7 @@ def constant(vector, match, constantValue):
     >>> raw = [1, 0, 3, 0, 5]
     >>> data = UML.createData('Matrix', raw)
     >>> constant(data, match.zero, 99)
-    [1, 99, 3, 99, 5]
+    [1.0, 99, 3.0, 99, 5.0]
     """
     match = convertMatchToFunction(match)
     return [constantValue if match(val) else val for val in vector]
@@ -164,7 +164,7 @@ def mean(vector, match):
     >>> raw = [1, 'na', 3, 'na', 5]
     >>> data = UML.createData('Matrix', raw)
     >>> mean(data, 'na')
-    [1, 3, 3, 3, 5]
+    [1, 3.0, 3, 3.0, 5]
 
     Match using a function from UML's match module.
 
@@ -172,7 +172,7 @@ def mean(vector, match):
     >>> raw = [6, 0, 2, 0, 4]
     >>> data = UML.createData('Matrix', raw)
     >>> mean(data, match.zero)
-    [6, 4, 2, 4, 4]
+    [6.0, 4.0, 2.0, 4.0, 4.0]
     """
     return statsBackend(vector, match, 'mean', UML.calculate.mean)
 
@@ -212,7 +212,7 @@ def median(vector, match):
     >>> raw = [1, 'na', 3, 'na', 5]
     >>> data = UML.createData('Matrix', raw)
     >>> median(data, 'na')
-    [1, 3, 3, 3, 5]
+    [1, 3.0, 3, 3.0, 5]
 
     Match using a function from UML's match module.
 
@@ -220,7 +220,7 @@ def median(vector, match):
     >>> raw = [6, 0, 2, 0, 4]
     >>> data = UML.createData('Matrix', raw)
     >>> median(data, match.zero)
-    [6, 4, 2, 4, 4]
+    [6.0, 4.0, 2.0, 4.0, 4.0]
     """
     return statsBackend(vector, match, 'median', UML.calculate.median)
 
@@ -258,7 +258,7 @@ def mode(vector, match):
     >>> raw = [1, 'na', 1, 'na', 5]
     >>> data = UML.createData('Matrix', raw)
     >>> mode(data, 'na')
-    [1, 1, 1, 1, 5]
+    [1, 1.0, 1, 1.0, 5]
 
     Match using a function from UML's match module.
 
@@ -266,7 +266,7 @@ def mode(vector, match):
     >>> raw = [6, 6, 2, 0, 0]
     >>> data = UML.createData('Matrix', raw)
     >>> mode(data, match.zero)
-    [6, 6, 2, 6, 6]
+    [6.0, 6.0, 2.0, 6.0, 6.0]
     """
     return statsBackend(vector, match, 'mode', UML.calculate.mode)
 
@@ -315,7 +315,7 @@ def forwardFill(vector, match):
     >>> raw = [6, 0, 2, 0, 4]
     >>> data = UML.createData('Matrix', raw)
     >>> forwardFill(data, match.zero)
-    [6, 6, 2, 2, 4]
+    [6.0, 6.0, 2.0, 2.0, 4.0]
     """
     match = convertMatchToFunction(match)
     if match(vector[0]):
@@ -374,13 +374,13 @@ def backwardFill(vector, match):
     >>> raw = [6, 0, 2, 0, 4]
     >>> data = UML.createData('Matrix', raw)
     >>> backwardFill(data, match.zero)
-    [6, 2, 2, 4, 4]
+    [6.0, 2.0, 2.0, 4.0, 4.0]
     """
     match = convertMatchToFunction(match)
     if match(vector[-1]):
         msg = directionError('backward fill', vector, 'last')
         raise InvalidArgumentValue(msg)
-    ret = numpy.empty_like(vector)
+    ret = numpy.empty_like(vector, dtype=numpy.object_)
     numValues = len(vector)
     for i, val in enumerate(reversed(vector)):
         idx = numValues - i - 1
@@ -430,7 +430,7 @@ def interpolate(vector, match, **kwarguments):
     >>> raw = [1, 'na', 3, 'na', 5]
     >>> data = UML.createData('Matrix', raw)
     >>> interpolate(data, 'na')
-    [1, 2, 3, 4, 5]
+    [1, 2.0, 3, 4.0, 5]
 
     Match using a function from UML's match module.
 
@@ -438,7 +438,7 @@ def interpolate(vector, match, **kwarguments):
     >>> raw = [6, 0, 4, 0, 2]
     >>> data = UML.createData('Matrix', raw)
     >>> interpolate(data, match.zero)
-    [6, 5, 4, 3, 2]
+    [6.0, 5.0, 4.0, 3.0, 2.0]
     """
     match = convertMatchToFunction(match)
     if 'x' in kwarguments:
@@ -508,14 +508,14 @@ def kNeighborsRegressor(data, match, **kwarguments):
     ...        [2, 2, 2],
     ...        ['na', 2, 2]]
     >>> data = UML.createData('Matrix', raw)
-    >>> kNeighborsClassifier(data, 'na', arguments={'n_neighbors': 3})
+    >>> kNeighborsRegressor(data, 'na', arguments={'n_neighbors': 3})
     Matrix(
-    [[  1   1   1  ]
-     [  1   1   1  ]
-     [  1   1 1.333]
-     [  2   2   2  ]
-     [1.333 2   2  ]]
-    )
+        [[  1   1   1  ]
+         [  1   1   1  ]
+         [  1   1 1.333]
+         [  2   2   2  ]
+         [1.333 2   2  ]]
+        )
     """
     return kNeighborsBackend("skl.KNeighborsRegressor", data, match,
                              **kwarguments)

--- a/UML/match/match.py
+++ b/UML/match/match.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import
 import numpy
 import six
 
+import UML
 from UML.exceptions import InvalidArgumentValue
 
 def missing(value):
@@ -105,7 +106,7 @@ def nonNumeric(value):
     >>> nonNumeric(8)
     False
     >>> nonNumeric(float('nan'))
-    True
+    False
     """
     return not isinstance(value, (int, float, complex, numpy.number))
 
@@ -673,9 +674,9 @@ def anyNonZero(data):
     >>> anyNonZero(data)
     True
 
-    >>> raw = [[1, 2, '0'],
-    ...        [1, 2, '1'],
-    ...        [1, 2, '2']]
+    >>> raw = [[0, 0, 0.0],
+    ...        [0, 0, 0.0],
+    ...        [0, 0, 0.0]]
     >>> data = UML.createData('List', raw)
     >>> anyNonZero(data)
     False

--- a/UML/uml.py
+++ b/UML/uml.py
@@ -105,7 +105,7 @@ def createRandomData(
          [88.000 24.000 3.000  22.000 53.000]
          [2.000  88.000 30.000 38.000 2.000 ]
          [64.000 60.000 21.000 33.000 76.000]]
-         pointNames={'a':0, 'b':1, 'c':2, 'd':3, 'e':4}
+        pointNames={'a':0, 'b':1, 'c':2, 'd':3, 'e':4}
         )
 
     Random floats, high sparsity.
@@ -113,11 +113,11 @@ def createRandomData(
     >>> sparse = UML.createRandomData('Sparse', 5, 5, .9)
     >>> sparse
     Sparse(
-        [[  0   0   0    0 0]
-         [  0   0 -0.138 0 0]
-         [0.497 0   0    0 0]
-         [  0   0   0    0 0]
-         [  0   0   0    0 0]]
+        [[  0    0 0   0   0]
+         [  0    0 0   0   0]
+         [-0.636 0 0   0   0]
+         [  0    0 0 0.291 0]
+         [  0    0 0   0   0]]
         )
     """
     if numPoints < 1:
@@ -875,14 +875,14 @@ def createData(
     Loading data from a file.
 
     >>> with open('createData.csv', 'w') as cd:
-    ...     cd.write('1,2,3\\n4,5,6')
+    ...     out = cd.write('1,2,3\\n4,5,6')
     >>> fromFile = UML.createData('Matrix', 'createData.csv')
     >>> fromFile
     Matrix(
         [[1.000 2.000 3.000]
          [4.000 5.000 6.000]]
         name="createData.csv"
-        path="/Users/Spark_Wave/createData.csv"
+        path="/UML/createData.csv"
         )
 
     Adding point and feature names.
@@ -1390,7 +1390,7 @@ def train(learnerName, trainX, trainY=None, performanceFunction=None,
     >>> cValue = tlAttributes['C']
     >>> kernelValue = tlAttributes['kernel']
     >>> print(cValue, kernelValue)
-    (0.1, 'linear')
+    0.1 linear
     """
     if UML.logger.active.position == 0:
         if enableLogging(useLog):
@@ -1764,6 +1764,7 @@ def trainAndTest(learnerName, trainX, trainY, testX, testY,
     >>> perform = UML.trainAndTest(
     ...     'sciKitLearn.SVC', trainX=trainX, trainY=trainY,
     ...     testX=testX, testY=testY,
+    ...     performanceFunction=UML.calculate.fractionIncorrect,
     ...     arguments={'C': 0.1}, kernel='linear')
     >>> perform
     0.0


### PR DESCRIPTION
Made updates to tests based on doctest results.

Most fixes were straightforward, but I did need to make some decisions on a few.
1) I agree the #doctest: +ELLIPSIS was hiding valuable information.  Rather than utilize that I simplified the tests so that all information would show without the need for ellipses.

2) import UML was added to all *_view.py files.  This was to allow the tests to pass, since they inherit their documentation from the non view functions.  The import is not actually necessary in the file though, its just to appease doctests, so I don't know whether to leave them in or not.

3) in base.py __getitem__, I used print() as I felt it provided a better visual representation for this method.  However, the print output contains blank lines. In order to pass the test, doctests requires <BLANKLINE> to be put in place. The doctests extension for Sphinx says that they will be removed for the html files, but since we are not currently using that extension in Sphinx, I don't know if that would still be the case.  I added the <BLANKLINE> for testing and  I also ran into an issue with doctests since the printed output contains some trailing whitespace and my IDE is set to automatically remove it upon saving.  I changed the setting and got them all to pass, but reapplied the setting and removed all the <BLANKLINE>s afterwords.

4) The createData example includes an example for loading from a file.  I put a dummy path in the output, so the test fails as when it runs it shows my local path.  Not sure what to do about that one.

So currently, 3 and 4 are still failing. There are 2 other failures but those are in points./features.calculate and are fixed in PR#121.  