### PR TITLE
simplify setNames helpers

### DIFF
--- a/nimble/data/axis.py
+++ b/nimble/data/axis.py
@@ -123,12 +123,9 @@ class Axis(object):
             setattr(self._base, names, None)
             setattr(self._base, namesInverse, None)
         else:
-            count = len(self)
-            if isinstance(assignments, dict):
-                self._setNamesFromDict(assignments, count)
-            else:
+            if not isinstance(assignments, dict):
                 assignments = valuesToPythonList(assignments, 'assignments')
-                self._setNamesFromList(assignments, count)
+            self._setNamesBackend(assignments)
 
         handleLogging(useLog, 'prep', '{ax}s.setNames'.format(ax=self._axis),
                       self._base.getTypeString(), self._sigFunc('setNames'),
@@ -1118,63 +1115,30 @@ class Axis(object):
         names[newName] = index
         self._base._incrementDefaultIfNeeded(newName, self._axis)
 
-    def _setNamesFromList(self, assignments, count):
+    def _setNamesBackend(self, assignments):
+        count = len(self)
         if len(assignments) != count:
             msg = "assignments may only be an ordered container type, with as "
             msg += "many entries (" + str(len(assignments)) + ") as this axis "
             msg += "is long (" + str(count) + ")"
             raise InvalidArgumentValue(msg)
-
-        if isinstance(self, Points):
-            def checkAndSet(val):
-                if val >= self._base._nextDefaultValuePoint:
-                    self._base._nextDefaultValuePoint = val + 1
-        else:
-            def checkAndSet(val):
-                if val >= self._base._nextDefaultValueFeature:
-                    self._base._nextDefaultValueFeature = val + 1
-
-        if count == 0:
-            self._setNamesFromDict({}, count)
-            return
-
-        for name in assignments:
-            if name is not None and not isinstance(name, str):
-                msg = 'assignments must contain only string values'
-                raise InvalidArgumentValue(msg)
-            if name is not None and name.startswith(DEFAULT_PREFIX):
-                try:
-                    num = int(name[DEFAULT_PREFIX_LENGTH:])
-                # Case: default prefix with non-integer suffix. This cannot
-                # cause a future integer suffix naming collision, so we
-                # can ignore it.
-                except ValueError:
-                    continue
-                checkAndSet(num)
-
-        #convert to dict so we only write the checking code once
-        temp = {}
-        for index in range(len(assignments)):
-            name = assignments[index]
-            # take this to mean fill it in with a default name
-            if name is None:
-                name = self._nextDefaultName()
-            if name in temp:
-                msg = "Cannot input duplicate names: " + str(name)
-                raise InvalidArgumentValue(msg)
-            temp[name] = index
-        assignments = temp
-
-        self._setNamesFromDict(assignments, count)
-
-    def _setNamesFromDict(self, assignments, count):
         if not isinstance(assignments, dict):
-            msg = "assignments may only be a dict"
-            raise InvalidArgumentType(msg)
-        if len(assignments) != count:
-            msg = "assignments may only have as many entries as this " \
-                  "axis is long"
-            raise InvalidArgumentValue(msg)
+            #convert to dict so we only write the checking code once
+            temp = {}
+            for index, name in enumerate(assignments):
+                # take this to mean fill it in with a default name
+                if name is None:
+                    name = self._nextDefaultName()
+                if not isinstance(name, str):
+                    msg = 'assignments must contain only string values'
+                    raise InvalidArgumentValue(msg)
+                if name.startswith(DEFAULT_PREFIX) and name in temp:
+                    name = self._nextDefaultName()
+                if name in temp:
+                    msg = "Cannot input duplicate names: " + str(name)
+                    raise InvalidArgumentValue(msg)
+                temp[name] = index
+            assignments = temp
 
         if count == 0:
             if isinstance(self, Points):
@@ -1679,14 +1643,14 @@ class Axis(object):
             objNames = self._base.points.getNames
             toInsertNames = toInsert.points.getNames
             def sorter(obj, names):
-                return obj.points.sort(sortHelper=names)
+                obj.points.sort(sortHelper=names)
         else:
             objNamesCreated = self._base._featureNamesCreated()
             toInsertNamesCreated = toInsert._featureNamesCreated()
             objNames = self._base.features.getNames
             toInsertNames = toInsert.features.getNames
             def sorter(obj, names):
-                return obj.features.sort(sortHelper=names)
+                obj.features.sort(sortHelper=names)
 
         # This may not look exhaustive, but because of the previous call to
         # _validateInsertableData before this helper, most of the toInsert

--- a/nimble/data/dataframeAxis.py
+++ b/nimble/data/dataframeAxis.py
@@ -34,14 +34,6 @@ class DataFrameAxis(Axis):
         #update the index or columns in self.data
         self._updateName()
 
-    def _setNamesFromList(self, assignments, count):
-        super(DataFrameAxis, self)._setNamesFromList(assignments, count)
-        self._updateName()
-
-    def _setNamesFromDict(self, assignments, count):
-        super(DataFrameAxis, self)._setNamesFromDict(assignments, count)
-        self._updateName()
-
     def _updateName(self):
         """
         update self.data.index or self.data.columns
@@ -92,6 +84,7 @@ class DataFrameAxis(Axis):
             self._base.data = self._base.data.iloc[indexPosition, :]
         else:
             self._base.data = self._base.data.iloc[:, indexPosition]
+        self._updateName()
 
     ##############################
     # High Level implementations #

--- a/nimble/data/dataframeFeatures.py
+++ b/nimble/data/dataframeFeatures.py
@@ -39,7 +39,7 @@ class DataFrameFeatures(DataFrameAxis, Features):
         endData = self._base.data.iloc[:, insertBefore:]
         self._base.data = pd.concat((startData, toInsert.data, endData),
                                     axis=1)
-        self._base._updateName(axis='feature')
+        self._updateName()
 
     def _transform_implementation(self, function, limitTo):
         for j, f in enumerate(self):

--- a/nimble/data/dataframePoints.py
+++ b/nimble/data/dataframePoints.py
@@ -41,7 +41,7 @@ class DataFramePoints(DataFrameAxis, Points):
         endData = self._base.data.iloc[insertBefore:, :]
         self._base.data = pd.concat((startData, toInsert.data, endData),
                                     axis=0)
-        self._base._updateName(axis='point')
+        self._updateName()
 
     def _transform_implementation(self, function, limitTo):
         for i, p in enumerate(self):


### PR DESCRIPTION
Remove `_setNamesFromList` and `_setNamesFromDict` in favor of `_setNamesBackend`.
Since `_setNamesFromList` ultimately called `_setNamesFromDict`, some validation and iteration is repeated unnecessarily.  For example, both check that only string values are present, which requires an extra iteration through a list. 

The changes in axis.py obviously affected the custom implementations in DataFrame for `_setNamesFromList` and `_setNamesFromDict`.  I found that the issue leading to these being implemented was not a name setting issue, but actually that DataFrame's `_sort_implementation` did not use the `_updateNames`.