### PR TITLE
no name generation by toString and repr

### DIFF
--- a/UML/data/base.py
+++ b/UML/data/base.py
@@ -1562,8 +1562,8 @@ class Base(object):
         numRows = min(self._pointCount, maxH)
         # if non default point names, print all (truncated) point names
         ret += dataHelpers.makeNamesLines(
-            indent, maxW, numRows, self._pointCount, self.points.getNames(),
-            'pointNames')
+            indent, maxW, numRows, self._pointCount,
+            self.points._getNamesNoGeneration(), 'pointNames')
         # if non default feature names, print all (truncated) feature names
         numCols = 0
         if byLine:
@@ -1574,7 +1574,11 @@ class Base(object):
         elif self._featureCount > 0:
             # if the container is empty, then roughly compute length of
             # the string of feature names, and then calculate numCols
-            strLength = (len("___".join(self.features.getNames()))
+            ftNames = self.features._getNamesNoGeneration()
+            if ftNames is None:
+                # mock up default looking names to avoid name generation
+                ftNames = [DEFAULT_PREFIX + '#'] * len(self.features)
+            strLength = (len("___".join(ftNames))
                          + len(''.join([str(i) for i
                                         in range(self._featureCount)])))
             numCols = int(min(1, maxW / float(strLength)) * self._featureCount)
@@ -1587,7 +1591,7 @@ class Base(object):
             numCols = self._featureCount
         ret += dataHelpers.makeNamesLines(
             indent, maxW, numCols, self._featureCount,
-            self.features.getNames(), 'featureNames')
+            self.features._getNamesNoGeneration(), 'featureNames')
 
         # if name not None, print
         if not self.name.startswith(DEFAULT_NAME_PREFIX):

--- a/UML/data/dataHelpers.py
+++ b/UML/data/dataHelpers.py
@@ -284,8 +284,11 @@ def makeNamesLines(indent, maxW, numDisplayNames, count, namesList, nameType):
     (posL, posR) = indicesSplit(numDisplayNames, count)
     possibleIndices = posL + posR
 
-    allDefault = all([namesList[i].startswith(DEFAULT_PREFIX)
-                      for i in possibleIndices])
+    if namesList is None:
+        allDefault = True
+    else:
+        allDefault = all([namesList[i].startswith(DEFAULT_PREFIX)
+                          for i in possibleIndices])
 
     if allDefault:
         return ""

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -902,6 +902,17 @@ class QueryBackend(DataTestObject):
                             ret = data.toString(includeNames=inc, maxWidth=mw, maxHeight=mh)
                             checkToStringRet(ret, data, inc, mw, mh)
 
+    def test_toString_lazyNameGeneration(self):
+        data = self.constructor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        ret = data.toString(includeNames=False)
+        assertNoNamesGenerated(data)
+        ret = data.toString(includeNames=True)
+        assertNoNamesGenerated(data)
+
+        empty = self.constructor([])
+        ret = empty.toString()
+        assertNoNamesGenerated(empty)
+
     def test_toString_nameAndValRecreation_randomized_longNames(self):
         """ Test long point and feature names do not exceed max width"""
         randGen = UML.createRandomData("List", 9, 9, 0)
@@ -1221,6 +1232,21 @@ class QueryBackend(DataTestObject):
     def test_repr_truncated(self):
         self.back_reprOutput(40, 20, truncated=True)
 
+    def test_repr_lazyNameGeneration(self):
+        data = self.constructor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        repr(data)
+        assertNoNamesGenerated(data)
+
+        # test an empty object w/ more than 0 features and names reset to None
+        empty = self.constructor([], featureNames=['a', 'b', 'c'])
+        try:
+            empty.features.setNames(None)
+        except TypeError:
+            # need to change names in views manually
+            empty._source.featureNames = None
+            empty._source.featureNamesInverse = None
+        repr(data)
+        assertNoNamesGenerated(empty)
 
     ###############################################
     # points.similarities / features.similarities #


### PR DESCRIPTION
Prevent `toString` and `__repr__` from generating point and feature names.  Tests revealed names not being generated in `toString` after the change made in dataHelpers.py `hasNonDefault` in a previous dev commit.  Tests showed `__repr__` was generating names and has been updated to eliminate this.