### PR TITLE
treatAsMissing bug fix

### DIFF
--- a/nimble/helpers.py
+++ b/nimble/helpers.py
@@ -563,6 +563,9 @@ def replaceNumpyValues(data, toReplace, replaceWith):
             and isinstance(replaceWith, (int, float, numpy.number))):
         toReplace = [val for val in toReplace
                      if isinstance(val, (int, float, numpy.number))]
+        toReplace = numpy.array(toReplace)
+    else:
+        toReplace = numpy.array(toReplace, dtype=numpy.object_)
 
     # numpy.isin cannot handle nan replacement, so if nan is in
     # toReplace we instead set the flag to trigger nan replacement

--- a/tests/testCreateData.py
+++ b/tests/testCreateData.py
@@ -2217,9 +2217,11 @@ def test_numericalReplaceMissingWithNonNumeric():
 def test_handmadeTreatAsMissing():
     for t in returnTypes:
         nan = numpy.nan
-        data = [[1, 2, ""], [numpy.nan, 5, 6], [7, None, 9], ["", "nan", "None"]]
-        toTest = nimble.createData(t, data, treatAsMissing=[numpy.nan, None, ""])
-        expData = [[1, 2, nan], [nan, 5, 6], [7, nan, 9], [nan, "nan", "None"]]
+        data = [[1, 2, ""], [nan, 5, 6], [7, "", 9], [nan, "nan", "None"]]
+        missingList = [nan, "", 5]
+        assert numpy.array(missingList).dtype != numpy.object_
+        toTest = nimble.createData(t, data, treatAsMissing=missingList)
+        expData = [[1, 2, nan], [nan, nan, 6], [7, nan, 9], [nan, "nan", "None"]]
         expRet = nimble.createData(t, expData, treatAsMissing=None)
         assert toTest == expRet
 


### PR DESCRIPTION
When using numpy to locate and replace values in the treatAsMissing list, some values were not being identified properly for replacement.  The reason seems to be that within the numpy.isin function, the treatAsMissing list must be converted to a numpy array which does not always have our desired dtype.  For example, ["na", 0] would be converted to array(['na', '0'], dtype='<U2'), so any 0 values would not be identified only string '0' values.  Providing the list with an object dtype, when necessary, to numpy.isin prevents this error.

Interestingly, this was missed by the testing because the test with mixed data types in treatAsMissing also contained None which caused numpy to assign the object dtype by default.  However, when the list contains only string and numeric values, numpy assigns a different dtype.  An existing test was modified so that treatAsMissing contains only string and numeric values to trigger this failure. 