### PR TITLE
Efficiency improvements for min, max, median, and quartiles

### DIFF
--- a/tests/calculate/statistic_test.py
+++ b/tests/calculate/statistic_test.py
@@ -40,10 +40,6 @@ def testQuartilesAPI():
     ret = quartiles(obj.pointView(0))
     assert ret == (5, 5, 5)
 
-    raw = [1, 1, 3, 3]
-    ret = quartiles(raw)
-    assert ret == (1, 2, 3)
-
     raw = [0, 1, 2, 3, 4, 5, 6, 7, 8]
     obj = createData("List", raw, useLog=False)
     ret = quartiles(obj)


### PR DESCRIPTION
Changes to min, max, median, and quartiles to make more efficient use of the numpy helpers.

* In _minmax for the non-Sparse case, change the intermediate format to be a numpy array. The source (https://github.com/numpy/numpy/blob/v1.17.0/numpy/lib/nanfunctions.py#L229-L337) (https://github.com/numpy/numpy/blob/v1.17.0/numpy/lib/nanfunctions.py#L344-L452) seems to suggest if when given exactly a numpy array, the fastest possible implementation can be used.
 
* This caused a behavior difference. Previously, nanmax and nanmin would raise exceptions when given a list of strings. When doing internal conversions, it would make a string dtype array, and raise an exception since it was non-numeric. However, when converted to an array from our data objects, an object dtype array was generated, and natural comparisons were used, resulting in a a legitimate string return value. These are now caught and replaced.

* for median and quartiles, the numpy helper has a parameter 'overwrite_input' which when True uses the input array as scratch space for the calculation instead of making a copy. Since copies of the data were already being made, the format was switched to be an array so that a second copy internal to the helper was avoided.

* Consequently (and as stated in the docstrings) non-nimble inputs are no longer accepted, because a copy("numpyarray") call is guaranteed to occur.
