### PR TITLE
bug fix: logger output

### DIFF
--- a/nimble/logger/session_logger.py
+++ b/nimble/logger/session_logger.py
@@ -151,7 +151,7 @@ class SessionLogger(object):
 
         timestamp = time.strftime('%Y-%m-%d %H:%M:%S')
         sessionNum = self.sessionNumber
-        logInfo = str(logInfo)
+        logInfo = repr(logInfo)
         statement = "INSERT INTO logger "
         statement += "(timestamp,sessionNumber,logType,logInfo) "
         statement += "VALUES (?,?,?,?);"
@@ -359,8 +359,12 @@ class SessionLogger(object):
 
             if arguments is not None and arguments != {}:
                 for name, value in arguments.items():
-                    arguments[name] = repr(value)
-
+                    try:
+                        literal_eval(repr(value))
+                        arguments[name] = value
+                    except (ValueError, SyntaxError):
+                        # use repr for objects which cannot eval
+                        arguments[name] = repr(value)
                 logInfo['arguments'] = arguments
 
             if metrics is not None and metrics != {}:

--- a/tests/logger/testLoggingIO.py
+++ b/tests/logger/testLoggingIO.py
@@ -223,7 +223,7 @@ def testLoadTypeFunctionsUseLog():
     assert "TrainedLearner" in logInfo
     assert "'learnerName': 'KNNClassifier'" in logInfo
     # all keys and values in learnerArgs are stored as strings
-    assert "'learnerArgs': {'k': '1'}" in logInfo
+    assert "'learnerArgs': {'k': 1}" in logInfo
 
     # loadData
     with tempfile.NamedTemporaryFile(suffix=".nimd") as tmpFile:
@@ -846,6 +846,46 @@ def testShowLogToStdOut():
         stdoutContent = out.getvalue().strip()
 
         assert stdoutContent == fileContent
+
+    finally:
+        sys.stdout = saved_stdout
+
+@configSafetyWrapper
+@emptyLogSafetyWrapper
+def testShowLogWithSubobject():
+    class Int_(object):
+        """
+        For the purposes of custom.KNNClassifier, behaves exactly as the
+        integer needed for k , but for the log will cause a failure if
+        not represented in arguments as a string.
+        """
+        def __init__(self, num):
+            self.num = num
+
+        def __index__(self):
+            return self.num
+
+        def __repr__(self):
+            return 'Int_({})'.format(self.num)
+
+    saved_stdout = sys.stdout
+    try:
+        trainX = [[1,0,0], [0,1,0], [0,0,1], [1,0,0], [0,1,0], [0,0,1],
+                  [1,0,0], [0,1,0], [0,0,1], [1,0,0], [0,1,0], [0,0,1]]
+        trainY = [[0], [1], [2], [0], [1], [2], [0], [1], [2], [0], [1], [2]]
+        trainXObj = nimble.createData('Sparse', trainX)
+        trainYObj = nimble.createData('List', trainY)
+        tl = nimble.train('custom.KNNClassifier', trainXObj, trainYObj,
+                          arguments={'k': Int_(1)}, useLog=True)
+        # redirect stdout
+        out = StringIO()
+        sys.stdout = out
+
+        # showLog to stdout with default arguments
+        nimble.showLog()
+        stdoutContent = out.getvalue().strip()
+
+        assert "Arguments: k=Int_(1)" in stdoutContent
 
     finally:
         sys.stdout = saved_stdout


### PR DESCRIPTION
There was a bug when the arguments dictionary for training functions included a subobject.  The data is stored in the log as a string, but in the form of a dictionary so when we extract it we plan on converting it back to a dictionary.  However, when a subobject was included in the arguments dictionary, ast.literal_eval is unable to transform the string back to a dictionary.  The code already included an exception for the CV object, because it caused the same failure.  Instead, now the `repr` for everything in arguments will be used, allowing literal_eval to load all these as strings.  Everything in arguments will be converted back to a string for the log output and no manipulation of arguments as their original type is necessary, so there should not be any drawbacks to this change.