### PR TITLE
Sparse pow

### DIFF
--- a/nimble/data/sparse.py
+++ b/nimble/data/sparse.py
@@ -978,7 +978,7 @@ class Sparse(Base):
             caller = self
             callee = other
         elif 'r' in opName:
-            caller = other.copy()
+            caller = other.copy('Sparse')
             callee = self
         else:
             caller = self.copy()


### PR DESCRIPTION
I noticed that the numeric test suite was hiding an error for Sparse power operations.  It appeared that Sparse could always perform the power operations, however this was because the test suite was always generating square objects. Scipy does not support this operation when the objects are not square, leading to an exception.

Updates:
- Modified test backends which apply to all operations to create objects of random sizes in both dimensions, except for matrix multiplication where square objects always allow for compatible shapes.
- Added a new helper '_genericPow_implementation` for power operations in Sparse so that these operations are performed elementwise for any object shape.
- Removed some unnecessary code from `genericMul_implementation`
- updated `pow` tests to use same `run_full_backend` as used in other operator tests.
  - This adds testing of different nimble object types for all `pow` operations and testing of `__rpow__` for nimble objects, which were previously missing