### PR TITLE
calculate and exception doc updates

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -26,6 +26,12 @@ NimbleParentDirPath = os.path.dirname(os.path.dirname(os.path.dirname(confFilePa
 sys.path.insert(0, NimbleParentDirPath)
 
 # -- General configuration ------------------------------------------------
+def process_docstring(app, what, name, obj, options, lines):
+    if what == 'module' and options.get('noindex', False):
+        del lines[:]
+
+def setup(app):
+    app.connect('autodoc-process-docstring', process_docstring)
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #needs_sphinx = '1.0'

--- a/documentation/source/nimble/calculate/confidence.rst
+++ b/documentation/source/nimble/calculate/confidence.rst
@@ -1,7 +1,8 @@
-confidence
+Confidence
 ==========
 
-.. automodule:: nimble.calculate.confidence
-   :members:
+.. automodule:: nimble.calculate
+   :noindex:
+   :members: confidenceIntervalHelper
    :undoc-members:
    :show-inheritance:

--- a/documentation/source/nimble/calculate/distance.rst
+++ b/documentation/source/nimble/calculate/distance.rst
@@ -1,7 +1,5 @@
-distance
+Distance
 ========
 
-.. automodule:: nimble.calculate.distance
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. automodule:: nimble.calculate
+   :noindex:

--- a/documentation/source/nimble/calculate/linalg.rst
+++ b/documentation/source/nimble/calculate/linalg.rst
@@ -1,7 +1,8 @@
-linalg
-======
+Linear Algebra
+==============
 
-.. automodule:: nimble.calculate.linalg
-   :members:
+.. automodule:: nimble.calculate
+   :noindex:
+   :members: inverse, pseudoInverse, solve, leastSquaresSolution
    :undoc-members:
    :show-inheritance:

--- a/documentation/source/nimble/calculate/loss.rst
+++ b/documentation/source/nimble/calculate/loss.rst
@@ -1,7 +1,8 @@
-loss
+Loss
 ====
 
-.. automodule:: nimble.calculate.loss
-   :members:
+.. automodule:: nimble.calculate
+   :noindex:
+   :members: fractionIncorrect, meanAbsoluteError, meanFeaturewiseRootMeanSquareError, rootMeanSquareError, varianceFractionRemaining
    :undoc-members:
    :show-inheritance:

--- a/documentation/source/nimble/calculate/matrix.rst
+++ b/documentation/source/nimble/calculate/matrix.rst
@@ -1,7 +1,8 @@
-matrix
+Matrix
 ======
 
-.. automodule:: nimble.calculate.matrix
-   :members:
+.. automodule:: nimble.calculate
+   :noindex:
+   :members: elementwiseMultiply, elementwisePower
    :undoc-members:
    :show-inheritance:

--- a/documentation/source/nimble/calculate/similarity.rst
+++ b/documentation/source/nimble/calculate/similarity.rst
@@ -1,7 +1,8 @@
-similarity
+Similarity
 ==========
 
-.. automodule:: nimble.calculate.similarity
-   :members:
+.. automodule:: nimble.calculate
+   :noindex:
+   :members: correlation, cosineSimilarity, covariance, fractionCorrect, rSquared
    :undoc-members:
    :show-inheritance:

--- a/documentation/source/nimble/calculate/statistic.rst
+++ b/documentation/source/nimble/calculate/statistic.rst
@@ -1,7 +1,8 @@
-statistic
+Statistic
 =========
 
-.. automodule:: nimble.calculate.statistic
-   :members:
+.. automodule:: nimble.calculate
+   :noindex:
+   :members: maximum, mean, median, mode, minimum, uniqueCount, proportionMissing, proportionZero, quartiles, residuals, standardDeviation
    :undoc-members:
    :show-inheritance:

--- a/documentation/source/nimble/calculate/utility.rst
+++ b/documentation/source/nimble/calculate/utility.rst
@@ -1,7 +1,8 @@
-utility
+Utility
 =======
 
-.. automodule:: nimble.calculate.utility
-   :members:
+.. automodule:: nimble.calculate
+   :noindex:
+   :members: detectBestResult
    :undoc-members:
    :show-inheritance:

--- a/documentation/source/nimble/exceptions.rst
+++ b/documentation/source/nimble/exceptions.rst
@@ -3,5 +3,6 @@ nimble.exceptions
 
 .. automodule:: nimble.exceptions
    :members:
+   :exclude-members: prettyListString, prettyDictString
    :undoc-members:
    :show-inheritance:

--- a/nimble/data/axis.py
+++ b/nimble/data/axis.py
@@ -1579,7 +1579,7 @@ class Axis(object):
             msg = "The argument named " + argName + " must not share any "
             msg += self._axis + "Names with the calling object, yet the "
             msg += "following names occured in both: "
-            msg += nimble.exceptions._prettyListString(shared)
+            msg += nimble.exceptions.prettyListString(shared)
             if truncated:
                 msg += "... (only first 10 entries out of " + str(full)
                 msg += " total)"

--- a/nimble/exceptions.py
+++ b/nimble/exceptions.py
@@ -91,7 +91,7 @@ class FileFormatException(NimbleException, ValueError):
     pass
 
 
-def _prettyListString(inList, useAnd=False, numberItems=False, itemStr=str):
+def prettyListString(inList, useAnd=False, numberItems=False, itemStr=str):
     """
     Used in the creation of exception messages to display lists in a more
     appealing way than default
@@ -110,7 +110,7 @@ def _prettyListString(inList, useAnd=False, numberItems=False, itemStr=str):
     return ret
 
 
-def _prettyDictString(inDict, useAnd=False, numberItems=False, keyStr=str,
+def prettyDictString(inDict, useAnd=False, numberItems=False, keyStr=str,
                       delim='=', valueStr=str):
     """
     Used in the creation of exception messages to display dicts in a more

--- a/nimble/interfaces/universal_interface.py
+++ b/nimble/interfaces/universal_interface.py
@@ -20,8 +20,8 @@ import nimble
 from nimble.exceptions import InvalidArgumentValue, ImproperObjectAction
 from nimble.exceptions import PackageException
 from nimble.utility import inheritDocstringsFactory
-from nimble.exceptions import _prettyListString
-from nimble.exceptions import _prettyDictString
+from nimble.exceptions import prettyListString
+from nimble.exceptions import prettyDictString
 from nimble.interfaces.interface_helpers import (
     generateBinaryScoresFromHigherSortedLabelScores,
     calculateSingleLabelScoresFromOneVsOneScores,
@@ -330,12 +330,12 @@ class UniversalInterface(six.with_metaclass(abc.ABCMeta, object)):
                 msg += ", we couldn't find a value for the parameter named "
                 msg += "'" + param + "'. "
                 msg += "The allowed parameters were: "
-                msg += _prettyListString(neededParams, useAnd=True)
+                msg += prettyListString(neededParams, useAnd=True)
                 msg += ". These were choosen as the best guess given the "
                 msg += "inputs out of the following (numbered) list of "
                 msg += "possible parameter sets: "
-                msg += _prettyListString(possibleParams, numberItems=True,
-                                         itemStr=_prettyListString)
+                msg += prettyListString(possibleParams, numberItems=True,
+                                         itemStr=prettyListString)
                 if len(availableDefaults) == 0:
                     msg += ". Out of the allowed parameters, all required "
                     msg += "values specified by the user"
@@ -343,13 +343,13 @@ class UniversalInterface(six.with_metaclass(abc.ABCMeta, object)):
                     msg += ". Out of the allowed parameters, the following "
                     msg += "could be omited, which would result in the "
                     msg += "associated default value being used: "
-                    msg += _prettyDictString(availableDefaults, useAnd=True)
+                    msg += prettyDictString(availableDefaults, useAnd=True)
 
                 if len(arguments) == 0:
                     msg += ". However, no arguments were inputed."
                 else:
                     msg += ". The full mapping of inputs actually provided "
-                    msg += "was: " + _prettyDictString(arguments)
+                    msg += "was: " + prettyDictString(arguments)
 
                 raise InvalidArgumentValue(msg)
 
@@ -358,16 +358,16 @@ class UniversalInterface(six.with_metaclass(abc.ABCMeta, object)):
             msg += "When trying to validate arguments for "
             msg += name + ", the following list of parameter "
             msg += "names were not matched: "
-            msg += _prettyListString(list(check.keys()), useAnd=True)
+            msg += prettyListString(list(check.keys()), useAnd=True)
             msg += ". The allowed parameters were: "
-            msg += _prettyListString(neededParams, useAnd=True)
+            msg += prettyListString(neededParams, useAnd=True)
             msg += ". These were choosen as the best guess given the "
             msg += "inputs out of the following (numbered) list of "
             msg += "possible parameter sets: "
-            msg += _prettyListString(possibleParams, numberItems=True,
-                                     itemStr=_prettyListString)
+            msg += prettyListString(possibleParams, numberItems=True,
+                                     itemStr=prettyListString)
             msg += ". The full mapping of inputs actually provided was: "
-            msg += _prettyDictString(arguments) + ". "
+            msg += prettyDictString(arguments) + ". "
             msg += "If extra parameters were intended to be passed to one of "
             msg += "the arguments, be sure to group them using a nimble.Init "
             msg += "object. "
@@ -496,17 +496,17 @@ class UniversalInterface(six.with_metaclass(abc.ABCMeta, object)):
             msg += "match the given input. However, from each possible "
             msg += "(numbered) parameter set, the following parameter names "
             msg += "were missing "
-            msg += _prettyListString(missing, numberItems=True,
-                                     itemStr=_prettyListString)
+            msg += prettyListString(missing, numberItems=True,
+                                     itemStr=prettyListString)
             msg += ". The following lists the required names in each of the "
             msg += "possible (numbered) parameter sets: "
-            msg += _prettyListString(nonDefaults, numberItems=True,
-                                     itemStr=_prettyListString)
+            msg += prettyListString(nonDefaults, numberItems=True,
+                                     itemStr=prettyListString)
             if len(arguments) == 0:
                 msg += ". However, no arguments were inputed."
             else:
                 msg += ". The full mapping of inputs actually provided was: "
-                msg += _prettyDictString(arguments) + ". "
+                msg += prettyDictString(arguments) + ". "
 
             raise InvalidArgumentValue(msg)
 
@@ -526,9 +526,9 @@ class UniversalInterface(six.with_metaclass(abc.ABCMeta, object)):
             msg = "EXTRA PARAMETER! "
             if argNames:
                 msg += "The following parameter names cannot be applied: "
-                msg += _prettyListString(invalidArguments, useAnd=True)
+                msg += prettyListString(invalidArguments, useAnd=True)
                 msg += ". The allowed parameters are: "
-                msg += _prettyListString(argNames, useAnd=True)
+                msg += prettyListString(argNames, useAnd=True)
             else:
                 msg += "No parameters are accepted for this operation"
             raise InvalidArgumentValue(msg)
@@ -1366,7 +1366,7 @@ class TrainedLearner(object):
                 msg = "The argument '" + arg + "' is not valid. "
                 if validArgs:
                     msg += "Valid arguments for retrain are: "
-                    msg += _prettyListString(validArgs)
+                    msg += prettyListString(validArgs)
                 else:
                     msg += "There are no valid arguments to retrain "
                     msg += "this learner"


### PR DESCRIPTION
Removed leading underscore for `_prettyListString` and `_prettyDictString` which was added to prevent documentation, instead adding `:exclude-members: prettyListString, prettyDictString` in the exceptions.rst file.

Rather than add a sentence to the calculate module page stating that each function could be called from nimble.calculate, I found a way to modify the displayed module to be only nimble.calculate. This required changing the `.. automodule::` from the submodule to only nimble.calculate, adding the `:noindex:` option since these were repeated references to nimble.calculate, and specifying the submodule functions in `:members:`.  This allowed the module to display as we want, but repeated the nimble.calculate module docstring on each page.  To eliminate the repeated docstring, functions were added to conf.py that remove the module docstring when the `noindex` option has been set.  I also changed the headings for each group in the nimble.calculate table of contents to be capitalized as I believe this further helps clarify these indicate groupings not submodules.  