### PR TITLE
filter skl packages with dependencies

### DIFF
--- a/nimble/interfaces/scikit_learn_interface.py
+++ b/nimble/interfaces/scikit_learn_interface.py
@@ -22,6 +22,7 @@ from nimble.interfaces.interface_helpers import collectAttributes
 from nimble.interfaces.interface_helpers import removeFromTailMatchedLists
 from nimble.helpers import inspectArguments
 from nimble.docHelpers import inheritDocstringsFactory
+from nimble.importExternalLibraries import importModule
 
 # Contains path to sciKitLearn root directory
 #sciKitLearnDir = '/usr/local/lib/python2.7/dist-packages'
@@ -59,7 +60,8 @@ class SciKitLearn(PredefinedInterface, UniversalInterface):
             # we want to ignore anything not in __all__ to prevent trying
             # to import libraries outside of scikit-learn dependencies
             sklAll = self.skl.__all__
-            return [pkg for pkg in packages if pkg[1].split('.')[1] in sklAll]
+            return [pkg for pkg in packages if pkg[1].split('.')[1] in sklAll
+                    and importModule(pkg[1]) is not None]
 
         with mock.patch('pkgutil.walk_packages', mockWalkPackages):
             try:


### PR DESCRIPTION
Used `importModule` to filter out the scikit-learn modules which fail to import because of pytest and Cython dependencies.  This solution allows for us to import the extra learners from sklearn.__all__ and should be robust for any dependency issues.

I tested this solution in minimal environments with scikit-learn versions 19.2, 20.3 and 21.2. I did try to remove the`if pkg[1].split('.')[1] in sklAll` requirement but this caused a major issue in 19.2.

Here are the counts comparing the prior implementation that did use sklearn.__all__ and this implementation.
0.19.2: 123, 143  
0.20.3 122, 145 
0.21.2 124, 147