### PR TITLE
add direct call to wrapping of elements functions

### DIFF
--- a/UML/data/elements.py
+++ b/UML/data/elements.py
@@ -19,7 +19,7 @@ import six
 import UML
 from UML.exceptions import InvalidArgumentType, InvalidArgumentValue
 from UML.exceptions import ImproperObjectAction
-from UML.logger import enableLogging
+from UML.logger import enableLogging, directCall
 from . import dataHelpers
 from .dataHelpers import valuesToPythonList, constructIndicesList
 from .dataHelpers import logCaptureFactory
@@ -179,8 +179,11 @@ class Elements(object):
              [7.000  18.000 9.000 ]]
             )
         """
-        if enableLogging(useLog):
-            wrapped = logCapture(self.transform)
+        if UML.logger.active.position == 0:
+            if enableLogging(useLog):
+                wrapped = logCapture(self.transform)
+            else:
+                wrapped = directCall(self.transform)
             return wrapped(toTransform, points, features, preserveZeros,
                            skipNoneReturnValues, useLog=False)
 
@@ -310,10 +313,13 @@ class Elements(object):
              [7.000  18.000 9.000 ]]
             )
         """
-        if enableLogging(useLog):
-            wrapped = logCapture(self.calculate)
+        if UML.logger.active.position == 0:
+            if enableLogging(useLog):
+                wrapped = logCapture(self.calculate)
+            else:
+                wrapped = directCall(self.calculate)
             return wrapped(function, points, features, preserveZeros,
-                           skipNoneReturnValues, useLog=False)
+                           skipNoneReturnValues, outputType, useLog=False)
 
         oneArg = False
         try:
@@ -426,10 +432,12 @@ class Elements(object):
         20
         """
         if hasattr(condition, '__call__'):
-            ret = self.calculate(function=condition, outputType='Matrix')
+            ret = self.calculate(function=condition, outputType='Matrix',
+                                 useLog=False)
         elif isinstance(condition, six.string_types):
             func = lambda x: eval('x'+condition)
-            ret = self.calculate(function=func, outputType='Matrix')
+            ret = self.calculate(function=func, outputType='Matrix',
+                                 useLog=False)
         else:
             msg = 'function can only be a function or string containing a '
             msg += 'comparison operator and a value'
@@ -527,8 +535,11 @@ class Elements(object):
              [12.000 12.000]]
             )
         """
-        if enableLogging(useLog):
-            wrapped = logCapture(self.multiply)
+        if UML.logger.active.position == 0:
+            if enableLogging(useLog):
+                wrapped = logCapture(self.multiply)
+            else:
+                wrapped = directCall(self.multiply)
             return wrapped(other, useLog=False)
 
         if not isinstance(other, UML.data.Base):
@@ -598,8 +609,11 @@ class Elements(object):
              [64.000 64.000]]
             )
         """
-        if enableLogging(useLog):
-            wrapped = logCapture(self.power)
+        if UML.logger.active.position == 0:
+            if enableLogging(useLog):
+                wrapped = logCapture(self.power)
+            else:
+                wrapped = directCall(self.power)
             return wrapped(other, useLog=False)
 
         # other is UML or single numerical value

--- a/tests/data/high_level_backend.py
+++ b/tests/data/high_level_backend.py
@@ -9,9 +9,9 @@ Methods tested in this file:
 
 In object HighLevelDataSafe:
 points.calculate, features.calculate, elements.calculate, points.count,
-features.count, elements.countUnique, points.unique, features.unique,
-points.mapReduce, features.mapReduce, isApproximatelyEqual,
-trainAndTestSets
+features.count, elements.count, elements.countUnique, points.unique,
+features.unique, points.mapReduce, features.mapReduce,
+isApproximatelyEqual, trainAndTestSets
 
 In object HighLevelModifying:
 replaceFeatureWithBinaryFeatures, points.shuffle, features.shuffle,

--- a/tests/logger/testLoggingIO.py
+++ b/tests/logger/testLoggingIO.py
@@ -511,6 +511,11 @@ def testBaseObjectFunctionsWithoutUseLog():
     count = dataObj.features.count(lambda x: type(x) == str)
     assert getLogLength() == 0
 
+    # elements.count; createData not logged
+    dataObj = UML.createData("Matrix", data, useLog=False)
+    count = dataObj.elements.count(lambda x: type(x) == str)
+    assert getLogLength() == 0
+
 @configSafetyWrapper
 def testHandmadeLogEntriesInput():
     # custom string


### PR DESCRIPTION
Noticed that functions in elements did not get updated to include the latest wrapping for the logger.  This could result in improper logging.  

These fixes are an improvement, but they also highlight a bigger issue.  For example, in elements.count, a call is made to elements.calculate.  Without useLog being set to False, the calculate operation is logged (if enabledByDefault in config is True). Explicitly setting useLog to False solves this specific problem, but does not prohibit this failure from occurring elsewhere or in the future.  Additionally, not all user-facing functions are currently tested for whether unintended logging like this is occurring.