### PR TITLE
remove unused parameters from subobjects init

### DIFF
--- a/UML/data/list.py
+++ b/UML/data/list.py
@@ -5,11 +5,9 @@ Class extending Base, using a list of lists to store data.
 from __future__ import division
 from __future__ import absolute_import
 import copy
-import numbers
 from functools import reduce
 
 import numpy
-import six
 from six.moves import range
 from six.moves import zip
 
@@ -277,7 +275,6 @@ class List(Base):
         if to in UML.data.available:
             ptNames = self.points._getNamesNoGeneration()
             ftNames = self.features._getNamesNoGeneration()
-            reuseData = True
             if isEmpty:
                 data = numpy.matrix(emptyData)
             elif to == 'List':

--- a/UML/data/matrix.py
+++ b/UML/data/matrix.py
@@ -43,12 +43,10 @@ class Matrix(Base):
         passed further up into the hierarchy if needed.
     """
 
-    def __init__(self, data, featureNames=None, reuseData=False,
-                 elementType=None, **kwds):
+    def __init__(self, data, reuseData=False, elementType=None, **kwds):
         if not isinstance(data, (numpy.matrix, numpy.ndarray)):
-            # and 'PassThrough' not in str(type(data)):
             msg = "the input data can only be a numpy matrix "
-            msg += "or ListPassThrough."
+            msg += "or numpy array."
             raise InvalidArgumentType(msg)
 
         if isinstance(data, numpy.matrix):
@@ -68,7 +66,6 @@ class Matrix(Base):
                 except ValueError:
                     self.data = numpy.matrix(data, dtype=object)
 
-        kwds['featureNames'] = featureNames
         kwds['shape'] = self.data.shape
         super(Matrix, self).__init__(**kwds)
 

--- a/UML/data/sparse.py
+++ b/UML/data/sparse.py
@@ -42,7 +42,7 @@ class Sparse(Base):
     Parameters
     ----------
     data : object
-        A scipy sparse matrix, numpy matrix, CooWithEmpty or CooDummy.
+        A scipy sparse matrix, numpy matrix.
     reuseData : bool
     elementType : type
         The scipy or numpy dtype of the data.
@@ -50,8 +50,7 @@ class Sparse(Base):
         Included due to best practices so args may automatically be
         passed further up into the hierarchy if needed.
     """
-    def __init__(self, data, pointNames=None, featureNames=None,
-                 reuseData=False, elementType=None, **kwds):
+    def __init__(self, data, reuseData=False, elementType=None, **kwds):
         if not scipy:
             msg = 'To use class Sparse, scipy must be installed.'
             raise PackageException(msg)
@@ -59,7 +58,7 @@ class Sparse(Base):
         if ((not isinstance(data, numpy.matrix))
                 and (not scipy.sparse.isspmatrix(data))):
             msg = "the input data can only be a scipy sparse matrix or a "
-            msg += "numpy matrix or CooWithEmpty or CooDummy."
+            msg += "numpy matrix"
             raise InvalidArgumentType(msg)
 
         if scipy.sparse.isspmatrix_coo(data):
@@ -75,8 +74,6 @@ class Sparse(Base):
 
         self._sorted = None
         kwds['shape'] = self.data.shape
-        kwds['pointNames'] = pointNames
-        kwds['featureNames'] = featureNames
         super(Sparse, self).__init__(**kwds)
 
     def _getPoints(self):


### PR DESCRIPTION
Removed parameters from Matrix and Sparse which were unused by their __init__ methods and could be passed to Base through **kwds.

Could not remove any parameters from List __init__, but the linter identified a couple imports and a variable in list.py which could be removed.