### PR TITLE
add exceptions directory

### DIFF
--- a/documentation/source/nimble/exceptions.rst
+++ b/documentation/source/nimble/exceptions.rst
@@ -3,4 +3,3 @@ nimble.exceptions
 
 .. automodule:: nimble.exceptions
    :members:
-   :exclude-members: prettyListString, prettyDictString

--- a/nimble/data/axis.py
+++ b/nimble/data/axis.py
@@ -1501,7 +1501,7 @@ class Axis(object):
             msg = "The argument named " + argName + " must not share any "
             msg += self._axis + "Names with the calling object, yet the "
             msg += "following names occured in both: "
-            msg += nimble.exceptions.prettyListString(shared)
+            msg += nimble.exceptions._prettyListString(shared)
             if truncated:
                 msg += "... (only first 10 entries out of " + str(full)
                 msg += " total)"

--- a/nimble/data/base.py
+++ b/nimble/data/base.py
@@ -4142,7 +4142,7 @@ class Base(object):
                 msg += "nimble.calculate.inverse. For safety and efficiency, "
                 msg += "matrixPower does not attempt to use pseudoInverse but "
                 msg += "it is available to users in nimble.calculate. "
-                msg += "The inverse operation failed because: " + e.value
+                msg += "The inverse operation failed because: " + e.message
                 raise exceptionType(msg)
 
         ret = operand

--- a/nimble/exceptions/__init__.py
+++ b/nimble/exceptions/__init__.py
@@ -1,0 +1,15 @@
+
+from .exceptions import NimbleException
+from .exceptions import InvalidArgumentType
+from .exceptions import InvalidArgumentValue
+from .exceptions import InvalidArgumentTypeCombination
+from .exceptions import InvalidArgumentValueCombination
+from .exceptions import ImproperObjectAction
+from .exceptions import PackageException
+from .exceptions import FileFormatException
+from .exceptions import _prettyListString
+from .exceptions import _prettyDictString
+
+__all__ = ['NimbleException', 'InvalidArgumentType', 'InvalidArgumentValue',
+           'InvalidArgumentTypeCombination', 'InvalidArgumentValueCombination',
+           'ImproperObjectAction', 'PackageException', 'FileFormatException']

--- a/nimble/exceptions/exceptions.py
+++ b/nimble/exceptions/exceptions.py
@@ -1,24 +1,23 @@
 """
-Module defining exceptions to be used in nimble.
-
+Module defining exceptions used in nimble.
 """
 
 class NimbleException(Exception):
     """
-    Override Python's Exception, requiring a value upon instantiation.
+    Override Python's Exception, requiring a message upon instantiation.
     """
-    def __init__(self, value):
-        if not isinstance(value, str):
-            raise TypeError("value must be a string")
-        self.value = value
-        self.className = self.__class__.__name__
-        super(NimbleException, self).__init__(value)
+    def __init__(self, message):
+        if not isinstance(message, str):
+            raise TypeError("message must be a string")
+        self.message = message
+        super(NimbleException, self).__init__(message)
 
     def __str__(self):
-        return self.value
+        return self.message
 
     def __repr__(self):
-        return "{cls}({val})".format(cls=self.className, val=repr(self.value))
+        return "{cls}({msg})".format(cls=self.__class__.__name__,
+                                     msg=repr(self.message))
 
 class InvalidArgumentType(NimbleException, TypeError):
     """
@@ -85,11 +84,13 @@ class PackageException(NimbleException, ImportError):
 class FileFormatException(NimbleException, ValueError):
     """
     Raised when the formatting of a file is not as expected.
+
+    This is a subclass of Python's ValueError.
     """
     pass
 
 
-def prettyListString(inList, useAnd=False, numberItems=False, itemStr=str):
+def _prettyListString(inList, useAnd=False, numberItems=False, itemStr=str):
     """
     Used in the creation of exception messages to display lists in a
     more appealing way than default.
@@ -106,7 +107,7 @@ def prettyListString(inList, useAnd=False, numberItems=False, itemStr=str):
     return ret
 
 
-def prettyDictString(inDict, useAnd=False, numberItems=False, keyStr=str,
+def _prettyDictString(inDict, useAnd=False, numberItems=False, keyStr=str,
                       delim='=', valueStr=str):
     """
     Used in the creation of exception messages to display dicts in a

--- a/nimble/fill/__init__.py
+++ b/nimble/fill/__init__.py
@@ -11,5 +11,5 @@ from .fill import forwardFill
 from .fill import backwardFill
 from .fill import interpolate
 
-__all__ = ['backwardFill', 'constant', 'factory', 'forwardFill', 'interpolate',
-           'mean', 'median', 'mode',]
+__all__ = ['backwardFill', 'constant', 'forwardFill', 'interpolate', 'mean',
+           'median', 'mode',]

--- a/nimble/interfaces/keras_interface.py
+++ b/nimble/interfaces/keras_interface.py
@@ -18,7 +18,7 @@ from nimble.interfaces.interface_helpers import collectAttributes
 from nimble.interfaces.interface_helpers import removeFromTailMatchedLists
 from nimble.helpers import inspectArguments
 from nimble.utility import inheritDocstringsFactory, numpy2DArray
-from nimble.exceptions import InvalidArgumentValue, prettyListString
+from nimble.exceptions import InvalidArgumentValue, _prettyListString
 
 
 # Contains path to keras root directory
@@ -217,7 +217,7 @@ To install keras
             msg += "When trying to validate arguments for "
             msg += learnerName + ", the following list of parameter "
             msg += "names were not matched: "
-            msg += prettyListString(extra, useAnd=True)
+            msg += _prettyListString(extra, useAnd=True)
             msg += ". Those parameters are only suitable for "
             if dataType == 'Sparse':
                 msg += "dense types (List, Matrix, DataFrame) and this object "

--- a/nimble/interfaces/universal_interface.py
+++ b/nimble/interfaces/universal_interface.py
@@ -21,8 +21,8 @@ from nimble.exceptions import InvalidArgumentValueCombination
 from nimble.exceptions import PackageException
 from nimble.utility import inheritDocstringsFactory
 from nimble.utility import cloudpickle
-from nimble.exceptions import prettyListString
-from nimble.exceptions import prettyDictString
+from nimble.exceptions import _prettyListString
+from nimble.exceptions import _prettyDictString
 from nimble.interfaces.interface_helpers import (
     generateBinaryScoresFromHigherSortedLabelScores,
     calculateSingleLabelScoresFromOneVsOneScores,
@@ -371,13 +371,13 @@ class UniversalInterface(metaclass=abc.ABCMeta):
                 msg += ", we couldn't find a value for the parameter named "
                 msg += "'" + param + "'. "
                 msg += "The allowed parameters were: "
-                msg += prettyListString(neededParams, useAnd=True)
+                msg += _prettyListString(neededParams, useAnd=True)
                 if len(possibleParams) > 1:
                     msg += ". These were choosen as the best guess given the "
                     msg += "inputs out of the following (numbered) list of "
                     msg += "possible parameter sets: "
-                    msg += prettyListString(possibleParams, numberItems=True,
-                                            itemStr=prettyListString)
+                    msg += _prettyListString(possibleParams, numberItems=True,
+                                            itemStr=_prettyListString)
 
                 if len(availableDefaults) == 0:
                     msg += ". All of the allowed parameters must be specified "
@@ -386,13 +386,13 @@ class UniversalInterface(metaclass=abc.ABCMeta):
                     msg += ". Out of the allowed parameters, the following "
                     msg += "could be omitted, which would result in the "
                     msg += "associated default value being used: "
-                    msg += prettyDictString(availableDefaults, useAnd=True)
+                    msg += _prettyDictString(availableDefaults, useAnd=True)
 
                 if len(arguments) == 0:
                     msg += ". However, no arguments were provided."
                 else:
                     msg += ". The full mapping of inputs actually provided "
-                    msg += "was: " + prettyDictString(arguments)
+                    msg += "was: " + _prettyDictString(arguments)
 
                 raise InvalidArgumentValue(msg)
 
@@ -401,18 +401,18 @@ class UniversalInterface(metaclass=abc.ABCMeta):
             msg += "When trying to validate arguments for "
             msg += name + ", the following list of parameter "
             msg += "names were not matched: "
-            msg += prettyListString(list(check.keys()), useAnd=True)
+            msg += _prettyListString(list(check.keys()), useAnd=True)
             msg += ". The allowed parameters were: "
-            msg += prettyListString(neededParams, useAnd=True)
+            msg += _prettyListString(neededParams, useAnd=True)
             if len(possibleParams) > 1:
                 msg += ". These were choosen as the best guess given the "
                 msg += "inputs out of the following (numbered) list of "
                 msg += "possible parameter sets: "
-                msg += prettyListString(possibleParams, numberItems=True,
-                                    itemStr=prettyListString)
+                msg += _prettyListString(possibleParams, numberItems=True,
+                                    itemStr=_prettyListString)
 
             msg += ". The full mapping of inputs actually provided was: "
-            msg += prettyDictString(arguments) + ". "
+            msg += _prettyDictString(arguments) + ". "
             msg += "If extra parameters were intended to be passed to one of "
             msg += "the arguments, be sure to group them using a nimble.Init "
             msg += "object. "
@@ -514,17 +514,17 @@ class UniversalInterface(metaclass=abc.ABCMeta):
             msg += "match the given input. However, from each possible "
             msg += "(numbered) parameter set, the following parameter names "
             msg += "were missing "
-            msg += prettyListString(missing, numberItems=True,
-                                     itemStr=prettyListString)
+            msg += _prettyListString(missing, numberItems=True,
+                                     itemStr=_prettyListString)
             msg += ". The following lists the required names in each of the "
             msg += "possible (numbered) parameter sets: "
-            msg += prettyListString(nonDefaults, numberItems=True,
-                                     itemStr=prettyListString)
+            msg += _prettyListString(nonDefaults, numberItems=True,
+                                     itemStr=_prettyListString)
             if len(arguments) == 0:
                 msg += ". However, no arguments were inputed."
             else:
                 msg += ". The full mapping of inputs actually provided was: "
-                msg += prettyDictString(arguments) + ". "
+                msg += _prettyDictString(arguments) + ". "
 
             raise InvalidArgumentValue(msg)
 
@@ -544,9 +544,9 @@ class UniversalInterface(metaclass=abc.ABCMeta):
             msg = "EXTRA PARAMETER! "
             if argNames:
                 msg += "The following parameter names cannot be applied: "
-                msg += prettyListString(invalidArguments, useAnd=True)
+                msg += _prettyListString(invalidArguments, useAnd=True)
                 msg += ". The allowed parameters are: "
-                msg += prettyListString(argNames, useAnd=True)
+                msg += _prettyListString(argNames, useAnd=True)
             else:
                 msg += "No parameters are accepted for this operation"
             raise InvalidArgumentValue(msg)

--- a/tests/calculate/utility_test.py
+++ b/tests/calculate/utility_test.py
@@ -107,7 +107,7 @@ def test_detectBestResult_exceptionsAreReported():
         detectBestResult(neverWorks)
         assert False  # we expected an exception in this test
     except InvalidArgumentValue as iav:
-        assert wanted in iav.value
+        assert wanted in iav.message
 
 @noLogEntryExpected
 def _backend(performanceFunction, optimality):

--- a/tests/testCreateData.py
+++ b/tests/testCreateData.py
@@ -449,18 +449,18 @@ def test_createData_CSV_unequalRowLength_position():
             nimble.createData(returnType="List", data=tmpCSV.name, featureNames=True)
             assert False  # the previous call should have raised an exception
         except FileFormatException as ffe:
-            print(ffe.value)
+            print(ffe.message)
             # We expect a message of the format:
             #
-            assert '1' in ffe.value  # defining line
-            assert '4' in ffe.value  # offending line
+            assert '1' in ffe.message  # defining line
+            assert '4' in ffe.message  # offending line
             # offending line number comes before defining line number
-            assert ffe.value.index('4') < ffe.value.index('1')
+            assert ffe.message.index('4') < ffe.message.index('1')
 
-            assert '8' in ffe.value  # expected length
-            assert '6' in ffe.value  # offending length
+            assert '8' in ffe.message  # expected length
+            assert '6' in ffe.message  # offending length
             # offending length comes before expected length
-            assert ffe.value.index('6') < ffe.value.index('8')
+            assert ffe.message.index('6') < ffe.message.index('8')
 
 
 ############################


### PR DESCRIPTION
Move exceptions.py into its own directory for improved control over user-facing api.
- prettyListString and prettyDictString no longer user-facing. Now prefaced with underscore and excluded from `__all__`
- changed required parameter name for `NimbleException` to `message` to be more descriptive.

While checking documentation rendering, a warning identified that `__all__` in fill.py included the `factory` function which has been removed, so this was addressed as well. 