### PR TITLE
find and fix sparse internal sort bugs

### DIFF
--- a/nimble/data/sparseAxis.py
+++ b/nimble/data/sparseAxis.py
@@ -191,6 +191,7 @@ class SparseAxis(Axis):
                 startIdx = endIdx
 
         repeated = coo_matrix((repData, (repRow, repCol)), shape=shape)
+        self._source._sorted = None
 
         return repeated
 
@@ -234,7 +235,7 @@ class SparseAxis(Axis):
 
         if structure != 'copy':
             self._source.data = notTargeted.tocoo()
-            self._source._sortInternal(self._axis)
+            self._source._sorted = None
 
         ret = targeted.tocoo()
 
@@ -289,6 +290,7 @@ class SparseAxis(Axis):
             keepData = numpy.array(keepData, dtype=dtype)
             self._source.data = coo_matrix((keepData, (keepRows, keepCols)),
                                            shape=selfShape)
+            self._source._sorted = None
         # need to manually set dtype or coo_matrix will force to simplest dtype
         targetData = numpy.array(targetData, dtype=dtype)
         ret = coo_matrix((targetData, (targetRows, targetCols)),

--- a/nimble/data/sparseElements.py
+++ b/nimble/data/sparseElements.py
@@ -129,6 +129,7 @@ class SparseElements(Elements):
             self._source.data = raw.tocoo()
         else:
             self._source.data = coo_matrix(raw, shape=self._source.data.shape)
+        self._source._sorted = None
 
     ######################
     # Structural helpers #
@@ -161,6 +162,7 @@ class SparseElements(Elements):
         self._source.referenceDataFrom(ret, useLog=False)
         self._source.points.setNames(pnames, useLog=False)
         self._source.features.setNames(fnames, useLog=False)
+        self._source._sorted = None
 
 
     def _transformEachElement_zeroPreserve_implementation(


### PR DESCRIPTION
In `_isIdentical_implementation`, copies were being made of the two Sparse objects. Sorting is an internal operation so there is no reason to perform it on a copy, but failures occurred without it. The failures were due to at least one of the Sparse objects having the `_sorted` attribute set to 'feature', but no longer actually being sorted as expected. Making a copy resets `_sorted` to `None` so each are sorted by feature properly before being compared.

Sparse `_validate_implementation` was not identifying all cases when data was no longer sorted as identified.  The validation only validated that the primary axis was still sorted as expected, however `_sortInternal` also sorts the opposite axis.  

As an example, an object containing a single point is sorted along the point axis. obj.data.row = [0, 0, 0], obj.data.col = [0, 1, 2], obj._sorted = 'point'.  However, this data can be manipulated to reorder obj.data.col to [2, 1, 0] but obj.data.row remains [0, 0, 0]. The validation, upon seeing this object is supposedly sorted by point, passes because obj.data.row is the same in both cases, but the columns are no longer sorted as expected with a call to `_sortInternal('point')`.

With the validation improved, functions which modify data but do not reset `_sorted` to `None` can be identified and have been addressed.