### PR TITLE
remove old option names in config

### DIFF
--- a/nimble/__init__.py
+++ b/nimble/__init__.py
@@ -81,7 +81,7 @@ configuration.autoRegisterFromSettings()
 
 # Now that we have loaded everything else, sync up the the settings object
 # as needed.
-configuration.setAndSaveAvailableIterfaceOptions()
+configuration.setAndSaveAvailableInterfaceOptions()
 
 # initialize the logging file
 logger.active = logger.initLoggerAndLogConfig()

--- a/nimble/configuration.py
+++ b/nimble/configuration.py
@@ -306,7 +306,7 @@ class SessionConfiguration(object):
                                               ToDelete):
                                 ret[kOpt] = self.changes[kSec][kOpt]
             if not found:
-                raise configparser.NoSectionError()
+                raise configparser.NoSectionError(section)
             return ret
         # Otherwise, treat it as a request for a single option,
         else:
@@ -561,16 +561,25 @@ def setInterfaceOptions(settingsObj, interface, save):
     """
     interfaceName = interface.getCanonicalName()
     optionNames = interface.optionNames
+    # remove any existing option names which are no longer in optionNames
+    try:
+        allOptions = settingsObj.get(interfaceName, None)
+        for opName in allOptions:
+            if opName not in optionNames:
+                settingsObj.delete(interfaceName, opName)
+    except configparser.NoSectionError:
+        pass
+    # set new option names
     for opName in optionNames:
         try:
             settingsObj.get(interfaceName, opName)
-        except (configparser.NoSectionError, configparser.NoOptionError):
+        except (configparser.Error):
             settingsObj.set(interfaceName, opName, "")
-        if save:
-            settingsObj.saveChanges(interfaceName, opName)
+    if save:
+        settingsObj.saveChanges(interfaceName)
 
 
-def setAndSaveAvailableIterfaceOptions():
+def setAndSaveAvailableInterfaceOptions():
     """
     Set and save the options for each available interface.
     """

--- a/tests/testConfig.py
+++ b/tests/testConfig.py
@@ -418,8 +418,7 @@ def test_settings_setInterfaceOptionsChanges():
     nimble.interfaces.available.append(tempInterface2)
 
     # set options for all interfaces, then reload
-    for interface in nimble.interfaces.available:
-        nimble.configuration.setInterfaceOptions(nimble.settings, interface, True)
+    nimble.configuration.setAndSaveAvailableInterfaceOptions()
     nimble.settings = nimble.configuration.loadSettings()
 
     nimble.settings.set('Test', 'Temp0', '0')
@@ -430,13 +429,13 @@ def test_settings_setInterfaceOptionsChanges():
 
     # change Test option names and reset options for all interfaces
     tempInterface1.optionNames[1] = 'NotTemp1'
-    for interface in nimble.interfaces.available:
-        nimble.configuration.setInterfaceOptions(nimble.settings, interface, True)
+    nimble.configuration.setAndSaveAvailableInterfaceOptions()
 
     # check values of both changed and unchanged names
     assert nimble.settings.get('Test', 'Temp0') == '0'
     try:
         nimble.settings.get('Test', 'Temp1')
+        assert False
     except six.moves.configparser.NoOptionError:
         pass
     assert nimble.settings.get('Test', 'NotTemp1') == ''


### PR DESCRIPTION
Added assert False in `test_settings_setInterfaceOptionsChanges` which highlighted that `setInterfaceOptions` was not removing any old option names from config if they were no longer included in the interface's options.  Now `setInterfaceOptions` will remove any options that are no longer available, then update with any new options. Any existing options that were previously set and are still included in the interface's options will be unaffected.

This update to `setInterfaceOptions` also uncovered a bug in configuration.py line 309. Added the required the section name argument for `configparser.NoSectionError`. 

Also, changed the for loop through interfaces in the test to use `setAndSaveAvailableInterfaceOptions` and noticed that function name had a typo so updated that as well.  