### PR TITLE
Allow for point/featureNames to define the subset in keepPoint/Features

### DIFF
--- a/nimble/helpers.py
+++ b/nimble/helpers.py
@@ -1763,7 +1763,7 @@ def _loadcsvUsingPython(openFile, pointNames, featureNames,
     # index values are valid
     keepFeaturesValidated = True
 
-    # at this stage, retFNames is either a list of False
+    # at this stage, retFNames is either a list or False
     # modifications are necessary if limiting features
     limitFeatures = keepFeatures != 'all'
     limitPoints = keepPoints != 'all'
@@ -1772,11 +1772,15 @@ def _loadcsvUsingPython(openFile, pointNames, featureNames,
         # featureNames list matches the features in keepFeatures
         keepFtIndices = []
         for ftID in keepFeatures:
-            if ftID in retFNames:
-                keepFtIndices.append(retFNames.index(ftID))
-            elif isinstance(ftID, str):
-                msg = "The value '" + ftID + "' in keepFeatures is not a "
-                msg += "valid featureName"
+            # cannot determine the index location of the feature by name since
+            # featureNames is only defining the names of the returned features
+            if isinstance(ftID, str):
+                msg = "Since featureNames were only provided for the values "
+                msg += "in keepFeatures, keepFeatures can contain only index "
+                msg += "values referencing the feature's location in the "
+                msg += "data. If attempting to use keepFeatures to reorder "
+                msg += "all features, instead create the object first then "
+                msg += "sort the features."
                 raise InvalidArgumentValue(msg)
             elif ftID >= 0:
                 keepFtIndices.append(ftID)
@@ -1825,23 +1829,16 @@ def _loadcsvUsingPython(openFile, pointNames, featureNames,
     if limitPoints and any(isinstance(ptID, str) for ptID in keepPoints):
         if not pointNames:
             msg = "keepPoints can contain only index values since "
-            msg += "no point names were provided"
+            msg += "no pointNames were provided"
             raise InvalidArgumentValue(msg)
-        # since we are iterating through the csv point by point, we do not
-        # know how many points there are and thus, whether pointNames has
-        # a name for each point. If keepPoints has less points than pointNames,
-        # we will assume we have access to all pointNames, but if the list
-        # lengths are equal and keepPoints contains pointNames, we cannot be
-        # sure that pointNames actually includes a name for each point and is
-        # not just the corresponding values for keepPoints so we need to
-        # raise an exception
+        # cannot determine the index location of the point by name since
+        # pointNames is only defining the names of the returned points
         elif pointNames is not True and len(pointNames) == len(keepPoints):
             msg = "Since pointNames were only provided for the values in "
             msg += "keepPoints, keepPoints can contain only index values "
             msg += "referencing the point's location in the data. If "
-            msg += "attempting to use keepPoints to reorder all data, instead "
-            msg += "create the object first then use the object's sort() "
-            msg += "method."
+            msg += "attempting to use keepPoints to reorder all points, "
+            msg += "instead create the object first then sort the points."
             raise InvalidArgumentValue(msg)
 
     extractedPointNames = []
@@ -1870,7 +1867,9 @@ def _loadcsvUsingPython(openFile, pointNames, featureNames,
                         msg += "range of possible indices, 0 to "
                         msg += str(len(row) - 1)
                         raise InvalidArgumentValue(msg)
+            # only need to do the validation once
             keepFeaturesValidated = True
+
         # this point will be used
         if keepPoints == 'all' or i in keepPoints or ptName in keepPoints:
             if limitFeatures:
@@ -1886,7 +1885,7 @@ def _loadcsvUsingPython(openFile, pointNames, featureNames,
             if firstRowLength is None:
                 firstRowLength = len(row)
                 lengthDefiningLine = skippedLines + i + 1
-            if firstRowLength != len(row):
+            elif firstRowLength != len(row):
                 delimiter = dialect.delimiter
                 msg = "The row on line " + str(skippedLines + i + 1) + " has "
                 msg += "length " + str(len(row)) + ". We expected length "

--- a/tests/testCreateData.py
+++ b/tests/testCreateData.py
@@ -2197,8 +2197,26 @@ def test_createData_keepPF_csv_nameAlignment_keptNames():
         assert fromCSVL == expected
         assert fromCSVD == expected
 
+
+def test_createData_csv_keepPoints_keepingAllPointNames_index():
+    data = [[111, 222, 333], [11, 22, 33], [1, 2, 3]]
+    pnames = ['1', '2', '3']
+    wanted = nimble.createData("Matrix", data=data, pointNames=pnames)
+    # instantiate from csv file
+    with tempfile.NamedTemporaryFile(suffix=".csv", mode='w') as tmpCSV:
+        tmpCSV.write("1,2,3\n")
+        tmpCSV.write("11,22,33\n")
+        tmpCSV.write("111,222,333\n")
+        tmpCSV.flush()
+
+        # cannot assume that pnames contains all pointNames for data
+        fromCSV = nimble.createData(
+            "Matrix", data=tmpCSV.name, pointNames=pnames, keepPoints=[2, 1, 0])
+        assert fromCSV == wanted
+
+
 @raises(InvalidArgumentValue)
-def test_createData_csv_keepPoints_keepingAllPointNames():
+def test_createData_csv_keepPoints_keepingAllPointNames_names():
     data = [[1, 2, 3], [11, 22, 33], [111, 222, 333]]
     pnames = ['1', '2', '3']
     wanted = nimble.createData("Matrix", data=data, pointNames=pnames)
@@ -2214,7 +2232,7 @@ def test_createData_csv_keepPoints_keepingAllPointNames():
             "Matrix", data=tmpCSV.name, pointNames=pnames, keepPoints=['3', '2', '1'])
 
 
-def test_createData_csv_keepFeatures_reordersAllFeatureNames():
+def test_createData_csv_keepFeatures_keepingAllFeatureNames_index():
     data = [[2, 3, 1], [22, 33, 11], [222, 333, 111]]
     fnames = ['2', '3', '1']
     wanted = nimble.createData("Matrix", data=data, featureNames=fnames)
@@ -2229,6 +2247,45 @@ def test_createData_csv_keepFeatures_reordersAllFeatureNames():
         fromCSV = nimble.createData(
             "Matrix", data=tmpCSV.name, featureNames=fnames, keepFeatures=[1, 2, 0])
         assert fromCSV == wanted
+
+@raises(InvalidArgumentValue)
+def test_createData_csv_keepFeatures_keepingAllFeatureNames_names():
+    data = [[2, 3, 1], [22, 33, 11], [222, 333, 111]]
+    fnames = ['b', 'c', 'a']
+    wanted = nimble.createData("Matrix", data=data, featureNames=fnames)
+    # instantiate from csv file
+    with tempfile.NamedTemporaryFile(suffix=".csv", mode='w') as tmpCSV:
+        tmpCSV.write("1,2,3\n")
+        tmpCSV.write("11,22,33\n")
+        tmpCSV.write("111,222,333\n")
+        tmpCSV.flush()
+
+        # assume featureNames passed aligns with order of keepFeatures
+        fromCSV = nimble.createData(
+            "Matrix", data=tmpCSV.name, featureNames=['a', 'b', 'c'], keepFeatures=['b', 'c' ,'a'])
+        assert fromCSV == wanted
+
+
+def test_createData_csv_keepFeatures_reordersFeatureNames_fnamesTrue():
+    data = [[22, 33, 11], [222, 333, 111]]
+    fnames = ['2', '3', '1']
+    wanted = nimble.createData("Matrix", data=data, featureNames=fnames)
+    # instantiate from csv file
+    with tempfile.NamedTemporaryFile(suffix=".csv", mode='w') as tmpCSV:
+        tmpCSV.write("1,2,3\n")
+        tmpCSV.write("11,22,33\n")
+        tmpCSV.write("111,222,333\n")
+        tmpCSV.flush()
+
+        # reordered based on keepFeatures since featureNames extracted
+        fromCSVNames = nimble.createData(
+            "Matrix", data=tmpCSV.name, featureNames=True, keepFeatures=fnames)
+        assert fromCSVNames == wanted
+
+        # reordered based on keepFeatures since featureNames extracted
+        fromCSVIndex = nimble.createData(
+            "Matrix", data=tmpCSV.name, featureNames=True, keepFeatures=[1, 2, 0])
+        assert fromCSVIndex == wanted
 
 ######################
 ### inputSeparator ###


### PR DESCRIPTION
Changes to keepPoints and keepFeatures for loading from a csv to allow for pointNames/featureNames lists to align with only the kept points/features. The changes now allow for the following:

1. If you have n features, have provided n featureNames, but have specified k features to keep: The k features will be returned in the order specified by keepFeatures, retaining the names assigned to them by featureNames.

2. If you have n features, have provided k featureNames, and have specified k features to keep: The k features (identified by index only) will be returned in the order specified by keepFeatures and named according the names provided in featureNames.

The assumption is used that when point/featureNames and point/keepFeatures are both lists of the same length then we assume that the point/featureNames are an ordered definition of the points/features in keepPoints/Features.  Names are not allowed in keepPoints and keepFeatures in this case because we are assuming we do not have access to all the names and therefore cannot use the index of the name in point/featureNames as a mapping to the index in the data.  For points, an exception is always required here because we cannot be sure how many points are in the data as we iterate through. For features, there could be an allowable special case when the length of featureNames matches the number of features, since we can check the feature count on the first point. However, this should be a rare case and only constitutes a reordering of all the data so I think it is simpler to raise an exception given the user can sort the data with one additional line of code after the object is created.
