### PR TITLE
CreateRandomData efficiency

### DIFF
--- a/UML/helpers.py
+++ b/UML/helpers.py
@@ -125,6 +125,14 @@ def isAllowedRaw(data, allowLPT=False):
     return False
 
 
+def validateReturnType(returnType):
+    retAllowed = copy.copy(UML.data.available)
+    retAllowed.append(None)
+    if returnType not in retAllowed:
+        msg = "returnType must be a value in " + str(retAllowed)
+        raise InvalidArgumentValue(msg)
+
+
 def extractNamesFromRawList(rawData, pnamesID, fnamesID):
     """
     Remove name data from a python list.
@@ -245,11 +253,7 @@ def createConstantHelper(numpyMaker, returnType, numPoints, numFeatures,
     Use numpy.ones or numpy.zeros to create constant UML objects of the
     designated returnType.
     """
-    retAllowed = copy.copy(UML.data.available)
-    if returnType not in retAllowed:
-        msg = "returnType must be a value in " + str(retAllowed)
-        raise InvalidArgumentValue(msg)
-
+    validateReturnType(returnType)
     if numPoints < 0:
         msg = "numPoints must be 0 or greater, yet " + str(numPoints)
         msg += " was given."
@@ -631,7 +635,10 @@ def initDataObject(
 
     # If skipping data processing, no modification needs to be made
     # to the data, so we can skip name extraction and missing replacement.
+    kwargs = {}
     if skipDataProcessing:
+        if returnType == 'List':
+            kwargs['checkAll'] = False
         pointNames = pointNames if pointNames != 'automatic' else None
         featureNames = featureNames if featureNames != 'automatic' else None
     else:
@@ -666,7 +673,7 @@ def initDataObject(
         ret = initMethod(rawData, pointNames=pointNames,
                          featureNames=featureNames, name=name,
                          paths=pathsToPass, elementType=elementType,
-                         reuseData=reuseData)
+                         reuseData=reuseData, **kwargs)
     except Exception:
         einfo = sys.exc_info()
         #something went wrong. instead, try to auto load and then convert
@@ -675,7 +682,7 @@ def initDataObject(
             ret = autoMethod(rawData, pointNames=pointNames,
                              featureNames=featureNames, name=name,
                              paths=pathsToPass, elementType=elementType,
-                             reuseData=reuseData)
+                             reuseData=reuseData, **kwargs)
             ret = ret.copy(to=returnType)
         # If it didn't work, report the error on the thing the user ACTUALLY
         # wanted

--- a/UML/uml.py
+++ b/UML/uml.py
@@ -19,6 +19,7 @@ from UML.logger import handleLogging, startTimer, stopTimer
 from UML.logger import stringToDatetime
 from UML.helpers import findBestInterface
 from UML.helpers import _learnerQuery
+from UML.helpers import validateReturnType
 from UML.helpers import _validScoreMode
 from UML.helpers import _validMultiClassStrategy
 from UML.helpers import _unpackLearnerName
@@ -128,6 +129,7 @@ def createRandomData(
          [  0    0 0   0   0]]
         )
     """
+    validateReturnType(returnType)
     if numPoints < 1:
         msg = "must specify a positive nonzero number of points"
         raise InvalidArgumentValue(msg)
@@ -411,11 +413,7 @@ def identity(returnType, size, pointNames='automatic',
         name="identity matrix list"
         )
     """
-    retAllowed = copy.copy(UML.data.available)
-    if returnType not in retAllowed:
-        msg = "returnType must be a value in " + str(retAllowed)
-        raise InvalidArgumentValue(msg)
-
+    validateReturnType(returnType)
     if size <= 0:
         msg = "size must be 0 or greater, yet " + str(size)
         msg += " was given."
@@ -917,11 +915,7 @@ def createData(
         featureNames={'a':0, 'b':1, 'c':2}
         )
     """
-    retAllowed = copy.copy(UML.data.available)
-    retAllowed.append(None)
-    if returnType not in retAllowed:
-        msg = "returnType must be a value in " + str(retAllowed)
-        raise InvalidArgumentValue(msg)
+    validateReturnType(returnType)
 
     def looksFileLike(toCheck):
         hasRead = hasattr(toCheck, 'read')


### PR DESCRIPTION
I attempted various other methods to improve on the current implementation, but for the most part, the speed of createRandomData is determined by the underlying numpy functions.  As the number of points and features grows, the increased time is a result of the time taken to create the random data via the numpy functions. However, for Sparse, the call to createData was causing additional slowness.  After addressing this, the speed was much improved. 

Similar to the `createDataNoValidation()` helper in dataHelpers.py, a method was needed for ignoring some of the data validation and transformation steps in the createData stack.  I separated `extractNamesAndConvertData()` into two separate functions, `extractNames()` and `convertData`, and added a `skipDataProcessing` parameter to `initDataObject`.  `skipDataProcessing` ignores extracting names and replacing missing data, as it is assumed that the data has already had the names extracted and that it will not be necessary to replace the missing values.  Though it does not directly affect `createRandomData`, `skipDataProcessing` will also set checkAll to False for List `__init__` which will provide efficiency when the rawData is a python list (for createRandomData it is a numpy.matrix).  The convertData step is still performed in all cases, to ensure the data looks how we expect prior to `__init__` for the object.  

`initDataObject(skipDataProcessing=True)` is only implemented in this PR for createRandomData, but I believe we can use it in other functions when we are defining the data being used.  This could also possibly be extended to take the place of the `createDataNoValidation()` helper in dataHelpers.py.

Additional change made was to provide a helper to validate the returnType.  The same four lines of code were used in many places, so I created `validateReturnType` to place in createRandomData, createData, identity and ones and zeros (via their shared backend).

Here are the results from the change from createData to initDataObject.  The improvements are smaller for the dense types, but much improved for Sparse. 
```
Object 10,000 pts x 1,000 fts
+-----------+----------+------------------+------------------+
| Object    | sparsity | dev              | refactor         |
+-----------+----------+------------------+------------------+
| List      | 0.99     | 955 ms ± 32.1 ms | 884 ms ± 36.5 ms |
+-----------+----------+------------------+------------------+
| Matrix    | 0.99     | 642 ms ± 53.4 ms | 583 ms ± 22.6 ms |
+-----------+----------+------------------+------------------+
| DataFrame | 0.99     | 585 ms ± 54 ms   | 558 ms ± 15.5 ms |
+-----------+----------+------------------+------------------+
| Sparse    | 0.99     | 1.87 s ± 31.7 ms | 614 ms ± 17.9 ms |
+-----------+----------+------------------+------------------+
| List      | 0.5      | 1.02 s ± 26.6 ms | 916 ms ± 4.78 ms |
+-----------+----------+------------------+------------------+
| Matrix    | 0.5      | 670 ms ± 23.4 ms | 634 ms ± 8.11 ms |
+-----------+----------+------------------+------------------+
| DataFrame | 0.5      | 747 ms ± 41.7 ms | 625 ms ± 19.4 ms |
+-----------+----------+------------------+------------------+
| Sparse    | 0.5      | timed out        | 914 ms ± 19.5 ms |
+-----------+----------+------------------+------------------+
| List      | 0        | 708 ms ± 12.5 ms | 671 ms ± 16.9 ms |
+-----------+----------+------------------+------------------+
| Matrix    | 0        | 441 ms ± 27 ms   | 398 ms ± 29.9 ms |
+-----------+----------+------------------+------------------+
| DataFrame | 0        | 419 ms ± 32 ms   | 374 ms ± 15.6 ms |
+-----------+----------+------------------+------------------+
| Sparse    | 0        | timed out        | 1.26 s ± 69.3 ms |
+-----------+----------+------------------+------------------+
```

