### PR TITLE
Adjust tests for p/f/e matching to avoid implying None is non-numeric

### DIFF
--- a/tests/data/high_level_backend.py
+++ b/tests/data/high_level_backend.py
@@ -1700,6 +1700,11 @@ class HighLevelDataSafe(DataTestObject):
 
         assert isMissing == expObj
 
+        # None is converted to nan by createData, here we explicitly pass the
+        # value the underlying representation uses, so we avoid making it
+        # look like None is considered a numeric
+        raw = [['a', numpy.nan, 'c'], [numpy.nan, numpy.nan, -3], [0, 'zero', numpy.nan]]
+        obj = self.constructor(raw)
         exp = [[True, False, True], [False, False, False], [False, True, False]]
 
         expObj = self.constructor(exp)
@@ -1789,7 +1794,10 @@ class HighLevelDataSafe(DataTestObject):
 
         assert allMissing == expObj
 
-        raw = [['a', None, 'c'], [numpy.nan, None, -3], [0, 'zero', 0]]
+        # None is converted to nan by createData, here we explicitly pass the
+        # value the underlying representation uses, so we avoid making it
+        # look like None is considered a numeric
+        raw = [['a', numpy.nan, 'c'], [numpy.nan, numpy.nan, -3], [0, 'zero', numpy.nan]]
         obj = self.constructor(raw)
 
         exp = [[True], [False], [True]]


### PR DESCRIPTION
None is definitively considered non-numeric by the definition of our matching functions. None is also replaced with NaN by default when our data objects are constructed. As a consequence of this, some recent tests for point, feature, and element matching had the appearance of indicating that the matching functions were providing results that None was actually numeric, because the expected values of the outputs were constructed to take into account this automatic conversion.

Since the tests in question were about the capability of being able to call the match methods, not the details of their outputs, the tests were modified so that this particular idiosyncrasy was avoided and overall clarity was improved.