### PR TITLE
modify all_estimators mock for cython issue

### DIFF
--- a/nimble/interfaces/scikit_learn_interface.py
+++ b/nimble/interfaces/scikit_learn_interface.py
@@ -58,7 +58,10 @@ class SciKitLearn(BuiltinInterface, UniversalInterface):
         pkgutil.walk_packages_ = pkgutil.walk_packages
         def mockWalkPackages(*args, **kwargs):
             packages = pkgutil.walk_packages_(*args, **kwargs)
-            return [pkg for pkg in packages if not 'conftest' in pkg[1]]
+            # each pkg is a tuple (importer, moduleName, isPackage)
+            # ignoring everything that is not a package prevents trying
+            # to import libraries outside of scikit-learn dependencies
+            return [pkg for pkg in packages if pkg[2]]
 
         with mock.patch('pkgutil.walk_packages', mockWalkPackages):
             all_estimators = all_estimators()


### PR DESCRIPTION
I realized while working on setup.py that the mock function used for `sklearn.utils.testing.all_estimators` does not eliminate all issues.  I had at some point installed cython in my testing environment, so this was not raising exceptions which would be raised for someone who does not have cython installed.  The issues are in sklearn tests and these are not python packages, so ignoring those and only importing the packages and subpackages available in sklearn eliminates any issues with dependencies related to sklearn tests. 