### PR TITLE
install updates

### DIFF
--- a/examples/normalizingExample.py
+++ b/examples/normalizingExample.py
@@ -30,14 +30,15 @@ if __name__ == "__main__":
 
     # use normalize to modify our data; we call a dimentionality reduction algorithm to
     # simply our mostly redundant points. k is the desired number of dimensions in the output
-    normalizeData('mlpy.PCA', trainObj, testX=testObj, arguments={'k': 1})
+    normalizeData('skl.PCA', trainObj, testX=testObj, arguments={'n_components': 1})
 
     # assert that we actually do have fewer dimensions
     assert len(trainObj.features) == 1
     assert len(testObj.features) == 1
 
     # assert we can predict the correct classes
-    ret = trainAndApply('mlpy.KNN', trainObj, trainObjY, testObj, arguments={'k': 1})
+    ret = trainAndApply('nimble.KNNClassifier', trainObj, trainObjY, testObj,
+                        arguments={'k': 1})
     assert ret[0, 0] == 1
     assert ret[1, 0] == 1
     assert ret[2, 0] == 0
@@ -45,5 +46,6 @@ if __name__ == "__main__":
 
     # demonstrate that the results have not changed, when compared to the original data;
     # uses python's **kwargs based argument passing.
-    retOrig = trainAndApply('mlpy.KNN', trainObjOrig, trainObjY, testObjOrig, k=1)
+    retOrig = trainAndApply('nimble.KNNClassifier', trainObjOrig, trainObjY,
+                            testObjOrig, k=1)
     assert ret == retOrig

--- a/nimble/core/logger/stopwatch.py
+++ b/nimble/core/logger/stopwatch.py
@@ -31,7 +31,7 @@ class Stopwatch(object):
             msg = "Task: " + taskName + " has already been started."
             raise TypeError(msg)
         else:
-            self.startTimes[taskName] = time.clock()
+            self.startTimes[taskName] = time.process_time()
             if taskName not in self.cumulativeTimes:
                 self.cumulativeTimes[taskName] = 0.0
             self.isRunningStatus[taskName] = True
@@ -52,7 +52,7 @@ class Stopwatch(object):
         elif not self.isRunningStatus[taskName]:
             raise TypeError("Unable to stop task that has already stopped")
 
-        self.stopTimes[taskName] = time.clock()
+        self.stopTimes[taskName] = time.process_time()
         self.isRunningStatus[taskName] = False
         if taskName in self.cumulativeTimes:
             self.cumulativeTimes[taskName] += (self.stopTimes[taskName]

--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ def run_setup(extensions=None):
         'Operating System :: OS Independent',
         )
     setupKwargs['include_package_data'] = True
-    setupKwargs['install_requires'] = ['six>=1.5.1', 'numpy>=1.10.4',]
+    setupKwargs['install_requires'] = ['numpy>=1.10.4']
     # extras
     pandas = 'pandas>=0.20'
     scipy = 'scipy>=1.0'
@@ -115,16 +115,21 @@ def run_setup(extensions=None):
     mlpy = 'machine-learning-py>=3.5;python_version<"3.7"'
     scikitlearn = 'scikit-learn>=0.19'
     keras = 'keras>=2.0'
-    nose = 'nose>=1.3'
+    autoimpute = 'autoimpute>=0.12'
     requests = 'requests>2.12'
-    interfaces = [mlpy, scikitlearn, keras]
-    userAll = [pandas, scipy, matplotlib, cloudpickle, cython, requests]
+    h5py = 'h5py>=2.10'
+    nose = 'nose>=1.3'
+    data = [pandas, scipy]
+    interfaces = [mlpy, scikitlearn, keras, autoimpute]
+    userAll = [matplotlib, cloudpickle, cython, requests, h5py]
+    userAll.extend(data)
     userAll.extend(interfaces)
     setupKwargs['extras_require'] = {
-        'all': userAll, 'interfaces': interfaces, 'pandas': pandas,
-        'scipy': scipy, 'matplotlib': matplotlib, 'cloudpickle': cloudpickle,
-        'cython': cython, 'mlpy': mlpy, 'scikit-learn': scikitlearn,
-        'keras': keras, 'nose': nose, 'requests': requests,
+        'all': userAll, 'data': data, 'interfaces': interfaces,
+        'pandas': pandas, 'scipy': scipy, 'matplotlib': matplotlib,
+        'cloudpickle': cloudpickle, 'cython': cython, 'requests': requests,
+        'h5py': h5py, 'mlpy': mlpy,  'scikit-learn': scikitlearn,
+        'keras': keras, 'autoimpute': autoimpute, 'nose': nose,
         }
 
     if extensions is not None:

--- a/tests/logger/testLoggingFlags.py
+++ b/tests/logger/testLoggingFlags.py
@@ -158,8 +158,8 @@ def test_trainAndTestOnTrainingData_trainError():
 
 def test_normalizeData():
     def wrapped(trainX, trainY, testX, testY, useLog):
-        return nimble.normalizeData('mlpy.PCA', trainX, testX=testX,
-                                  arguments={'k': 1}, useLog=useLog)
+        return nimble.normalizeData('skl.PCA', trainX, testX=testX,
+                                  arguments={'n_components': 1}, useLog=useLog)
 
     backend(wrapped, runAndCheck)
 


### PR DESCRIPTION
The creation of source and binary distributions through setup.py worked without issue, but there were some updates to setup.py needed:
- Removed `six` from required dependencies.
- Added `autoimpute` and `h5py` to optional extras and added 'data' extra to install all dependencies needed to create any concrete data type (pandas and scipy).

These installs also identified some errors due to later python versions (>3.6). These issues were addressed in this PR:
- mlpy is disabled for python3.7+, so altered tests and examples using mlpy to use sklearn and nimble learners.
- `time.clock()` was removed in python3.8 so changed it to a suggested replacement `time.process_time()`

There are some potential outstanding issues regarding later versions of optional dependencies, but these can be addressed in a separate PR.