### PR TITLE
Elements removal followup

### DIFF
--- a/nimble/data/base.py
+++ b/nimble/data/base.py
@@ -924,12 +924,19 @@ class Base(object):
         ret = self._calculate_backend(wrappedMatch, points, features,
                                       allowBoolOutput=True)
 
-        ret.points.setNames(self.points._getNamesNoGeneration(), useLog=False)
-        ret.features.setNames(self.features._getNamesNoGeneration(),
-                              useLog=False)
+        pnames = self.points._getNamesNoGeneration()
+        if pnames is not None and points is not None:
+            ptIdx = constructIndicesList(self, 'point', points)
+            pnames = [pnames[i] for i in ptIdx]
+        fnames = self.features._getNamesNoGeneration()
+        if fnames is not None and features is not None:
+            ftIdx = constructIndicesList(self, 'feature', features)
+            fnames = [fnames[j] for j in ftIdx]
+        ret.points.setNames(pnames, useLog=False)
+        ret.features.setNames(fnames, useLog=False)
 
         handleLogging(useLog, 'prep', 'matchingElements', self.getTypeString(),
-                      Base.matchingElements, toMatch)
+                      Base.matchingElements, toMatch, points, features)
 
         return ret
 

--- a/nimble/interfaces/shogun_interface.py
+++ b/nimble/interfaces/shogun_interface.py
@@ -352,12 +352,6 @@ To install shogun
         if outputFormat == 'label' and 'remap' in customDict:
             remap = customDict['remap']
             if remap is not None:
-                def makeInverseMapper(inverseMappingParam):
-                    def inverseMapper(value):
-                        return inverseMappingParam[int(value)]
-
-                    return inverseMapper
-
                 ret.transformElements(remap, useLog=False)
 
         return ret

--- a/tests/data/high_level_backend.py
+++ b/tests/data/high_level_backend.py
@@ -1806,10 +1806,12 @@ class HighLevelDataSafe(DataTestObject):
     @oneLogEntryExpected
     def test_matchingElements_pfLimited(self):
         raw = [[1, 2, -3], [-1, -2, 3]]
-        obj = self.constructor(raw)
-        matches = obj.matchingElements(lambda x: x > 0, points=0, features=[1, 2])
+        pnames = ['1', '-1']
+        fnames = ['a', 'b', 'c']
+        obj = self.constructor(raw, pnames, fnames)
+        matches = obj.matchingElements(lambda x: x > 0, points='1', features=[1, 2])
         expRaw = [[True, False]]
-        expected = self.constructor(expRaw)
+        expected = self.constructor(expRaw, ['1'], ['b', 'c'])
         assert matches == expected
 
     @logCountAssertionFactory(4)

--- a/tests/logger/testLoggingIO.py
+++ b/tests/logger/testLoggingIO.py
@@ -438,6 +438,12 @@ def testPrepTypeFunctionsUseLog():
     checkLogContents('calculateOnElements', "Matrix",
                      {'toCalculate': "lambda x: len(x)", 'features': 0})
 
+    # matchingElements
+    dataObj = nimble.createData("Matrix", data, useLog=False)
+    calculated = dataObj.matchingElements(lambda e: e > 2, features=[1, 2])
+    checkLogContents('matchingElements', "Matrix",
+                     {'toMatch': "lambda e: e > 2", 'features': [1, 2]})
+
     ###################
     # Points/Features #
     ###################
@@ -751,6 +757,27 @@ def testFailedLambdaStringConversion():
     calculated = dataObj.calculateOnElements(lambda x: len(x), features=0)
     checkLogContents('calculateOnElements', "Matrix",
                      {'toCalculate': "<lambda>", 'features': 0})
+
+@configSafetyWrapper
+@emptyLogSafetyWrapper
+def testLambdaStringConversionCommas():
+    nimble.settings.set('logger', 'enabledByDefault', 'True')
+
+    data = [["a", 1, 1], ["a", 1, 1], ["a", 1, 1], ["a", 1, 1], ["a", 1, 1], ["a", 1, 1],
+            ["b", 2, 2], ["b", 2, 2], ["b", 2, 2], ["b", 2, 2], ["b", 2, 2], ["b", 2, 2],
+            ["c", 3, 3], ["c", 3, 3], ["c", 3, 3], ["c", 3, 3], ["c", 3, 3], ["c", 3, 3]]
+    for retType in nimble.data.available:
+        dataObj = nimble.createData(retType, data, useLog=False)
+        calculated1 = dataObj.points.calculate(lambda x: [x[0], x[2]], points=0)
+        checkLogContents('points.calculate', retType, {'function': "lambda x: [x[0], x[2]]",
+                                                        'points': 0})
+        calculated2 = dataObj.points.calculate(lambda x: (x[0], x[2]), points=6)
+        checkLogContents('points.calculate', retType, {'function': "lambda x: (x[0], x[2])",
+                                                        'points': 6})
+        calculated3 = dataObj.points.calculate(lambda x: {x[0]: None, x[2]: None}, points=12)
+        checkLogContents('points.calculate', retType,
+                         {'function': "lambda x: {x[0]: None, x[2]: None}",
+                          'points': 12})
 
 @emptyLogSafetyWrapper
 @raises(InvalidArgumentType)


### PR DESCRIPTION
1) remove dead `makeInverseMapper` in shogun interface
2) Fix name handling when points/features are limited in `matchingElements`
3) Restore `testLambdaStringConversionCommas`