### PR TITLE
Custom.KNNClassifier updates

### DIFF
--- a/tests/customLearners/knn_test.py
+++ b/tests/customLearners/knn_test.py
@@ -40,26 +40,31 @@ def testKNNClassificationSimpleScores():
     assert ret[1, 1] == 2
 
 
-def testKNNClassificationTie():
-    """ Test KNN classification uses k=1 value when scores are tied """
+def testKNNClassification_NearestBreaksTie():
+    """ Test KNN classification uses nearest value to break tie """
 
-    data = [[0, 0, 0], [1, 10, 10], [0, -1, 4], [1, 0, 20]]
+    data = [[0, 0, 0], [1, 10, 10], [1, 11, 11], [2, -9, -9], [2, -10, -10]]
     trainObj = nimble.createData('Matrix', data)
 
-    data2 = [[2, 2], [20, 20]]
+    data2 = [[1, 1], [-1, -1]]
     testObj = nimble.createData('Matrix', data2)
 
     name = 'Custom.KNNClassifier'
-    tl = nimble.train(name, trainObj, 0, k=4)
-    predK4 = tl.apply(testObj)
-    scores = tl.getScores(testObj)
-    predK1 = nimble.trainAndApply(name, trainObj, 0, testObj, k=1)
 
-    # check tie occurred
-    assert scores[0, 0] == scores[0, 1]
-    assert scores[1, 0] == scores[1, 1]
-    # check predictions are k=1
-    assert predK4 == predK1
+    tl = nimble.train(name, trainObj, 0, k=5)
+    predK5 = tl.apply(testObj)
+    scores = tl.getScores(testObj)
+
+    # nearest neighbor has label 0 for each point in testObj, but when
+    # k=5, 0 receives only one vote and 1 and 2 are tied at 2 votes
+    assert scores[0, 0] == 1
+    assert scores[1, 0] == 1
+    assert scores[0, 1] == 2 and scores[0, 2] == 2
+    assert scores[1, 1] == 2 and scores[1, 2] == 2
+    # for first point in testObj, 1 is the nearest label of the tied votes
+    assert predK5[0] == 1
+    # for the second point in testObj, 2 is the nearest label of the tied votes
+    assert predK5[1] == 2
 
 
 def testKNNClassificationGetScores():


### PR DESCRIPTION
Improve efficiency of `KNNClassifier` by implementing the algorithm using a vectorized approach.  

All distances are calculated using numpy operations, returning a matrix of distances with the shape (numTestPoints, numTrainPts), where the element at `[p, q]` represents the distance between point `p` in testX and point `q` in trainX.  This matrix is generated using the helper `_getDistanceMatrix` as it is used in both `apply()` and `getScores()`.

The helper `_kNeighborOrderedLabelsAndVotes` generates a list of labels ordered by distance and a dictionary mapping unique labels from the neighbors to the number of times those labels occur.

In `apply()`, ties are now broken using the label of the closest point which has a label in the list of tied best labels. This will often be the closest point (k=1) but if not, this will continue to iterate through the points in order until a suitable label is found to break the tie.

In `getScores`, there was a bug not caught due to the simplicity of the tests.  If the number of labels in trainY exceeded the number of labels of the nearest neighbors this would fail.  The code was modified and a test was added so that the returned object from getScores accounts for all possible labels in trainY.

Speed improvements are evident throughout tests using this learner, but most noticeably the time for testCrossValidate.py decreased from over 26 seconds to under 0.6 seconds on my system.
