### PR TITLE
remove interface

### DIFF
--- a/nimble/__init__.py
+++ b/nimble/__init__.py
@@ -79,8 +79,7 @@ configuration.autoRegisterFromSettings()
 
 # Now that we have loaded everything else, sync up the the settings object
 # as needed.
-for interface in interfaces.available:
-    configuration.setInterfaceOptions(settings, interface, save=True)
+configuration.setAndSaveAvailableIterfaceOptions()
 
 # initialize the logging file
 logger.active = logger.initLoggerAndLogConfig()

--- a/nimble/configuration.py
+++ b/nimble/configuration.py
@@ -569,6 +569,14 @@ def setInterfaceOptions(settingsObj, interface, save):
             settingsObj.saveChanges(interfaceName, opName)
 
 
+def setAndSaveAvailableIterfaceOptions():
+    """
+    Set and save the options for each available interface.
+    """
+    for interface in nimble.interfaces.available:
+        setInterfaceOptions(nimble.settings, interface, save=True)
+
+
 def autoRegisterFromSettings():
     """
     Helper which looks at the learners listed in nimble.settings under


### PR DESCRIPTION
Remove `interface` from the top level namespace by replacing the `for` loop which sets interface options in `__init__.py` with a call to a function, `setAndSaveAvailableInterfaceOptions`, in `configuration.py` containing the same loop.