### PR TITLE
sparse zero preserving scalar operations

### DIFF
--- a/nimble/data/sparse.py
+++ b/nimble/data/sparse.py
@@ -878,6 +878,10 @@ class Sparse(Base):
                 otherConv = other.copy('Matrix')
                 ret = getattr(selfData, opName)(otherConv.data)
             else:
+                nonZeroModifying = ['truediv', 'floordiv', 'mod']
+                if any(name in opName for name in nonZeroModifying):
+                    return self._scalarZeroPreservingBinary_implementation(
+                        opName, other)
                 # scalar operations apply to all elements; use dense
                 return self._genericNumericBinary_implementation(opName, other)
 
@@ -989,18 +993,37 @@ class Sparse(Base):
                 otherData = other.copy().data.data
             else:
                 otherData = other.data.data
-        elif isinstance(other, nimble.data.Base):
+        else: # another Base object type
             otherData = other.copy('Sparse').data.data
-        else:
-            otherData = other
+
         ret = numpy.mod(selfData.data, otherData)
         coo = coo_matrix((ret, (selfData.row, selfData.col)),
                          shape=self.shape)
         coo.eliminate_zeros() # remove any zeros introduced into data
         if opName.startswith('__i'):
-            absPath, relPath = self._absPath, self._relPath
             self.data = coo
-            self._absPath, self._relPath = absPath, relPath
+            return self
+        return Sparse(coo)
+
+    def _scalarZeroPreservingBinary_implementation(self, opName, other):
+        """
+        Helper applying operation directly to data attribute.
+
+        Zeros are preserved for these operations, so we only need to
+        apply the operation to the data attribute, the row and col
+        attributes will remain unchanged.
+        """
+        if self.data.data is None:
+            selfData = self.copy().data
+        else:
+            selfData = self.data
+
+        ret = getattr(selfData.data, opName)(other)
+        coo = coo_matrix((ret, (selfData.row, selfData.col)),
+                         shape=self.shape)
+        coo.eliminate_zeros() # remove any zeros introduced into data
+        if opName.startswith('__i'):
+            self.data = coo
             return self
         return Sparse(coo)
 

--- a/tests/assertionHelpers.py
+++ b/tests/assertionHelpers.py
@@ -38,9 +38,17 @@ def logCountAssertionFactory(count):
 noLogEntryExpected = logCountAssertionFactory(0)
 oneLogEntryExpected = logCountAssertionFactory(1)
 
+
 class LazyNameGenerationAssertionError(AssertionError):
     pass
 
 def assertNoNamesGenerated(obj):
     if obj.points._namesCreated() or obj.features._namesCreated():
         raise LazyNameGenerationAssertionError
+
+
+class CalledFunctionException(Exception):
+    pass
+
+def calledException(*args, **kwargs):
+    raise CalledFunctionException()

--- a/tests/calculate/matrix_test.py
+++ b/tests/calculate/matrix_test.py
@@ -11,15 +11,10 @@ from nimble.calculate import elementwiseMultiply
 from nimble.calculate import elementwisePower
 from nimble.exceptions import InvalidArgumentType
 from ..assertionHelpers import noLogEntryExpected
+from ..assertionHelpers import CalledFunctionException, calledException
 
-class CalledFunctionException(Exception):
-    pass
-
-def functionCalled(*args, **kwargs):
-    raise CalledFunctionException()
-
-@patch('nimble.data.Elements.multiply', side_effect=functionCalled)
-def test_elementwiseMultiply_callsObjElementsMultiply(mockObj):
+@patch('nimble.data.Elements.multiply', calledException)
+def test_elementwiseMultiply_callsObjElementsMultiply():
     left = [[1, 2, 3], [4, 5, 6]]
     right = [[6, 5, 4], [3, 2, 1]]
     for leftRType in nimble.data.available:
@@ -57,8 +52,8 @@ def test_elementwiseMultiply_logCount():
     mult = elementwiseMultiply(leftObj, rightObj)
 
 
-@patch('nimble.data.Elements.power', side_effect=functionCalled)
-def test_elementwisePower_callsObjElementsMultiply(mockObj):
+@patch('nimble.data.Elements.power', calledException)
+def test_elementwisePower_callsObjElementsMultiply():
     left = [[1, 2, 3], [4, 5, 6]]
     right = [[6, 5, 4], [3, 2, 1]]
     for leftRType in nimble.data.available:

--- a/tests/data/high_level_backend.py
+++ b/tests/data/high_level_backend.py
@@ -47,6 +47,7 @@ from .baseObject import DataTestObject
 from ..assertionHelpers import logCountAssertionFactory
 from ..assertionHelpers import noLogEntryExpected, oneLogEntryExpected
 from ..assertionHelpers import assertNoNamesGenerated
+from ..assertionHelpers import CalledFunctionException, calledException
 
 
 preserveName = "PreserveTestName"
@@ -93,13 +94,6 @@ def plusOneOnlyEven(value):
         return (value + 1)
     else:
         return None
-
-class CalledFunctionException(Exception):
-    def __init__(self):
-        pass
-
-def calledException(*args, **kwargs):
-    raise CalledFunctionException()
 
 def noChange(value):
     return value
@@ -166,8 +160,8 @@ class HighLevelDataSafe(DataTestObject):
         calc = toTest.points.calculate(returnInvalidObj)
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.axis.constructIndicesList', side_effect=calledException)
-    def test_points_calculate_calls_constructIndicesList(self, mockFunc):
+    @mock.patch('nimble.data.axis.constructIndicesList', calledException)
+    def test_points_calculate_calls_constructIndicesList(self):
         toTest = self.constructor([[1,2,],[3,4]], pointNames=['a', 'b'])
 
         ret = toTest.points.calculate(noChange, points=['a', 'b'])
@@ -366,8 +360,8 @@ class HighLevelDataSafe(DataTestObject):
         calc = toTest.features.calculate(returnInvalidObj)
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.axis.constructIndicesList', side_effect=calledException)
-    def test_features_calculate_calls_constructIndicesList(self, mockFunc):
+    @mock.patch('nimble.data.axis.constructIndicesList', calledException)
+    def test_features_calculate_calls_constructIndicesList(self):
         toTest = self.constructor([[1,2],[3,4]], featureNames=['a', 'b'])
 
         ret = toTest.features.calculate(noChange, features=['a', 'b'])
@@ -515,8 +509,8 @@ class HighLevelDataSafe(DataTestObject):
     #######################
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.elements.constructIndicesList', side_effect=calledException)
-    def test_elements_calculate_calls_constructIndicesList1(self, mockFunc):
+    @mock.patch('nimble.data.elements.constructIndicesList', calledException)
+    def test_elements_calculate_calls_constructIndicesList1(self):
         toTest = self.constructor([[1,2],[3,4]], pointNames=['a', 'b'])
 
         def noChange(point):
@@ -525,8 +519,8 @@ class HighLevelDataSafe(DataTestObject):
         ret = toTest.elements.calculate(noChange, points=['a', 'b'])
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.elements.constructIndicesList', side_effect=calledException)
-    def test_elements_calculate_calls_constructIndicesList2(self, mockFunc):
+    @mock.patch('nimble.data.elements.constructIndicesList', calledException)
+    def test_elements_calculate_calls_constructIndicesList2(self):
         toTest = self.constructor([[1,2],[3,4]], featureNames=['a', 'b'])
 
         def noChange(point):

--- a/tests/data/low_level_backend.py
+++ b/tests/data/low_level_backend.py
@@ -42,6 +42,7 @@ from nimble.exceptions import InvalidArgumentValueCombination, ImproperObjectAct
 from nimble.randomness import pythonRandom
 from ..assertionHelpers import logCountAssertionFactory
 from ..assertionHelpers import noLogEntryExpected, oneLogEntryExpected
+from ..assertionHelpers import CalledFunctionException, calledException
 
 ###########
 # helpers #
@@ -64,13 +65,6 @@ class GetItemOnly(object):
 class NotIterable(object):
     def __init__(self, *args):
         self.values = args
-
-class CalledFunctionException(Exception):
-    def __init__(self):
-        pass
-
-def calledException(*args, **kwargs):
-    raise CalledFunctionException()
 
 def confirmExpectedNames(toTest, axis, expected):
     if axis == 'point':
@@ -486,8 +480,8 @@ class LowLevelBackend(object):
         toTest.points.setNames(toAssign)
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.base.valuesToPythonList', side_effect=calledException)
-    def test_points_setNames_calls_valuesToPythonList(self, mockFunc):
+    @mock.patch('nimble.data.base.valuesToPythonList', calledException)
+    def test_points_setNames_calls_valuesToPythonList(self):
         toTest = self.constructor(pointNames=['one', 'two', 'three'])
         toTest.points.setNames(['a', 'b', 'c'])
 
@@ -616,8 +610,8 @@ class LowLevelBackend(object):
         toTest.features.setNames(toAssign)
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.base.valuesToPythonList', side_effect=calledException)
-    def test_features_setNames_calls_valuesToPythonList(self, mockFunc):
+    @mock.patch('nimble.data.base.valuesToPythonList', calledException)
+    def test_features_setNames_calls_valuesToPythonList(self):
         toTest = self.constructor(featureNames=['one', 'two', 'three'])
         toTest.features.setNames(['a', 'b', 'c'])
 
@@ -1132,8 +1126,8 @@ class LowLevelBackend(object):
         assert constructIndicesList(toTest, 'feature', mixFts1D) == expected
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.base.valuesToPythonList', side_effect=calledException)
-    def test_points_setNames_calls_valuesToPythonList(self, mockFunc):
+    @mock.patch('nimble.data.base.valuesToPythonList', calledException)
+    def test_points_setNames_calls_valuesToPythonList(self):
         pointNames = ['p1','p2','p3']
         toTest = self.constructor(pointNames=pointNames)
         constructIndicesList(toTest, ['p1', 'p2', 'p3'])

--- a/tests/data/numerical_backend.py
+++ b/tests/data/numerical_backend.py
@@ -17,6 +17,7 @@ import sys
 import numpy
 import os
 import os.path
+from unittest.mock import patch
 
 from nose.tools import *
 import six
@@ -31,6 +32,7 @@ from nimble.randomness import pythonRandom
 from .baseObject import DataTestObject
 from ..assertionHelpers import logCountAssertionFactory, noLogEntryExpected
 from ..assertionHelpers import assertNoNamesGenerated
+from ..assertionHelpers import CalledFunctionException, calledException
 
 
 preserveName = "PreserveTestName"
@@ -679,6 +681,18 @@ def run_full_backend_rOp(constructor, npEquiv, nimbleOp, inplace, sparsity):
 
     back_autoVsNumpyScalar(constructor, npEquiv, nimbleOp, inplace, sparsity)
 
+@patch('nimble.data.Sparse._scalarZeroPreservingBinary_implementation', calledException)
+def back_sparseScalarZeroPreserving(constructor, nimbleOp):
+    data = [[1, 2, 3], [0, 0, 0]]
+    toTest = constructor(data)
+    rint = pythonRandom.randint(1, 5)
+    try:
+        ret = getattr(toTest, nimbleOp)(rint)
+        if toTest.getTypeString() == "Sparse":
+            assert False # did not use _scalarZeroPreservingBinary_implementation
+    except CalledFunctionException:
+        assert toTest.getTypeString() == "Sparse"
+
 
 class NumericalDataSafe(DataTestObject):
 
@@ -893,6 +907,9 @@ class NumericalDataSafe(DataTestObject):
     def test_truediv_binaryelementwise_NamePath_preservations(self):
         back_binaryelementwise_NamePath_preservations(self.constructor, '__truediv__', False)
 
+    def test_truediv_Sparse_calls_scalarZeroPreservingBinary(self):
+        back_sparseScalarZeroPreserving(self.constructor, '__truediv__')
+
 
     ################
     # __rtruediv__ #
@@ -916,6 +933,8 @@ class NumericalDataSafe(DataTestObject):
     def test_rtruediv_binaryelementwise_NamePath_preservations(self):
         back_binaryelementwise_NamePath_preservations(self.constructor, '__rtruediv__', False)
 
+    def test_rtruediv_Sparse_calls_scalarZeroPreservingBinary(self):
+        back_sparseScalarZeroPreserving(self.constructor, '__rtruediv__')
 
     ###############
     # __floordiv__ #
@@ -938,6 +957,9 @@ class NumericalDataSafe(DataTestObject):
 
     def test_floordiv_binaryelementwise_NamePath_preservations(self):
         back_binaryelementwise_NamePath_preservations(self.constructor, '__floordiv__', False)
+
+    def test_floordiv_Sparse_calls_scalarZeroPreservingBinary(self):
+        back_sparseScalarZeroPreserving(self.constructor, '__floordiv__')
 
 
     ################
@@ -962,6 +984,9 @@ class NumericalDataSafe(DataTestObject):
     def test_rfloordiv_binaryelementwise_NamePath_preservations(self):
         back_binaryelementwise_NamePath_preservations(self.constructor, '__rfloordiv__', False)
 
+    def test_rfloordiv_Sparse_calls_scalarZeroPreservingBinary(self):
+        back_sparseScalarZeroPreserving(self.constructor, '__rfloordiv__')
+
 
     ###############
     # __mod__ #
@@ -984,6 +1009,9 @@ class NumericalDataSafe(DataTestObject):
 
     def test_mod_binaryelementwise_NamePath_preservations(self):
         back_binaryelementwise_NamePath_preservations(self.constructor, '__mod__', False)
+
+    def test_mod_Sparse_calls_scalarZeroPreservingBinary(self):
+        back_sparseScalarZeroPreserving(self.constructor, '__mod__')
 
 
     ################
@@ -1008,6 +1036,8 @@ class NumericalDataSafe(DataTestObject):
     def test_rmod_binaryelementwise_NamePath_preservations(self):
         back_binaryelementwise_NamePath_preservations(self.constructor, '__rmod__', False)
 
+    def test_rmod_Sparse_calls_scalarZeroPreservingBinary(self):
+        back_sparseScalarZeroPreserving(self.constructor, '__rmod__')
 
     ###########
     # __pow__ #
@@ -1538,6 +1568,9 @@ class NumericalModifying(DataTestObject):
     def test_itruediv_binaryelementwise_NamePath_preservations(self):
         back_binaryelementwise_NamePath_preservations(self.constructor, '__itruediv__', True)
 
+    def test_itruediv_Sparse_calls_scalarZeroPreservingBinary(self):
+        back_sparseScalarZeroPreserving(self.constructor, '__itruediv__')
+
 
     ################
     # __ifloordiv__ #
@@ -1560,6 +1593,9 @@ class NumericalModifying(DataTestObject):
 
     def test_ifloordiv_binaryelementwise_NamePath_preservations(self):
         back_binaryelementwise_NamePath_preservations(self.constructor, '__ifloordiv__', True)
+
+    def test_ifloordiv_Sparse_calls_scalarZeroPreservingBinary(self):
+        back_sparseScalarZeroPreserving(self.constructor, '__ifloordiv__')
 
 
     ################
@@ -1584,6 +1620,9 @@ class NumericalModifying(DataTestObject):
 
     def test_imod_binaryelementwise_NamePath_preservations(self):
         back_binaryelementwise_NamePath_preservations(self.constructor, '__imod__', True)
+
+    def test_imod_Sparse_calls_scalarZeroPreservingBinary(self):
+        back_sparseScalarZeroPreserving(self.constructor, '__imod__')
 
 
     ###########

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -38,6 +38,7 @@ from nimble.exceptions import InvalidArgumentValueCombination
 from .baseObject import DataTestObject
 from ..assertionHelpers import noLogEntryExpected, oneLogEntryExpected
 from ..assertionHelpers import assertNoNamesGenerated
+from ..assertionHelpers import CalledFunctionException, calledException
 
 
 preserveName = "PreserveTestName"
@@ -58,12 +59,6 @@ def _pnames(num):
     for i in range(num):
         ret.append('p' + str(i))
     return ret
-
-class CalledFunctionException(Exception):
-    pass
-
-def calledException(*args, **kwargs):
-    raise CalledFunctionException()
 
 
 class QueryBackend(DataTestObject):
@@ -1281,7 +1276,7 @@ class QueryBackend(DataTestObject):
     @raises(CalledFunctionException)
     def backend_sim_callsFunctions(self, objFunc, calcFunc, axis):
         toPatch = 'nimble.calculate.' + calcFunc
-        with patch(toPatch, side_effect=calledException):
+        with patch(toPatch, calledException):
             if axis == 'point':
                 data = [[3, 0, 3], [0, 0, 3], [3, 0, 0]]
                 obj = self.constructor(data)
@@ -1678,7 +1673,7 @@ class QueryBackend(DataTestObject):
     @raises(CalledFunctionException)
     def backend_stat_callsFunctions(self, objFunc, calcFunc, axis):
         toPatch = 'nimble.calculate.' + calcFunc
-        with patch(toPatch, side_effect=calledException):
+        with patch(toPatch, calledException):
             if axis == 'point':
                 data = [[3, 0, 3], [0, 0, 3], [3, 0, 0]]
                 obj = self.constructor(data)

--- a/tests/data/structure_backend.py
+++ b/tests/data/structure_backend.py
@@ -48,6 +48,7 @@ from .baseObject import DataTestObject
 from ..assertionHelpers import logCountAssertionFactory
 from ..assertionHelpers import noLogEntryExpected, oneLogEntryExpected
 from ..assertionHelpers import assertNoNamesGenerated
+from ..assertionHelpers import CalledFunctionException, calledException
 
 scipy = nimble.importModule('scipy.sparse')
 pd = nimble.importModule('pandas')
@@ -75,13 +76,6 @@ def plusOneOnlyEven(value):
         return (value + 1)
     else:
         return None
-
-class CalledFunctionException(Exception):
-    def __init__(self):
-        pass
-
-def calledException(*args, **kwargs):
-    raise CalledFunctionException()
 
 def noChange(value):
     return value
@@ -635,8 +629,8 @@ class StructureDataSafe(StructureShared):
     ###############
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.axis.constructIndicesList', side_effect=calledException)
-    def test_points_copy_calls_constructIndicesList(self, mockFunc):
+    @mock.patch('nimble.data.axis.constructIndicesList', calledException)
+    def test_points_copy_calls_constructIndicesList(self):
         toTest = self.constructor([[1,2,],[3,4]], pointNames=['a', 'b'])
 
         ret = toTest.points.copy(['a', 'b'])
@@ -1403,8 +1397,8 @@ class StructureDataSafe(StructureShared):
     #####################
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.axis.constructIndicesList', side_effect=calledException)
-    def test_features_copy_calls_constructIndicesList(self, mockFunc):
+    @mock.patch('nimble.data.axis.constructIndicesList', calledException)
+    def test_features_copy_calls_constructIndicesList(self):
         toTest = self.constructor([[1,2,],[3,4]], featureNames=['a', 'b'])
 
         ret = toTest.features.copy(['a', 'b'])
@@ -2349,13 +2343,13 @@ class StructureModifying(StructureShared):
         ret = self.constructor(coo_str)
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.base.valuesToPythonList', side_effect=calledException)
-    def test_init_pointNames_calls_valuesToPythonList(self, mockFunc):
+    @mock.patch('nimble.data.base.valuesToPythonList', calledException)
+    def test_init_pointNames_calls_valuesToPythonList(self):
         self.constructor([1,2,3], pointNames=['one'])
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.base.valuesToPythonList', side_effect=calledException)
-    def test_init_featureNames_calls_valuesToPythonList(self, mockFunc):
+    @mock.patch('nimble.data.base.valuesToPythonList', calledException)
+    def test_init_featureNames_calls_valuesToPythonList(self):
         self.constructor([1,2,3], featureNames=['a', 'b', 'c'])
 
     ###############
@@ -3471,8 +3465,8 @@ class StructureModifying(StructureShared):
     ##################
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.axis.constructIndicesList', side_effect=calledException)
-    def test_points_extract_calls_constructIndicesList(self, mockFunc):
+    @mock.patch('nimble.data.axis.constructIndicesList', calledException)
+    def test_points_extract_calls_constructIndicesList(self):
         toTest = self.constructor([[1,2,],[3,4]], pointNames=['a', 'b'])
 
         ret = toTest.points.extract(['a', 'b'])
@@ -4255,8 +4249,8 @@ class StructureModifying(StructureShared):
     ######################
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.axis.constructIndicesList', side_effect=calledException)
-    def test_features_extract_calls_constructIndicesList(self, mockFunc):
+    @mock.patch('nimble.data.axis.constructIndicesList', calledException)
+    def test_features_extract_calls_constructIndicesList(self):
         toTest = self.constructor([[1,2,],[3,4]], featureNames=['a', 'b'])
 
         ret = toTest.features.extract(['a', 'b'])
@@ -4929,8 +4923,8 @@ class StructureModifying(StructureShared):
     #################
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.axis.constructIndicesList', side_effect=calledException)
-    def test_points_delete_calls_constructIndicesList(self, mockFunc):
+    @mock.patch('nimble.data.axis.constructIndicesList', calledException)
+    def test_points_delete_calls_constructIndicesList(self):
         toTest = self.constructor([[1,2,],[3,4]], pointNames=['a', 'b'])
 
         toTest.points.delete(['a', 'b'])
@@ -5569,8 +5563,8 @@ class StructureModifying(StructureShared):
     ###################
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.axis.constructIndicesList', side_effect=calledException)
-    def test_features_delete_calls_constructIndicesList(self, mockFunc):
+    @mock.patch('nimble.data.axis.constructIndicesList', calledException)
+    def test_features_delete_calls_constructIndicesList(self):
         toTest = self.constructor([[1,2,],[3,4]], featureNames=['a', 'b'])
 
         toTest.features.delete(['a', 'b'])
@@ -6117,8 +6111,8 @@ class StructureModifying(StructureShared):
     #################
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.axis.constructIndicesList', side_effect=calledException)
-    def test_points_retain_calls_constructIndicesList(self, mockFunc):
+    @mock.patch('nimble.data.axis.constructIndicesList', calledException)
+    def test_points_retain_calls_constructIndicesList(self):
         """ Test points.retain calls constructIndicesList before calling _genericStructuralFrontend"""
         toTest = self.constructor([[1,2,],[3,4]], pointNames=['a', 'b'])
         toTest.points.retain(['a', 'b'])
@@ -6803,8 +6797,8 @@ class StructureModifying(StructureShared):
     ###################
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.axis.constructIndicesList', side_effect=calledException)
-    def test_features_retain_calls_constructIndicesList(self, mockFunc):
+    @mock.patch('nimble.data.axis.constructIndicesList', calledException)
+    def test_features_retain_calls_constructIndicesList(self):
         toTest = self.constructor([[1,2,],[3,4]], featureNames=['a', 'b'])
 
         toTest.features.retain(['a', 'b'])
@@ -7515,8 +7509,8 @@ class StructureModifying(StructureShared):
         origObj.points.transform(emitLower)
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.axis.constructIndicesList', side_effect=calledException)
-    def test_points_transform_calls_constructIndicesList(self, mockFunc):
+    @mock.patch('nimble.data.axis.constructIndicesList', calledException)
+    def test_points_transform_calls_constructIndicesList(self):
         toTest = self.constructor([[1,2,],[3,4]], pointNames=['a', 'b'])
 
         toTest.points.transform(noChange, points=['a', 'b'])
@@ -7652,8 +7646,8 @@ class StructureModifying(StructureShared):
         origObj.features.transform(None)
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.axis.constructIndicesList', side_effect=calledException)
-    def test_features_transform_calls_constructIndicesList(self, mockFunc):
+    @mock.patch('nimble.data.axis.constructIndicesList', calledException)
+    def test_features_transform_calls_constructIndicesList(self):
         toTest = self.constructor([[1,2,],[3,4]], featureNames=['a', 'b'])
 
         toTest.features.transform(noChange, features=['a', 'b'])
@@ -7762,8 +7756,8 @@ class StructureModifying(StructureShared):
     ##########################
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.elements.constructIndicesList', side_effect=calledException)
-    def test_elements_transform_calls_constructIndicesList1(self, mockFunc):
+    @mock.patch('nimble.data.elements.constructIndicesList', calledException)
+    def test_elements_transform_calls_constructIndicesList1(self):
         toTest = self.constructor([[1,2],[3,4]], pointNames=['a', 'b'])
 
         def noChange(point):
@@ -7772,8 +7766,8 @@ class StructureModifying(StructureShared):
         toTest.elements.transform(noChange, points=['a', 'b'])
 
     @raises(CalledFunctionException)
-    @mock.patch('nimble.data.elements.constructIndicesList', side_effect=calledException)
-    def test_elements_transform_calls_constructIndicesList2(self, mockFunc):
+    @mock.patch('nimble.data.elements.constructIndicesList', calledException)
+    def test_elements_transform_calls_constructIndicesList2(self):
         toTest = self.constructor([[1,2],[3,4]], featureNames=['a', 'b'])
 
         def noChange(point):

--- a/tests/test_train_apply_test_frontends.py
+++ b/tests/test_train_apply_test_frontends.py
@@ -16,6 +16,7 @@ from nimble.randomness import pythonRandom
 from nimble.exceptions import InvalidArgumentValue
 from nimble.exceptions import InvalidArgumentValueCombination
 from .assertionHelpers import logCountAssertionFactory, oneLogEntryExpected
+from .assertionHelpers import CalledFunctionException, calledException
 
 def test_trainAndApply_dataInputs():
     variables = ["x1", "x2", "x3", "label"]
@@ -454,13 +455,7 @@ def test_trainFunctions_cv_triggered_errors():
         # different exception since this triggers crossValidation directly
         assert "folds" in str(iavc)
 
-class CalledException(Exception):
-    pass
-
-def raiseCalledException(*args, **kwargs):
-    raise CalledException()
-
-@mock.patch('nimble.core.crossValidate', raiseCalledException)
+@mock.patch('nimble.core.crossValidate', calledException)
 def test_frontend_CV_triggering():
     #with small data set
     variables = ["x1", "x2", "x3"]
@@ -474,24 +469,24 @@ def test_frontend_CV_triggering():
         try:
             train('Custom.KNNClassifier', trainX=trainObj, trainY=labelsObj,
                   performanceFunction=fractionIncorrect, k=nimble.CV([1, 2]), folds=5)
-            assert False # expected CVWasCalledException
-        except CalledException:
+            assert False # expected CalledFunctionException
+        except CalledFunctionException:
             pass
 
         try:
             trainAndApply('Custom.KNNClassifier', trainX=trainObj, trainY=labelsObj,
                           performanceFunction=fractionIncorrect, testX=trainObj,
                           k=nimble.CV([1, 2]), folds=5)
-            assert False # expected CVWasCalledException
-        except CalledException:
+            assert False # expected CalledFunctionException
+        except CalledFunctionException:
             pass
 
         try:
             trainAndTest('Custom.KNNClassifier', trainX=trainObj, trainY=labelsObj,
                          testX=trainObj, testY=labelsObj, performanceFunction=fractionIncorrect,
                          k=nimble.CV([1, 2]), folds=5)
-            assert False # expected CVWasCalledException
-        except CalledException:
+            assert False # expected CalledFunctionException
+        except CalledFunctionException:
             pass
     except Exception:
         einfo = sys.exc_info()
@@ -611,8 +606,8 @@ def test_trainAndTestOnTrainingData_logCount_withCV():
         return nimble.trainAndTestOnTrainingData(learner, trainX, trainY, performanceFunction, k=nimble.CV([1, 2]))
     back_logCount(wrapped)
 
-@raises(CalledException)
-@mock.patch('nimble.interfaces.universal_interface.TrainedLearner._validTestData', raiseCalledException)
+@raises(CalledFunctionException)
+@mock.patch('nimble.interfaces.universal_interface.TrainedLearner._validTestData', calledException)
 def test_trainAndApply_testXValidation():
     variables = ["x1", "x2", "x3", "label"]
     numPoints = 20
@@ -631,8 +626,8 @@ def test_trainAndApply_testXValidation():
     # trainY is ID, testX does not contain labels; test int
     out = nimble.trainAndApply(learner, trainObj, 3, testObjNoLabels)
 
-@raises(CalledException)
-@mock.patch('nimble.interfaces.universal_interface.TrainedLearner._validTestData', raiseCalledException)
+@raises(CalledFunctionException)
+@mock.patch('nimble.interfaces.universal_interface.TrainedLearner._validTestData', calledException)
 def test_trainAndTest_testXValidation():
     variables = ["x1", "x2", "x3", "label"]
     numPoints = 20
@@ -654,8 +649,8 @@ def test_trainAndTest_testXValidation():
     out = nimble.trainAndTest(learner, trainObj, trainObjLabels, testObjData,
                               testObjLabels, perfFunc)
 
-@raises(CalledException)
-@mock.patch('nimble.interfaces.universal_interface.TrainedLearner._validTestData', raiseCalledException)
+@raises(CalledFunctionException)
+@mock.patch('nimble.interfaces.universal_interface.TrainedLearner._validTestData', calledException)
 def test_TL_apply_testXValidation():
     variables = ["x1", "x2", "x3", "label"]
     numPoints = 20
@@ -675,8 +670,8 @@ def test_TL_apply_testXValidation():
     tl = nimble.train(learner, trainObj, 3)
     out = tl.apply(testObjNoLabels)
 
-@raises(CalledException)
-@mock.patch('nimble.interfaces.universal_interface.TrainedLearner._validTestData', raiseCalledException)
+@raises(CalledFunctionException)
+@mock.patch('nimble.interfaces.universal_interface.TrainedLearner._validTestData', calledException)
 def test_TL_test_testXValidation():
     variables = ["x1", "x2", "x3", "label"]
     numPoints = 20
@@ -698,8 +693,8 @@ def test_TL_test_testXValidation():
     tl = nimble.train(learner, trainObj, trainObjLabels)
     out = tl.test(testObjData, testObjLabels, perfFunc)
 
-@raises(CalledException)
-@mock.patch('nimble.interfaces.universal_interface.TrainedLearner._validTestData', raiseCalledException)
+@raises(CalledFunctionException)
+@mock.patch('nimble.interfaces.universal_interface.TrainedLearner._validTestData', calledException)
 def test_TL_getScores_testXValidation():
     variables = ["x1", "x2", "x3", "label"]
     numPoints = 20


### PR DESCRIPTION
Helper, `_scalarZeroPreservingBinary_implementation`, for floordiv, truediv, and mod (__*__, __i*__, __r*__) operations in Sparse when `other` is a scalar value to improve prevent conversion to a dense representation since these operation preserves zeros.

Added tests to check that Sparse is calling `_scalarZeroPreservingBinary_implementation` instead of defaulting to the dense implementation. This type of test is becoming more and more common in our testing so `CalledFunctionException` and `calledException` helpers (sometimes called other names but serving the same purpose) were being created and utilized in many test files.  I created one instance of these helpers in tests/assertionHelpers.py and now have the test files import them.