### PR TITLE
Expand usage of _check method in Sparse

### DIFF
--- a/nimble/core/data/sparse.py
+++ b/nimble/core/data/sparse.py
@@ -3,6 +3,8 @@ Class extending Base, defining an object to hold and manipulate a scipy
 coo_matrix.
 """
 
+import warnings
+
 import numpy
 
 import nimble
@@ -921,7 +923,6 @@ class Sparse(Base):
 
             assert self.data.dtype.type is not numpy.string_
 
-
             sortedAxis = self._sorted['axis']
             sortedIndices = self._sorted['indices']
             if sortedAxis is not None:
@@ -941,8 +942,10 @@ class Sparse(Base):
             without_replicas_coo = removeDuplicatesNative(self.data)
             assert len(self.data.data) == len(without_replicas_coo.data)
 
-            # call the coo_matrix structure consistency checker
-            self.data._check()
+            with warnings.catch_warnings():
+                warnings.simplefilter('error')
+                # call the coo_matrix structure consistency checker
+                self.data._check()
 
     def _containsZero_implementation(self):
         """


### PR DESCRIPTION
Instead of overriding the `coo_matrix._check` method entirely, the `coo_matrix_skipcheck` subclass now only overrides it during `__init__`, and it has been added as a call in Sparse's `validate` method. This ensures that during testing, the full suite of consistency checks implemented for the coo_matrix is run, and by making use of the method as defined (instead of reproducing a portion of the functionality), those checks will automatically be up to date with the best practices as defined by scipy.
