### PR TITLE
convert data to prevent pandas object return

### DIFF
--- a/UML/data/base.py
+++ b/UML/data/base.py
@@ -3907,7 +3907,8 @@ class Base(object):
         if isUML:
             if opName.startswith('__r'):
                 return NotImplemented
-
+            if other.getTypeString() != "Matrix":
+                other = other.copy(to="Matrix")
             self._genericNumericBinary_sizeValidation(opName, other)
             self._validateEqualNames('point', 'point', opName, other)
             self._validateEqualNames('feature', 'feature', opName, other)

--- a/UML/data/matrixElements.py
+++ b/UML/data/matrixElements.py
@@ -98,9 +98,13 @@ class MatrixElements(Elements):
             result = other.data.multiply(self._source.data)
             if hasattr(result, 'todense'):
                 result = result.todense()
-            self._source.data = numpy.matrix(result)
         else:
-            self._source.data = numpy.multiply(self._source.data, other.data)
+            result = numpy.multiply(self._source.data, other.data)
+        if isinstance(result, numpy.matrix):
+            self._source.data = result
+        else:
+            self._source.data = numpy.matrix(result)
+
 
 class MatrixElementsView(ElementsView, MatrixElements):
     """


### PR DESCRIPTION
Pandas version 0.24 (latest stable release) returning pandas objects for numeric binary operations when the pandas object is the right hand side object.  In the past, this was returning a numpy object, which our data objects expected for instantiation.  To continue the past behavior, the right hand side object is now converted to a Matrix first in `_genericNumericBinary`, which has resolved all issues. Similarly, in `elements._multiply_implementation` for Matrix, the data needed to be converted to a numpy matrix after the operation, since a pandas dataframe is now sometimes returned.  

The change in `_genericNumericBinary` was even required for some DataFrame to DataFrame operations to work correctly.  It is probably worth doing a deep dive into `_genericNumericBinary`, this patch is effective in the short term but a less generic approach to numeric binary operations is likely preferable.

