### PR TITLE
None for point/feature names in createData

### DIFF
--- a/UML/data/base.py
+++ b/UML/data/base.py
@@ -3707,13 +3707,10 @@ class Base(object):
 
         # exact conditions in which we need to instantiate this object
         if other == 0 or other % 2 == 0:
-            identityPNames = 'automatic' if retPNames is None else retPNames
-            identityFNames = 'automatic' if retFNames is None else retFNames
             identity = UML.createData(self.getTypeString(),
                                       numpy.eye(self._pointCount),
-                                      pointNames=identityPNames,
-                                      featureNames=identityFNames,
-                                      useLog=False)
+                                      pointNames=retPNames,
+                                      featureNames=retFNames, useLog=False)
         if other == 0:
             return identity
 

--- a/UML/helpers.py
+++ b/UML/helpers.py
@@ -151,6 +151,13 @@ def extractNamesFromRawList(rawData, pnamesID, fnamesID):
         msg += "the only accepted list formats, yet the (0,0)th element was "
         msg += str(type(rawData[0][0]))
         raise TypeError(msg)
+    mustCopy = ['automatic', True]
+    if pnamesID in mustCopy or fnamesID is mustCopy:
+        # copy rawData to avoid modifying the original user data
+        if isinstance(rawData[0], tuple):
+            rawData = [list(row) for row in rawData]
+        else:
+            rawData = [row.copy() for row in rawData]
 
     firstRow = rawData[0] if len(rawData) > 0 else None
     secondRow = rawData[1] if len(rawData) > 1 else None
@@ -383,11 +390,11 @@ def extractNamesAndConvertData(returnType, rawData, pointNames, featureNames,
                                                          featureNames)
 
         # tempPointNames and tempFeatures may either be None or explicit names.
-        # pointNames and featureNames may be True, False, 'automatic', or
-        # explicit names
+        # pointNames and featureNames may be True, False, None, 'automatic', or
+        # explicit names. False and None have the same behavior.
 
         # User explicitly did not want names extracted
-        if pointNames is False:
+        if pointNames is False or pointNames is None:
             # assert that data was not accidentally removed
             assert tempPointNames is None
             pointNames = None
@@ -406,7 +413,7 @@ def extractNamesAndConvertData(returnType, rawData, pointNames, featureNames,
             pointNames = pointNames
 
         # User explicitly did not want names extracted
-        if featureNames is False:
+        if featureNames is False or featureNames is None:
             # assert that data was not accidentally removed
             assert tempFeatureNames is None
             featureNames = None
@@ -419,7 +426,7 @@ def extractNamesAndConvertData(returnType, rawData, pointNames, featureNames,
         # We could have extracted name and did
         elif featureNames == 'automatic' and tempFeatureNames is not None:
             featureNames = tempFeatureNames
-        # Point names were provided by user
+        # Feature names were provided by user
         else:
             assert tempFeatureNames is None
             featureNames = featureNames
@@ -438,8 +445,8 @@ def extractNamesAndConvertData(returnType, rawData, pointNames, featureNames,
                 isAllowedSingleElement(rawData[0])
                 or isinstance(rawData[0], list)
                 or hasattr(rawData[0], 'setLimit'))):
-       # attempt to convert the list to floats to remain consistent with other
-       # UML types if unsuccessful we will keep the list as is
+        # attempt to convert the list to floats to remain consistent with other
+        # UML types if unsuccessful we will keep the list as is
         try:
             # 1D list
             rawData = list(map(numpy.float, rawData))

--- a/tests/data/baseObject.py
+++ b/tests/data/baseObject.py
@@ -72,7 +72,7 @@ def viewConstructorMaker(concreteType):
         # data in the concrete object
         if len(orig.points) != 0:
             firstPRaw = [[0] * len(orig.features)]
-            fNamesParam = orig.features.getNames() if orig.features._namesCreated() else 'automatic'
+            fNamesParam = orig.features._getNamesNoGeneration()
             firstPoint = UML.helpers.initDataObject(concreteType, rawData=firstPRaw,
                                                     pointNames=['firstPNonView'], featureNames=fNamesParam,
                                                     name=name, path=orig.path, keepPoints='all', keepFeatures='all',
@@ -99,7 +99,7 @@ def viewConstructorMaker(concreteType):
         # data in the concrete object
         if len(orig.features) != 0:
             lastFRaw = [[1] * len(full.points)]
-            fNames = full.points.getNames() if full.points._namesCreated() else 'automatic'
+            fNames = full.points._getNamesNoGeneration()
             lastFeature = UML.helpers.initDataObject(concreteType, rawData=lastFRaw,
                                                      featureNames=fNames, pointNames=['lastFNonView'],
                                                      name=name, path=orig.path, keepPoints='all', keepFeatures='all',


### PR DESCRIPTION
Initially planned for this branch to allow None as an argument for createData pointNames and featureNames, however, it appears that I inadvertently allowed this when creating the `createDataNoValidation` function in data/dataHelpers.py.  This was allowed by a modification in `extractNamesAndConvertData` in helpers.py where I allowed NoneTypes to be processed.

So that already being done, tests were added to ensure that the output when names are None is the same as the output when names are False.  There were only a couple instances where I found that we could remove or modify lines of code now that None is accepted.

While writing these tests, they revealed a bug when raw data is a list and point/feature names are extracted.  In this case, the input raw data was being modified so if the user went to access the data later, it would not be the same.  Tests were written for all input types, but it appears that this bug only affected data that was run through `extractNamesFromRawList`.
