### PR TITLE
cleanup code in UniversalInterface and TrainedLearner

### DIFF
--- a/nimble/helpers.py
+++ b/nimble/helpers.py
@@ -3873,11 +3873,7 @@ def _validData(trainX, trainY, testX, testY, testRequired):
             msg += "of the feature containing labels in testX"
             raise InvalidArgumentType(msg)
         if isinstance(testY, Base):
-        #			if not len(trainY.features) == 1:
-        #               msg = "If trainY is a Data object, then it may only "
-        #               msg += "have one feature"
-        #				raise ArgumentException(msg)
-            if len(testY.points) != len(testY.points):
+            if len(testY.points) != len(testX.points):
                 msg = "If testY is a Data object, then it must have the same "
                 msg += "number of points as testX"
                 raise InvalidArgumentValueCombination(msg)

--- a/nimble/interfaces/mlpy_interface.py
+++ b/nimble/interfaces/mlpy_interface.py
@@ -313,7 +313,7 @@ To install mlpy
 
     def _incrementalTrainer(self, learner, trainX, trainY, arguments,
                             customDict):
-        raise RuntimeError()
+        raise NotImplementedError
 
 
     def _applier(self, learnerName, learner, testX, newArguments,

--- a/nimble/interfaces/scikit_learn_interface.py
+++ b/nimble/interfaces/scikit_learn_interface.py
@@ -374,7 +374,7 @@ To install scikit-learn
     def _incrementalTrainer(self, learner, trainX, trainY, arguments,
                             customDict):
         # see partial_fit(X, y[, classes, sample_weight])
-        pass
+        raise NotImplementedError
 
 
     def _applier(self, learnerName, learner, testX, newArguments,

--- a/tests/interfaces/universal_test.py
+++ b/tests/interfaces/universal_test.py
@@ -407,34 +407,13 @@ def backend_warningscapture(toCall, prepCall=None):
         sys.stderr = backup
 
 
-def test_warningscapture_trainAndApply():
-    cData = generateClassificationData(2, 10, 5)
-    ((trainX, trainY), (testX, testY)) = cData
-    @noLogEntryExpected
-    def wrapped(AWObject):
-        AWObject.trainAndApply('foo', trainX)
-
-    backend_warningscapture(wrapped)
-
-
-def test_warningscapture_trainAndTest():
-    cData = generateClassificationData(2, 10, 5)
-    ((trainX, trainY), (testX, testY)) = cData
-
-    def metric(x, y):
-        return 0
-
-    @noLogEntryExpected
-    def wrapped(AWObject):
-        AWObject.trainAndTest('foo', trainX, trainY, testX, testY, metric)
-
-    backend_warningscapture(wrapped)
-
-
 def test_warningscapture_train():
+    cData = generateClassificationData(2, 10, 5)
+    ((trainX, trainY), (testX, testY)) = cData
+
     @noLogEntryExpected
     def wrapped(AWObject):
-        AWObject.train('foo', None)
+        AWObject.train('foo', trainX)
 
     backend_warningscapture(wrapped)
 

--- a/tests/logger/testLoggingCount.py
+++ b/tests/logger/testLoggingCount.py
@@ -143,7 +143,7 @@ elements_funcs = elements_logged + elements_notLogged
 elements_tested = list(map(prefixAdder('Elements'), elements_funcs))
 
 ui_logged = [
-    'train', 'trainAndApply', 'trainAndTest',
+    'train',
     ]
 ui_notLogged = [
     'accessible', 'findCallable', 'getCanonicalName',


### PR DESCRIPTION
1. Removed dead functions trainAndApply and trainAndTest from UniversalInterface
2. Removed attributes trainX, trainY, transformedTrainX, transformedTrainY from TrainedLearner and added _trainXShape for use with validating testX
3. Changed numpy.int64 to numpy.integer. I checked the entire code base and these were the only two instances where this needed to be updated
4. fixed line 3880 in helpers.py to compare testY and testX (also removed the commented out code above which seemed outdated)
5. Interfaces without implementations for _incrementalTrain were doing a variety of things (pass, RunTimeError, NotImplementedError) so I changed all to NotImplementedError.
6. Updated some documentation in universal_interface.py