### PR TITLE
modify configSafetyWrapper location and efficiency

### DIFF
--- a/tests/customLearners/custom_learner_test.py
+++ b/tests/customLearners/custom_learner_test.py
@@ -3,8 +3,8 @@ import numpy.testing
 
 import nimble
 from nimble.customLearners import CustomLearner
-from nimble.configuration import configSafetyWrapper
 from nimble.exceptions import InvalidArgumentValue
+from ..assertionHelpers import configSafetyWrapper
 
 
 @raises(TypeError)

--- a/tests/customLearners/multioutput_linear_regression_test.py
+++ b/tests/customLearners/multioutput_linear_regression_test.py
@@ -1,6 +1,6 @@
 import nimble
 from nimble.customLearners.multioutput_linear_regression import MultiOutputLinearRegression
-from nimble.configuration import configSafetyWrapper
+from ..assertionHelpers import configSafetyWrapper
 
 # test for failure to import?
 

--- a/tests/interfaces/universal_integration_test.py
+++ b/tests/interfaces/universal_integration_test.py
@@ -17,12 +17,12 @@ from nose.plugins.attrib import attr
 #@attr('slow')
 
 import nimble
-from nimble.configuration import configSafetyWrapper
 from nimble.exceptions import InvalidArgumentValue, PackageException
 from nimble.interfaces.universal_interface import UniversalInterface
 from nimble.helpers import generateClusteredPoints
 from nimble.helpers import generateClassificationData
 from nimble.helpers import generateRegressionData
+from ..assertionHelpers import configSafetyWrapper
 
 
 def checkFormat(scores, numLabels):

--- a/tests/logger/testLoggingFlags.py
+++ b/tests/logger/testLoggingFlags.py
@@ -12,7 +12,7 @@ import numpy
 import nimble
 from nimble.helpers import generateClassificationData
 from nimble.calculate import fractionIncorrect
-from nimble.configuration import configSafetyWrapper
+from ..assertionHelpers import configSafetyWrapper
 
 learnerName = 'custom.KNNClassifier'
 

--- a/tests/logger/testLoggingIO.py
+++ b/tests/logger/testLoggingIO.py
@@ -21,10 +21,10 @@ import numpy
 import nimble
 from nimble.helpers import generateClassificationData
 from nimble.calculate import rootMeanSquareError as RMSE
-from nimble.configuration import configSafetyWrapper
 from nimble.exceptions import InvalidArgumentValue
 from nimble.exceptions import InvalidArgumentValueCombination
 from nimble.exceptions import InvalidArgumentType
+from ..assertionHelpers import configSafetyWrapper
 
 #####################
 # Helpers for tests #

--- a/tests/testConfig.py
+++ b/tests/testConfig.py
@@ -14,9 +14,9 @@ import configparser
 import nimble
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
 from nimble.exceptions import ImproperObjectAction, PackageException
-from nimble.configuration import configSafetyWrapper
 from nimble.interfaces.universal_interface import UniversalInterface
 from nimble.interfaces.universal_interface import PredefinedInterface
+from .assertionHelpers import configSafetyWrapper
 
 
 ###############

--- a/tests/testCrossValidate.py
+++ b/tests/testCrossValidate.py
@@ -25,7 +25,7 @@ from nimble.helpers import computeMetrics
 from nimble.helpers import generateClassificationData
 from nimble.helpers import KFoldCrossValidator
 from nimble.customLearners import CustomLearner
-from nimble.configuration import configSafetyWrapper
+from .assertionHelpers import configSafetyWrapper
 from .assertionHelpers import oneLogEntryExpected
 
 

--- a/tests/testCustomLearnerRegistration.py
+++ b/tests/testCustomLearnerRegistration.py
@@ -10,7 +10,7 @@ import nimble
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
 from nimble.customLearners import CustomLearner
 from nimble.customLearners.ridge_regression import RidgeRegression
-from nimble.configuration import configSafetyWrapper
+from .assertionHelpers import configSafetyWrapper
 from .assertionHelpers import noLogEntryExpected
 
 

--- a/tests/testNormalizeData.py
+++ b/tests/testNormalizeData.py
@@ -4,7 +4,7 @@ Tests for the top level function nimble.normalizeData
 
 import nimble
 from nimble.customLearners import CustomLearner
-from nimble.configuration import configSafetyWrapper
+from .assertionHelpers import configSafetyWrapper
 from .assertionHelpers import oneLogEntryExpected
 
 # successful run no testX


### PR DESCRIPTION
Moved `configSafetyWrapper` to tests/assertionHelpers.py since it is only used in tests and modified it to increase efficiency.

Previously, the config file was written to a tempfile, then after running the test, the tempfile is used to rewrite the config file to restore it to it's state before the test.  This implementation eliminates writing to a file twice.  Instead, the `SessionConfiguration` instance at `nimble.settings` is replaced with a new `SessionConfiguration` instance using the tempfile. This prevents the test from making any changes to the actual config file. After the test, `nimble.settings` is returned to the original `SessionConfiguration` instance.

This change allows the test suite to run about 10% faster on my system.