### PR TITLE
use sparse data for SparseView elementwise multiplication

### DIFF
--- a/nimble/data/sparse.py
+++ b/nimble/data/sparse.py
@@ -1043,13 +1043,13 @@ class Sparse(Base):
 
         # CHOICE OF OUTPUT WILL BE DETERMINED BY SCIPY!!!!!!!!!!!!
         # for other.data as any dense or sparse matrix
-        directMul = isinstance(other, (Sparse, nimble.data.Matrix))
-        notView = not isinstance(other, BaseView)
-        if directMul and notView:
-            toMul = other.data
+        if isinstance(other, Sparse):
+            toMul = other._getSparseData()
+        elif isinstance(other, nimble.data.Matrix):
+            toMul = scipy.sparse.coo_matrix(other.data)
         else:
-            toMul = other.copy(to='numpyarray')
-        raw = target.data.multiply(scipy.sparse.coo_matrix(toMul))
+            toMul = scipy.sparse.coo_matrix(other.copy(to='numpyarray'))
+        raw = target.data.multiply(toMul)
         if scipy.sparse.isspmatrix(raw):
             raw = raw.tocoo()
         else:


### PR DESCRIPTION
Alter `_genericMul_implementation` to prevent SparseView data from being converted to a dense representation.