### PR TITLE
add MAD to statistics and change sample standard deviation to default

### DIFF
--- a/nimble/calculate/__init__.py
+++ b/nimble/calculate/__init__.py
@@ -24,6 +24,7 @@ from .similarity import confusionMatrix
 from .statistic import maximum
 from .statistic import mean
 from .statistic import median
+from .statistic import medianAbsoluteDeviation
 from .statistic import mode
 from .statistic import minimum
 from .statistic import uniqueCount

--- a/nimble/calculate/statistic.py
+++ b/nimble/calculate/statistic.py
@@ -16,7 +16,7 @@ numericalTypes = (int, float, numpy.number)
 
 def numericRequired(func):
     """
-    Handles None return for functions that require numeric data.
+    Handles NaN return for functions that require numeric data.
     """
     @functools.wraps(func)
     def wrapped(*args, **kwargs):
@@ -135,7 +135,7 @@ def _minmax(values, minmax):
         ret = numpy.nanmax(toProcess)
 
     if isinstance(ret, str):
-        return None
+        return numpy.nan
     else:
         return ret
 
@@ -154,7 +154,7 @@ def mean(values):
     The mean of the values in a vector.
 
     This function requires numeric data and ignores any NaN values.
-    Non-numeric values will results in None being returned.
+    Non-numeric values will results in NaN being returned.
 
     Parameters
     ----------
@@ -185,7 +185,7 @@ def median(values):
     The median of the values in a vector.
 
     This function requires numeric data and ignores any NaN values.
-    Non-numeric values will results in None being returned.
+    Non-numeric values will results in NaN being returned.
 
     Parameters
     ----------
@@ -211,7 +211,7 @@ def mode(values):
     The mode of the values in a vector.
 
     This function requires numeric data and ignores any NaN values.
-    Non-numeric values will results in None being returned.
+    Non-numeric values will results in NaN being returned.
 
     Parameters
     ----------
@@ -242,29 +242,29 @@ def mode(values):
     return mostCommon
 
 @numericRequired
-def standardDeviation(values, sample=False):
+def standardDeviation(values, sample=True):
     """
     The standard deviation of the values in a vector.
 
     This function requires numeric data and ignores any NaN values.
-    Non-numeric values will results in None being returned.
+    Non-numeric values will results in NaN being returned.
 
     Parameters
     ----------
     values : nimble Base object
         Must be one-dimensional.
     sample : bool
-        If False, the default, the population standard deviation is
-        returned. If True, the sample standard deviation is returned.
+        If True, the default, the sample standard deviation is
+        returned. If False, the population standard deviation is returned.
 
     Examples
     --------
     >>> raw = [1, 2, 3, 4, 5, 6, float('nan')]
     >>> vector = nimble.createData('Matrix', raw)
     >>> standardDeviation(vector)
-    1.707825127659933
-    >>> standardDeviation(vector, sample=True)
     1.8708286933869707
+    >>> standardDeviation(vector, sample=False)
+    1.707825127659933
     """
     if values.getTypeString() == 'Sparse':
         nonZero = values.data.data.astype(numpy.float)
@@ -283,6 +283,30 @@ def standardDeviation(values, sample=False):
     if sample:
         return numpy.nanstd(arr, ddof=1)
     return numpy.nanstd(arr)
+
+@numericRequired
+def medianAbsoluteDeviation(values):
+    """
+    The median absolute deviation of the values in a vector.
+
+    This function requires numeric data and ignores any NaN values.
+    Non-numeric values will results in NaN being returned.
+
+    Parameters
+    ----------
+    values : nimble Base object
+        Must be one-dimensional.
+
+    Examples
+    --------
+    >>> raw = [1, 2, 3, 4, 5, 6, float('nan')]
+    >>> vector = nimble.createData('Matrix', raw)
+    >>> medianAbsoluteDeviation(vector)
+    1.5
+    """
+    arr = values.copy('numpy array', outputAs1D=True).astype(numpy.float)
+    mad = numpy.nanmedian(numpy.abs(arr - numpy.nanmedian(arr)))
+    return mad
 
 def uniqueCount(values):
     """
@@ -305,7 +329,7 @@ def quartiles(values):
 
     Return a 3-tuple (lowerQuartile, median, upperQuartile). This
     function requires numeric data and ignores any NaN values.
-    Non-numeric values will results in None being returned.
+    Non-numeric values will results in NaN being returned.
 
     Parameters
     ----------

--- a/nimble/data/axis.py
+++ b/nimble/data/axis.py
@@ -917,12 +917,13 @@ class Axis(object):
             toCall = nimble.calculate.proportionZero
         elif cleanFuncName in ['std', 'standarddeviation','samplestd',
                                'samplestandarddeviation']:
-            def sampleStandardDeviation(values):
-                return nimble.calculate.standardDeviation(values, True)
-
-            toCall = sampleStandardDeviation
-        elif cleanFuncName in ['populationstd', 'populationstandarddeviation']:
             toCall = nimble.calculate.standardDeviation
+        elif cleanFuncName in ['populationstd', 'populationstandarddeviation']:
+
+            def populationStandardDeviation(values):
+                return nimble.calculate.standardDeviation(values, False)
+
+            toCall = populationStandardDeviation
 
         if self._axis == 'point' or groupByFeature is None:
             return self._statisticsBackend(cleanFuncName, toCall)

--- a/tests/calculate/statistic_test.py
+++ b/tests/calculate/statistic_test.py
@@ -30,8 +30,8 @@ def testStDev():
     dataArr = np.array([[1], [1], [3], [4], [2], [6], [12], [0]])
     testRowList = createData('List', data=dataArr, featureNames=['nums'])
     stDevContainer = testRowList.features.calculate(standardDeviation)
-    stDev = stDevContainer.copy(to="python list")[0][0]
-    assert_almost_equal(stDev, 3.6379, 3)
+    stDev = stDevContainer[0, 0]
+    assert_almost_equal(stDev, 3.8891, 3)
 
 @noLogEntryExpected
 def testQuartilesAPI():
@@ -160,12 +160,31 @@ def testStandardDeviation():
         objl = createData(dataType, raw, useLog=False)
 
         retlf = objl.features.calculate(func, useLog=False)
-        retlfCorrect = createData(dataType, [3, None, 1.5], useLog=False)
+        retlfData = [4.242640687119285, None, 2.1213203435596424]
+        retlfCorrect = createData(dataType, retlfData, useLog=False)
         assert retlf.isIdentical(retlfCorrect)
         assert retlfCorrect.isIdentical(retlf)
 
         retlp = objl.points.calculate(func, useLog=False)
-        retlpCorrect = createData(dataType, [[None], [0.5], [3.8586123009300755]],
+        retlpData = [[None], [0.7071067811865476], [4.725815626252609]]
+        retlpCorrect = createData(dataType, retlpData, useLog=False)
+        assert retlp.isIdentical(retlpCorrect)
+        assert retlpCorrect.isIdentical(retlp)
+
+@noLogEntryExpected
+def testMedianAbsoluteDeviation():
+    raw = [[1, 'a', np.nan], [None, 5, 6], [7, 0, 9], [3, 9, 15]]
+    func = nimble.calculate.statistic.medianAbsoluteDeviation
+    for dataType in testDataTypes:
+        objl = createData(dataType, raw, useLog=False)
+
+        retlf = objl.features.calculate(func, useLog=False)
+        retlfCorrect = createData(dataType, [2, None, 3], useLog=False)
+        assert retlf.isIdentical(retlfCorrect)
+        assert retlfCorrect.isIdentical(retlf)
+
+        retlp = objl.points.calculate(func, useLog=False)
+        retlpCorrect = createData(dataType, [[None], [0.5], [2], [6]],
                                   useLog=False)
         assert retlp.isIdentical(retlpCorrect)
         assert retlpCorrect.isIdentical(retlp)

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -2869,9 +2869,9 @@ class QueryBackend(DataTestObject):
 
         ret = obj.featureReport()
         line1 = "featureName   minimum   maximum   mean   median   standardDeviation   uniqueCount"
-        line2 = "        one     1.00      3.00    2.00    2.00           0.82              3     "
-        line3 = "        two     0.00      4.00    2.00    2.00           1.63              3     "
-        line4 = "      three     8.80      9.20    9.00    9.00           0.16              3     "
+        line2 = "        one     1.00      3.00    2.00    2.00           1.00              3     "
+        line3 = "        two     0.00      4.00    2.00    2.00           2.00              3     "
+        line4 = "      three     8.80      9.20    9.00    9.00           0.20              3     "
         expLines = [line1, line2, line3, line4]
 
         for retLine, expLine in zip(ret.split('\n'), expLines):
@@ -2884,8 +2884,8 @@ class QueryBackend(DataTestObject):
 
         ret = obj.featureReport()
         line1 = "featureName   minimum   maximum   mean   median   standardDeviation   uniqueCount"
-        line2 = "        one     1.00      3.00    2.00    2.00           0.82              3     "
-        line3 = "        two     1.00      3.00    2.00    2.00           0.82              3     "
+        line2 = "        one     1.00      3.00    2.00    2.00           1.00              3     "
+        line3 = "        two     1.00      3.00    2.00    2.00           1.00              3     "
         line4 = "      three     nan       nan     nan     nan            nan               3     "
         expLines = [line1, line2, line3, line4]
 

--- a/tests/logger/data_set_analyzier_tests.py
+++ b/tests/logger/data_set_analyzier_tests.py
@@ -13,59 +13,59 @@ from nimble import createData
 from nimble.logger.data_set_analyzer import *
 
 
-def testMatrix():
+def testProduceInfoTable_denseData():
     """
-        Test the functionality of calculating statistical/informational
-        funcs on a Matrix object using the produceInfoTable.
+    Test the functionality of calculating statistical/informational
+    funcs on objects with dense data using the produceInfoTable.
     """
     data1 = np.array([[1, 2, 3, 1], [3, 3, 1, 5], [1, 1, 5, 2]])
     names1 = ['var1', 'var2', 'var3', 'var4']
+    for retType in nimble.data.available:
+        trainObj = createData(retType, data=data1, featureNames=names1)
+        funcs = featurewiseFunctionGenerator()
+        rawTable = produceFeaturewiseInfoTable(trainObj, funcs)
+        funcNames = rawTable[0]
+        for i in range(len(funcNames)):
+            funcName = funcNames[i]
+            if funcName == "mean":
+                assert_almost_equal(rawTable[1][i], 1.6667, 3)
+                assert_almost_equal(rawTable[2][i], 2.000, 3)
+                assert_almost_equal(rawTable[3][i], 3.000, 3)
+                assert_almost_equal(rawTable[4][i], 2.6667, 3)
+            elif funcName == "minimum":
+                assert_equal(rawTable[1][i], 1)
+                assert_equal(rawTable[2][i], 1)
+                assert_equal(rawTable[3][i], 1)
+                assert_equal(rawTable[4][i], 1)
+            elif funcName == "maximum":
+                assert_equal(rawTable[1][i], 3)
+                assert_equal(rawTable[2][i], 3)
+                assert_equal(rawTable[3][i], 5)
+                assert_equal(rawTable[4][i], 5)
+            elif funcName == "uniqueCount":
+                assert_equal(rawTable[1][i], 2)
+                assert_equal(rawTable[2][i], 3)
+                assert_equal(rawTable[3][i], 3)
+                assert_equal(rawTable[4][i], 3)
+            elif funcName == "standardDeviation":
+                assert_almost_equal(rawTable[1][i], 1.1547, 3)
+                assert_almost_equal(rawTable[2][i], 1.0000, 3)
+                assert_almost_equal(rawTable[3][i], 2.0000, 3)
+                assert_almost_equal(rawTable[4][i], 2.0816, 3)
+            elif funcName == "median":
+                assert_equal(rawTable[1][i], 1.0)
+                assert_equal(rawTable[2][i], 2.0)
+                assert_equal(rawTable[3][i], 3.0)
+                assert_equal(rawTable[4][i], 2.0)
 
-    trainObj = createData('Matrix', data=data1, featureNames=names1)
-    funcs = featurewiseFunctionGenerator()
-    rawTable = produceFeaturewiseInfoTable(trainObj, funcs)
-    funcNames = rawTable[0]
-    for i in range(len(funcNames)):
-        funcName = funcNames[i]
-        if funcName == "mean":
-            assert_almost_equal(rawTable[1][i], 1.6667, 3)
-            assert_almost_equal(rawTable[2][i], 2.000, 3)
-            assert_almost_equal(rawTable[3][i], 3.000, 3)
-            assert_almost_equal(rawTable[4][i], 2.6667, 3)
-        elif funcName == "minimum":
-            assert_equal(rawTable[1][i], 1)
-            assert_equal(rawTable[2][i], 1)
-            assert_equal(rawTable[3][i], 1)
-            assert_equal(rawTable[4][i], 1)
-        elif funcName == "maximum":
-            assert_equal(rawTable[1][i], 3)
-            assert_equal(rawTable[2][i], 3)
-            assert_equal(rawTable[3][i], 5)
-            assert_equal(rawTable[4][i], 5)
-        elif funcName == "uniqueCount":
-            assert_equal(rawTable[1][i], 2)
-            assert_equal(rawTable[2][i], 3)
-            assert_equal(rawTable[3][i], 3)
-            assert_equal(rawTable[4][i], 3)
-        elif funcName == "standardDeviation":
-            assert_almost_equal(rawTable[1][i], 0.9428, 3)
-            assert_almost_equal(rawTable[2][i], 0.8165, 3)
-            assert_almost_equal(rawTable[3][i], 1.633, 3)
-            assert_almost_equal(rawTable[4][i], 1.6997, 3)
-        elif funcName == "median":
-            assert_equal(rawTable[1][i], 1.0)
-            assert_equal(rawTable[2][i], 2.0)
-            assert_equal(rawTable[3][i], 3.0)
-            assert_equal(rawTable[4][i], 2.0)
 
-
-def testSparse():
+def testProduceInfoTable_sparseData():
     """
-        Test the functionality of calculating statistical/informational
-        funcs on a Matrix object using the produceInfoTable.
+    Test the functionality of calculating statistical/informational
+    funcs on objects with sparse data using the produceInfoTable.
 
-        Testing matrix is 6 x 6, with 11 non-zero values, 1 None/Missing value,
-        and 24 zero values.
+    Testing matrix is 6 x 6, with 11 non-zero values, 1 None/Missing value,
+    and 24 zero values.
     """
     row = np.array([0, 0, 1, 1, 2, 2, 2, 3, 4, 4, 4, 5])
     col = np.array([0, 4, 2, 3, 1, 3, 4, 0, 1, 3, 4, 5])
@@ -76,97 +76,57 @@ def testSparse():
         raise PackageException(msg)
 
     raw = scipy.sparse.coo_matrix((vals, (row, col)))
-    testObj = createData('Sparse', data=raw)
-    funcs = featurewiseFunctionGenerator()
-    rawTable = produceFeaturewiseInfoTable(testObj, funcs)
 
-    funcNames = rawTable[0]
-    for i in range(len(funcNames)):
-        funcName = funcNames[i]
-        if funcName == "mean":
-            assert_almost_equal(rawTable[1][i], 0.3333, 3)
-            assert_almost_equal(rawTable[2][i], 0.3333, 3)
-            assert_almost_equal(rawTable[3][i], 0.1667, 3)
-            assert_almost_equal(rawTable[4][i], 0.4000, 3)
-            assert_almost_equal(rawTable[5][i], 0.5000, 3)
-            assert_almost_equal(rawTable[6][i], 0.1667, 3)
-        elif funcName == "minimum":
-            assert_equal(rawTable[1][i], 0)
-            assert_equal(rawTable[2][i], 0)
-            assert_equal(rawTable[3][i], 0)
-            assert_equal(rawTable[4][i], 0)
-            assert_equal(rawTable[5][i], 0)
-            assert_equal(rawTable[6][i], 0)
-        elif funcName == "maximum":
-            assert_equal(rawTable[1][i], 1)
-            assert_equal(rawTable[2][i], 1)
-            assert_equal(rawTable[3][i], 1)
-            assert_equal(rawTable[4][i], 1)
-            assert_equal(rawTable[5][i], 1)
-            assert_equal(rawTable[6][i], 1)
-        elif funcName == "uniqueCount":
-            assert_equal(rawTable[1][i], 2)
-            assert_equal(rawTable[2][i], 2)
-            assert_equal(rawTable[3][i], 2)
-            assert_equal(rawTable[4][i], 2)
-            assert_equal(rawTable[5][i], 2)
-            assert_equal(rawTable[6][i], 2)
-        elif funcName == "standardDeviation":
-            assert_almost_equal(rawTable[1][i], 0.4714, 3)
-            assert_almost_equal(rawTable[2][i], 0.4714, 3)
-            assert_almost_equal(rawTable[3][i], 0.3727, 3)
-            assert_almost_equal(rawTable[4][i], 0.4899, 3)
-            assert_almost_equal(rawTable[5][i], 0.500, 3)
-            assert_almost_equal(rawTable[6][i], 0.3727, 3)
-        elif funcName == "median":
-            assert_equal(rawTable[1][i], 0)
-            assert_equal(rawTable[2][i], 0)
-            assert_equal(rawTable[3][i], 0)
-            assert_equal(rawTable[4][i], 0)
-            assert_equal(rawTable[5][i], 0.5)
-            assert_equal(rawTable[6][i], 0)
-
-
-def testList():
-    data1 = np.array([[1, 2, 3, 1], [3, 3, 1, 5], [1, 1, 5, 2]])
-    names1 = ['var1', 'var2', 'var3', 'var4']
-
-    trainObj = createData('List', data=data1, featureNames=names1)
-    funcs = featurewiseFunctionGenerator()
-    rawTable = produceFeaturewiseInfoTable(trainObj, funcs)
-    funcNames = rawTable[0]
-    for i in range(len(funcNames)):
-        funcName = funcNames[i]
-        if funcName == "mean":
-            assert_almost_equal(rawTable[1][i], 1.6667, 3)
-            assert_almost_equal(rawTable[2][i], 2.000, 3)
-            assert_almost_equal(rawTable[3][i], 3.000, 3)
-            assert_almost_equal(rawTable[4][i], 2.6667, 3)
-        elif funcName == "minimum":
-            assert_equal(rawTable[1][i], 1)
-            assert_equal(rawTable[2][i], 1)
-            assert_equal(rawTable[3][i], 1)
-            assert_equal(rawTable[4][i], 1)
-        elif funcName == "maximum":
-            assert_equal(rawTable[1][i], 3)
-            assert_equal(rawTable[2][i], 3)
-            assert_equal(rawTable[3][i], 5)
-            assert_equal(rawTable[4][i], 5)
-        elif funcName == "uniqueCount":
-            assert_equal(rawTable[1][i], 2)
-            assert_equal(rawTable[2][i], 3)
-            assert_equal(rawTable[3][i], 3)
-            assert_equal(rawTable[4][i], 3)
-        elif funcName == "standardDeviation":
-            assert_almost_equal(rawTable[1][i], 0.9428, 3)
-            assert_almost_equal(rawTable[2][i], 0.8165, 3)
-            assert_almost_equal(rawTable[3][i], 1.633, 3)
-            assert_almost_equal(rawTable[4][i], 1.6997, 3)
-        elif funcName == "median":
-            assert_equal(rawTable[1][i], 1.0)
-            assert_equal(rawTable[2][i], 2.0)
-            assert_equal(rawTable[3][i], 3.0)
-            assert_equal(rawTable[4][i], 2.0)
+    for retType in nimble.data.available:
+        testObj = createData(retType, data=raw)
+        funcs = featurewiseFunctionGenerator()
+        rawTable = produceFeaturewiseInfoTable(testObj, funcs)
+        print(rawTable)
+        funcNames = rawTable[0]
+        for i in range(len(funcNames)):
+            funcName = funcNames[i]
+            if funcName == "mean":
+                assert_almost_equal(rawTable[1][i], 0.3333, 3)
+                assert_almost_equal(rawTable[2][i], 0.3333, 3)
+                assert_almost_equal(rawTable[3][i], 0.1667, 3)
+                assert_almost_equal(rawTable[4][i], 0.4000, 3)
+                assert_almost_equal(rawTable[5][i], 0.5000, 3)
+                assert_almost_equal(rawTable[6][i], 0.1667, 3)
+            elif funcName == "minimum":
+                assert_equal(rawTable[1][i], 0)
+                assert_equal(rawTable[2][i], 0)
+                assert_equal(rawTable[3][i], 0)
+                assert_equal(rawTable[4][i], 0)
+                assert_equal(rawTable[5][i], 0)
+                assert_equal(rawTable[6][i], 0)
+            elif funcName == "maximum":
+                assert_equal(rawTable[1][i], 1)
+                assert_equal(rawTable[2][i], 1)
+                assert_equal(rawTable[3][i], 1)
+                assert_equal(rawTable[4][i], 1)
+                assert_equal(rawTable[5][i], 1)
+                assert_equal(rawTable[6][i], 1)
+            elif funcName == "uniqueCount":
+                assert_equal(rawTable[1][i], 2)
+                assert_equal(rawTable[2][i], 2)
+                assert_equal(rawTable[3][i], 2)
+                assert_equal(rawTable[4][i], 2)
+                assert_equal(rawTable[5][i], 2)
+                assert_equal(rawTable[6][i], 2)
+            elif funcName == "standardDeviation":
+                assert_almost_equal(rawTable[1][i], 0.5164, 3)
+                assert_almost_equal(rawTable[2][i], 0.5164, 3)
+                assert_almost_equal(rawTable[3][i], 0.4082, 3)
+                assert_almost_equal(rawTable[4][i], 0.5477, 3)
+                assert_almost_equal(rawTable[5][i], 0.5477, 3)
+                assert_almost_equal(rawTable[6][i], 0.4082, 3)
+            elif funcName == "median":
+                assert_equal(rawTable[1][i], 0)
+                assert_equal(rawTable[2][i], 0)
+                assert_equal(rawTable[3][i], 0)
+                assert_equal(rawTable[4][i], 0)
+                assert_equal(rawTable[5][i], 0.5)
+                assert_equal(rawTable[6][i], 0)
 
 
 def testAppendColumns():
@@ -238,13 +198,3 @@ def testProduceAggregateTable():
             assert rawTable[1][i] == 4
         elif funcName == "points":
             assert rawTable[1][i] == 3
-
-
-
-
-
-
-
-
-
-

--- a/tests/logger/testLoggingCount.py
+++ b/tests/logger/testLoggingCount.py
@@ -64,10 +64,10 @@ calculate_funcs = [
     'elementwiseMultiply', 'elementwisePower', 'f1Score', 'falseNegative',
     'falsePositive', 'fractionCorrect', 'fractionIncorrect', 'inverse',
     'leastSquaresSolution', 'maximum', 'mean', 'meanAbsoluteError',
-    'meanFeaturewiseRootMeanSquareError', 'median', 'minimum', 'mode',
-    'precision', 'proportionMissing', 'proportionZero', 'pseudoInverse',
-    'quartiles', 'recall', 'residuals', 'rootMeanSquareError', 'rSquared',
-    'solve', 'specificity', 'standardDeviation', 'trueNegative',
+    'meanFeaturewiseRootMeanSquareError', 'median', 'medianAbsoluteDeviation',
+    'minimum', 'mode', 'precision', 'proportionMissing', 'proportionZero',
+    'pseudoInverse', 'quartiles', 'recall', 'residuals', 'rootMeanSquareError',
+    'rSquared', 'solve', 'specificity', 'standardDeviation', 'trueNegative',
     'truePositive', 'uniqueCount', 'varianceFractionRemaining',
     ]
 calculate_tested = list(map(prefixAdder('nimble.calculate'), calculate_funcs))


### PR DESCRIPTION
1) Add Median Absolute Deviation function to nimble.calculate
2) Change default to `True` for `sample` parameter in `standardDeviation` and adjust tests accordingly
3) Fix None values not changed to NaN in _minMaxBackend and documentation