### PR TITLE
Adjust formatIfNeeded in dataHelpers to omit unneeded conditional

### DIFF
--- a/nimble/data/dataHelpers.py
+++ b/nimble/data/dataHelpers.py
@@ -216,9 +216,8 @@ def formatIfNeeded(value, sigDigits):
     Format the value into a string, and in the case of a float typed value,
     limit the output to the given number of significant digits.
     """
-    if _looksNumeric(value) and not (value is True or value is False):
-        if isinstance(value, (float, numpy.float)) and sigDigits is not None:
-            return format(value, '.' + str(int(sigDigits)) + 'f')
+    if isinstance(value, (float, numpy.float)) and sigDigits is not None:
+        return format(value, '.' + str(int(sigDigits)) + 'f')
     return str(value)
 
 


### PR DESCRIPTION
As a consequence of organic modifications over a long period of time, and modifications in what values we allowed to be represented, the formatIfNeeded helper ended up with a nested conditional where the inner check was a direct check for the needed cases, and the outer check was a strict superset of the needed cases. There was seemingly no side effect or other reason for the first conditional's inclusion in the code.