### PR TITLE
extend matchingElements accepted inputs

### DIFF
--- a/nimble/data/axis.py
+++ b/nimble/data/axis.py
@@ -14,7 +14,6 @@ import copy
 from abc import abstractmethod
 import inspect
 import sys
-import operator
 import functools
 
 import numpy
@@ -33,6 +32,7 @@ from .features import Features
 from .dataHelpers import DEFAULT_PREFIX, DEFAULT_PREFIX2, DEFAULT_PREFIX_LENGTH
 from .dataHelpers import valuesToPythonList, constructIndicesList
 from .dataHelpers import validateInputString
+from .dataHelpers import isQueryString, axisQueryFunction
 from .dataHelpers import isAllowedSingleElement, sortIndexPosition
 from .dataHelpers import createDataNoValidation
 from .dataHelpers import wrapMatchFunctionFactory
@@ -1202,11 +1202,16 @@ class Axis(object):
                 targetList.append(target)
             # if not a name then assume it's a query string
             else:
-                if self._isPoint:
-                    hasNameChecker2 = self._base.features._hasName
+                query = isQueryString(target, startswithOperator=False)
+                if query:
+                    offAxis = 'features' if self._isPoint else 'points'
+                    hasName = getattr(self._base, offAxis)._hasName
+                    target = axisQueryFunction(query, axis, hasName)
+                # the target can't be converted to a function
                 else:
-                    hasNameChecker2 = self._base.points._hasName
-                target = _stringToFunction(target, axis, hasNameChecker2)
+                    msg = "'{0}' is not a valid {1} ".format(target, axis)
+                    msg += 'name nor a valid query string'
+                    raise InvalidArgumentValue(msg)
 
         # list-like container types
         if target is not None and not hasattr(target, '__call__'):
@@ -1748,68 +1753,6 @@ def _validateStartEndRange(start, end, axis, axisLength):
     if start > end:
         msg = "The start index cannot be greater than the end index"
         raise InvalidArgumentValueCombination(msg)
-
-def _stringToFunction(string, axis, nameChecker):
-    """
-    Convert a query string into a python function.
-    """
-    optrDict = {'<=': operator.le, '>=': operator.ge,
-                '!=': operator.ne, '==': operator.eq,
-                '<': operator.lt, '>': operator.gt}
-    # to set in for loop
-    nameOfPtOrFt = None
-    valueOfPtOrFt = None
-    optrOperator = None
-
-    for optr in ['<=', '>=', '!=', '==', '=', '<', '>']:
-        if optr in string:
-            targetList = string.split(optr)
-            # user can use '=' but optrDict only contains '=='
-            optr = '==' if optr == '=' else optr
-            #after splitting at the optr, list must have 2 items
-            if len(targetList) != 2:
-                msg = "the target({0}) is a ".format(string)
-                msg += "query string but there is an error"
-                raise InvalidArgumentValue(msg)
-            nameOfPtOrFt = targetList[0]
-            valueOfPtOrFt = targetList[1]
-            nameOfPtOrFt = nameOfPtOrFt.strip()
-            valueOfPtOrFt = valueOfPtOrFt.strip()
-
-            #when point, check if the feature exists or not
-            #when feature, check if the point exists or not
-            if not nameChecker(nameOfPtOrFt):
-                if axis == 'point':
-                    offAxis = 'feature'
-                else:
-                    offAxis = 'point'
-                msg = "the {0} ".format(offAxis)
-                msg += "'{0}' doesn't exist".format(nameOfPtOrFt)
-                raise InvalidArgumentValue(msg)
-
-            optrOperator = optrDict[optr]
-            # convert valueOfPtOrFt from a string, if possible
-            try:
-                valueOfPtOrFt = float(valueOfPtOrFt)
-            except ValueError:
-                pass
-            #convert query string to a function
-            def target_f(x):
-                return optrOperator(x[nameOfPtOrFt], valueOfPtOrFt)
-
-            target_f.vectorized = True
-            target_f.nameOfPtOrFt = nameOfPtOrFt
-            target_f.valueOfPtOrFt = valueOfPtOrFt
-            target_f.optr = optrOperator
-            target = target_f
-            break
-    # the target can't be converted to a function
-    else:
-        msg = "'{0}' is not a valid {1} ".format(string, axis)
-        msg += 'name nor a valid query string'
-        raise InvalidArgumentValue(msg)
-
-    return target
 
 class AxisIterator(object):
     """

--- a/nimble/data/base.py
+++ b/nimble/data/base.py
@@ -42,6 +42,7 @@ from .dataHelpers import csvCommaFormat
 from .dataHelpers import validateElementFunction, wrapMatchFunctionFactory
 from .dataHelpers import getDictionaryMappingFunction
 from .dataHelpers import ElementIterator1D
+from .dataHelpers import isQueryString, elementQueryFunction
 
 
 def to2args(f):
@@ -865,15 +866,15 @@ class Base(object):
         """
         Return an object of boolean values identifying matching values.
 
-        Apply a function returning a boolean value for each element in
-        this object. Common matching functions can be found in nimble's
-        match module.
+        Common matching functions can be found in nimble's match module.
 
         Parameters
         ----------
-        toMatch : function
-            * function - in the form of toMatch(elementValue) which
+        toMatch
+            * value - elements equal to the value return True
+            * function - in the form of toMatch(elementValue) that
               returns True, False, 0 or 1.
+            * str - a comparison operator and a value (i.e ">=0")
         points : point, list of points
             The subset of points to limit the matching to. If None,
             the matching will apply to all points.
@@ -898,11 +899,11 @@ class Base(object):
         >>> from nimble import match
         >>> raw = [[1, -1, 1], [-3, 3, -3]]
         >>> data = nimble.createData('Matrix', raw)
-        >>> isPositive = data.matchingElements(match.positive)
-        >>> isPositive
+        >>> isNegativeOne = data.matchingElements(-1)
+        >>> isNegativeOne
         Matrix(
-            [[ True False  True]
-             [False  True False]]
+            [[False  True False]
+             [False False False]]
             )
 
         >>> from nimble import match
@@ -914,8 +915,29 @@ class Base(object):
             [[False False  True]
              [ True False False]]
             )
+
+        >>> from nimble import match
+        >>> raw = [[1, -1, 1], [-3, 3, -3]]
+        >>> data = nimble.createData('Matrix', raw)
+        >>> isPositive = data.matchingElements(">0")
+        >>> isPositive
+        Matrix(
+            [[ True False  True]
+             [False  True False]]
+            )
         """
-        wrappedMatch = wrapMatchFunctionFactory(toMatch)
+        matchArg = toMatch # preserve toMatch in original state for log
+        if not callable(matchArg):
+            query = isQueryString(matchArg)
+            if query:
+                func = elementQueryFunction(query)
+            # if not a comparison string, element must equal matchArg
+            else:
+                matchVal = matchArg
+                func = lambda elem: elem == matchVal
+            matchArg = func
+
+        wrappedMatch = wrapMatchFunctionFactory(matchArg)
 
         ret = self._calculate_backend(wrappedMatch, points, features,
                                       allowBoolOutput=True)
@@ -1044,17 +1066,16 @@ class Base(object):
         >>> numLessThanOne
         20
         """
-        if hasattr(condition, '__call__'):
-            ret = self.calculateOnElements(condition, outputType='Matrix',
-                                           useLog=False)
-        elif isinstance(condition, str):
-            func = lambda x: eval('x'+condition)
-            ret = self.calculateOnElements(func, outputType='Matrix',
-                                           useLog=False)
-        else:
-            msg = 'function can only be a function or string containing a '
+        query = isQueryString(condition)
+        if query:
+            condition = elementQueryFunction(query)
+        elif not hasattr(condition, '__call__'):
+            msg = 'condition can only be a function or string containing a '
             msg += 'comparison operator and a value'
             raise InvalidArgumentType(msg)
+
+        ret = self.calculateOnElements(condition, outputType='Matrix',
+                                       useLog=False)
         return int(numpy.sum(ret.data))
 
     def countUniqueElements(self, points=None, features=None):

--- a/tests/data/high_level_backend.py
+++ b/tests/data/high_level_backend.py
@@ -1042,6 +1042,12 @@ class HighLevelDataSafe(DataTestObject):
         ret = toTest.countElements('>=5')
         assert ret == 5
 
+        ret = toTest.countElements('   >=   5   ')
+        assert ret == 5
+
+        ret = toTest.countElements('=5')
+        assert ret == 1
+
         ret = toTest.countElements(lambda x: x % 2 == 1)
         assert ret == 5
 
@@ -1820,6 +1826,62 @@ class HighLevelDataSafe(DataTestObject):
         assert matches[1, 0] is False or matches[1, 0] is numpy.bool_(False)
         assert matches[1, 1] is False or matches[1, 1] is numpy.bool_(False)
         assert matches[1, 2] is False or matches[1, 2] is numpy.bool_(False)
+
+    def test_matchingElements_valueInput(self):
+        raw = [[1, 2, 3], [-1, -2, -3], [0, 'a', 0]]
+        obj = self.constructor(raw)
+        match1 = obj.matchingElements(lambda x: x == 0)
+        match2 = obj.matchingElements(0)
+        assert match1 == match2
+
+        match1 = obj.matchingElements(lambda x: x == 'a')
+        match2 = obj.matchingElements('a')
+        assert match1 == match2
+
+    def test_matchingElements_comparisonStringInput(self):
+        raw = [[1, 2, 3], [-1, -2, -3], [0, 0, 0]]
+        obj = self.constructor(raw)
+        ['==', '=', '!=', '>', '<', '>=', '<=']
+        match1 = obj.matchingElements(lambda x: x == 0)
+        match2 = obj.matchingElements('==0')
+        ws1, ws2, ws3 = [' ' * numpy.random.randint(1, 5) for _ in range(3)]
+        match3 = obj.matchingElements(ws1 + '==' + ws2 + '0' + ws3)
+        assert match1 == match2 == match3
+
+        match2 = obj.matchingElements('=0')
+        ws1, ws2, ws3 = [' ' * numpy.random.randint(1, 5) for _ in range(3)]
+        match3 = obj.matchingElements(ws1 + '=' + ws2 + '0' + ws3)
+        assert match1 == match2 == match3
+
+        match1 = obj.matchingElements(lambda x: x != 0)
+        match2 = obj.matchingElements('!=0')
+        ws1, ws2, ws3 = [' ' * numpy.random.randint(1, 5) for _ in range(3)]
+        match3 = obj.matchingElements(ws1 + '!=' + ws2 + '0' + ws3)
+        assert match1 == match2 == match3
+
+        match1 = obj.matchingElements(lambda x: x > 0)
+        match2 = obj.matchingElements('>0')
+        ws1, ws2, ws3 = [' ' * numpy.random.randint(1, 5) for _ in range(3)]
+        match3 = obj.matchingElements(ws1 + '>' + ws2 + '0' + ws3)
+        assert match1 == match2 == match3
+
+        match1 = obj.matchingElements(lambda x: x < 0)
+        match2 = obj.matchingElements('<0')
+        ws1, ws2, ws3 = [' ' * numpy.random.randint(1, 5) for _ in range(3)]
+        match3 = obj.matchingElements(ws1 + '<' + ws2 + '0' + ws3)
+        assert match1 == match2 == match3
+
+        match1 = obj.matchingElements(lambda x: x >= 0)
+        match2 = obj.matchingElements('>=0')
+        ws1, ws2, ws3 = [' ' * numpy.random.randint(1, 5) for _ in range(3)]
+        match3 = obj.matchingElements(ws1 + '>=' + ws2 + '0' + ws3)
+        assert match1 == match2 == match3
+
+        match1 = obj.matchingElements(lambda x: x <= 0)
+        match2 = obj.matchingElements('<=0')
+        ws1, ws2, ws3 = [' ' * numpy.random.randint(1, 5) for _ in range(3)]
+        match3 = obj.matchingElements(ws1 + '<=' + ws2 + '0' + ws3)
+        assert match1 == match2 == match3
 
     @oneLogEntryExpected
     def test_matchingElements_pfLimited(self):


### PR DESCRIPTION
Allow single values and query strings as additional input options for `matchingElements`.

Refactored some of the helpers supporting query strings.
1) Moved any existing helpers to dataHelpers so that all query string related functionality is now in the same location. `Base.countElements`, `Base.matchingElements` and `Axis._genericStructuralFrontend` all use these helpers.
2) Changed to use of regex to identify query strings, rather than a `for` loop. Behavior varies for functions when the string is not a query string, so the `isQueryString` function determines if the string can be used to generate a function. If so, it returns the match object that can be passed to the other helpers, `elementQueryFunction` and `axisQueryFunction` to process the match object into a valid function.
3) Modified `countElements` to use these helpers. The previous implementation was less robust and did not support a single '=', making it inconsistent with the other query string input functions.