### PR TITLE
no failure for featureReport non-numeric

### DIFF
--- a/nimble/calculate/statistic.py
+++ b/nimble/calculate/statistic.py
@@ -66,6 +66,8 @@ def _minmax(values, minmax, ignoreNoneNan=True, noCompMixType=True):
     """
     Given a 1D vector of values, find the minimum or maximum value.
     """
+    if not _isNumericalFeatureGuesser(values):
+        return None
     if minmax == 'min':
         compStr = '__lt__'
         func1 = lambda x, y: x > y
@@ -265,17 +267,10 @@ def _isMissing(point):
 
 def _isNumericalFeatureGuesser(featureVector):
     """
-    Returns true if the vector only contains primitive numerical non-complex values,
-    returns false otherwise.
+    Returns true if the vector only contains primitive numerical
+    non-complex values, returns false otherwise.
     """
-    try:
-        if featureVector.getTypeString() in ['Matrix']:
-            return True
-    except AttributeError:
-        pass
-
-    #if all items in featureVector are numerical or None/NaN, return True; otherwise, False.
-    return all([isinstance(item, numericalTypes) for item in featureVector if item])
+    return all(isinstance(val, numericalTypes) for val in featureVector if val)
 
 
 def _isNumericalPoint(point):

--- a/nimble/logger/data_set_analyzer.py
+++ b/nimble/logger/data_set_analyzer.py
@@ -207,10 +207,10 @@ def featurewiseFunctionGenerator():
     calculateForEachFeature function.  Includes: min(), max(), mean(),
     median(), standardDeviation(), numUniqueValues()
     """
-    functions = [nimble.calculate.minimum, nimble.calculate.maximum,
+    functions = (nimble.calculate.minimum, nimble.calculate.maximum,
                  nimble.calculate.mean, nimble.calculate.median,
                  nimble.calculate.standardDeviation,
-                 nimble.calculate.uniqueCount]
+                 nimble.calculate.uniqueCount)
     return functions
 
 
@@ -223,8 +223,8 @@ def aggregateFunctionGenerator():
     the proportion of entries that are equal to zero and the proportion
     of entries that are missing (i.e. are None or NaN).
     """
-    functions = [nimble.calculate.proportionZero,
-                 nimble.calculate.proportionMissing]
+    functions = (nimble.calculate.proportionZero,
+                 nimble.calculate.proportionMissing)
     return functions
 
 

--- a/nimble/logger/session_logger.py
+++ b/nimble/logger/session_logger.py
@@ -433,9 +433,10 @@ class SessionLogger(object):
     ### LOG OUTPUT ###
     ##################
 
-    def showLog(self, levelOfDetail, leastSessionsAgo, mostSessionsAgo,
-                startDate, endDate, maximumEntries, searchForText, regex,
-                saveToFileName, append):
+    def showLog(self, levelOfDetail=2, leastSessionsAgo=0, mostSessionsAgo=2,
+                startDate=None, endDate=None, maximumEntries=100,
+                searchForText=None, regex=False, saveToFileName=None,
+                append=False):
         """
         Output data from the logger.
 

--- a/tests/calculate/statistic_test.py
+++ b/tests/calculate/statistic_test.py
@@ -53,7 +53,7 @@ def testQuartilesAPI():
     assert ret == (2, 4, 6)
 
 #the following tests will test both None/NaN ignoring and calculation correctness
-testDataTypes = ['List', 'DataFrame']#'Matrix','Sparse'
+testDataTypes = nimble.data.available
 
 @noLogEntryExpected
 def testProportionMissing():

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -6,7 +6,7 @@ pointView, featureView, view, containsZero, __eq__, __ne__, toString,
 __repr__, points.similarities, features.similarities, points.statistics,
 features.statistics, points.__iter__, features.__iter__,
 elements.__iter__, points.nonZeroIterator, features.nonZeroIterator,
-inverse, solveLinearSystem
+inverse, solveLinearSystem, featureReport, summaryReport
 """
 from __future__ import absolute_import
 from __future__ import print_function
@@ -2818,6 +2818,59 @@ class QueryBackend(DataTestObject):
         bobj = self.constructor(b)
 
         Aobj.solveLinearSystem(bobj, solveFunction='foo')
+
+
+    #################
+    # featureReport #
+    #################
+
+    def test_featureReport_allNumeric(self):
+        fnames = ['one', 'two', 'three']
+        obj = self.constructor([[1, 4, 9], [2, 2, 9.2], [3, 0, 8.8]],
+                               featureNames=fnames)
+
+        ret = obj.featureReport()
+        line1 = "featureName   minimum   maximum   mean   median   standardDeviation   uniqueCount"
+        line2 = "        one     1.00      3.00    2.00    2.00           0.82             3.00   "
+        line3 = "        two     0.00      4.00    2.00    2.00           1.63             3.00   "
+        line4 = "      three     8.80      9.20    9.00    9.00           0.16             3.00   "
+        expLines = [line1, line2, line3, line4]
+
+        for retLine, expLine in zip(ret.split('\n'), expLines):
+            assert retLine == expLine
+
+    def test_featureReport_withNonNumeric(self):
+        fnames = ['one', 'two', 'three']
+        obj = self.constructor([[1, 2, 'a'], [2, 1, 'b'], [3, 3, 'c']],
+                               featureNames=fnames)
+
+        ret = obj.featureReport()
+        line1 = "featureName   minimum   maximum   mean   median   standardDeviation   uniqueCount"
+        line2 = "        one     1.00      3.00    2.00    2.00           0.82             3.00   "
+        line3 = "        two     1.00      3.00    2.00    2.00           0.82             3.00   "
+        line4 = "      three     nan       nan     nan     nan            nan              3.00   "
+        expLines = [line1, line2, line3, line4]
+
+        for retLine, expLine in zip(ret.split('\n'), expLines):
+            assert retLine == expLine
+
+
+    #################
+    # summaryReport #
+    #################
+
+    def test_summaryReport(self):
+        fnames = ['one', 'two', 'three']
+        obj = self.constructor([[0, 2, 'a'], [2, None, 'b'], [0, 3, 'c']],
+                               featureNames=fnames)
+
+        ret = obj.summaryReport()
+        line1 = "proportionZero   proportionMissing   Values   Points   Features"
+        line2 = "     0.22               0.11           9        3         3    "
+        expLines = [line1, line2]
+
+        for retLine, expLine in zip(ret.split('\n'), expLines):
+            assert retLine == expLine
 
 ###########
 # Helpers #


### PR DESCRIPTION
1) Eliminated exception raised if `featureReport()` is called and there are non-numeric features.  Now `nan` be displayed in those cases.
  a) Failure was due to backend for `minimum` and `maximum` in calculate/statistics not checking if all the data was numeric.  Now performs that check and returns None if there is non-numeric data, matching the convention of the mean, median and standardDeviation functions.
  b) Fixed bug allowing operations for Matrix type, which should not be allowed. It appears maybe at one point the Matrix type could guarantee numeric data, but this is no longer the case. This allowed, for example, 0.00 to be returned as the standard deviation of a non-numeric feature.
  c) There appears to be some code testing the backend functions in tests/logger/data_set_analyzier_tests.py. However, since `featureReport` and `summaryReport` are in Base and did not have any tests, I added some simple tests which include tests with non-numeric values. 
  ```python
  >>> obj = nimble.createData('Sparse', [[1, 2, 'a'], [2, 1, 'b'], [3, 3, 'c']],
  ...                         featureNames=['one', 'two', 'three'])
  >>> print(obj.featureReport())
  featureName   minimum   maximum   mean   median   standardDeviation   uniqueCount
          one     1.00      3.00    2.00    2.00           0.82             3.00   
          two     1.00      3.00    2.00    2.00           0.82             3.00   
        three     nan       nan     nan     nan            nan              3.00 
  ```
2) Added default values to `SessionLogger.showLog`.  Initially did not provide defaults since primarily this is used as the backend for `nimble.showLog` which will provide all parameters. However, it would be annoying to provide every parameter if using this method directly so I think adding the defaults is the best option.

3) Small updates:
  a) `featurewiseFunctionGenerator` and `aggregateFunctionGenerator` were returning lists, updated to return generators to match names.
  b) tests/calculate/statistics_test.py was only testing List and DataFrame objects, modified to test all objects.