### PR TITLE
randomness updates to support reproducibility in keras

### DIFF
--- a/nimble/core/interfaces/shogun_interface.py
+++ b/nimble/core/interfaces/shogun_interface.py
@@ -35,6 +35,25 @@ trainYAliases = ['trainlab', 'lab', 'labs', 'labels', 'training_labels',
 # kernel : k, kernel
 # distance : d
 
+class _ShogunRandom:
+    """
+    Wrap shogun's randomness object to make adjustments that allow it
+    to work with nimble randomness control.
+    """
+    def __init__(self, shogunRandom):
+        self.shogunRandom = shogunRandom
+        self.setSeed(42)
+
+    def setSeed(self, seed):
+        if seed is None:
+            self.shogunRandom.init_random(int(numpy.random.randint(2 ** 32)))
+        else:
+            self.shogunRandom.init_random(seed)
+
+    def getSeed(self):
+        return self.shogunRandom.get_seed()
+
+
 @inheritDocstringsFactory(UniversalInterface)
 class Shogun(PredefinedInterface, UniversalInterface):
     """
@@ -43,6 +62,12 @@ class Shogun(PredefinedInterface, UniversalInterface):
 
     def __init__(self):
         self.shogun = modifyImportPathAndImport('shogun', 'shogun')
+        # setup handling for shogun randomness
+        shogunRandom = _ShogunRandom(self.shogun.Math)
+        randomInfo = {'state': None,
+                      'methods': ('setSeed', 'getSeed', 'setSeed')}
+        nimble.random._saved[shogunRandom] = randomInfo
+
         self.versionString = None
 
         def isLearner(obj):

--- a/nimble/random/__init__.py
+++ b/nimble/random/__init__.py
@@ -9,6 +9,7 @@ from .randomness import setSeed
 from .randomness import _generateSubsidiarySeed
 from .randomness import _startAlternateControl
 from .randomness import _endAlternateControl
+from .randomness import _saved
 
 
 __all__ = ['data', 'numpyRandom', 'pythonRandom', 'setSeed']

--- a/runTests.py
+++ b/runTests.py
@@ -222,5 +222,6 @@ if __name__ == '__main__':
             warnings.simplefilter('ignore')
             # need to turn on warnings for tests/interfaces/universal_test
             warnings.filterwarnings('always', module=r'.*universal_test')
+            warnings.filterwarnings('always', module=r'.*keras_interface')
             nose.run(addplugins=plugins, argv=args)
     exit(0)

--- a/tests/interfaces/keras_interface_test.py
+++ b/tests/interfaces/keras_interface_test.py
@@ -5,14 +5,16 @@ Cannot test for expected result equality due to inability to control for
 randomness in Keras.
 """
 import functools
+import warnings
 
 import numpy as np
-from nose.tools import raises
+from nose.tools import raises, with_setup
 
 import nimble
 from nimble.core.interfaces.keras_interface import Keras
 from nimble.exceptions import InvalidArgumentValue
 from nimble._utility import DeferredModuleImport
+from nimble.random import _startAlternateControl, _endAlternateControl
 from .skipTestDecorator import SkipMissing
 from tests.helpers import logCountAssertionFactory, noLogEntryExpected
 
@@ -251,3 +253,64 @@ def testKeras_fitOnlyParametersDisallowedForSparse(optimizer):
                        optimizer=optimizer, layers=layers,
                        loss='binary_crossentropy', metrics=['accuracy'],
                        epochs=2, steps_per_epoch=20, shuffle=True)
+
+
+@with_setup(_startAlternateControl, _endAlternateControl)
+@keraSkipDec
+@noLogEntryExpected
+@chooseOptimizer
+def testKerasReproducibility(optimizer):
+    tfVersion1 = False
+    try:
+        from tensorflow import __version__
+        if __version__[:2] == '1.':
+            tfVersion1 = True
+    except ImportError:
+        pass
+
+    if tfVersion1:
+        # can't control randomness in this version. For testing, keras has
+        # already been loaded, but by instantiating a new Keras instance we can
+        # check that the warning will be displayed when users first use keras
+        with warnings.catch_warnings(record=True) as rec:
+            _ = nimble.core.interfaces.keras_interface.Keras()
+            start = "Randomness is outside of Nimble's control"
+            assert rec and str(rec[0].message).startswith(start)
+    else:
+        # for version2 we expect reproducibility
+        nimble.random.setSeed(1234, useLog=False)
+        x_data = nimble.random.numpyRandom.random((1000, 20))
+        y_data = nimble.random.numpyRandom.randint(2, size=(1000, 1))
+        x_train = nimble.data('Matrix', x_data, useLog=False)
+        y_train = nimble.data('Matrix', y_data, convertToType=float, useLog=False)
+
+        layer0 = nimble.Init('Dense', units=64, activation='relu', input_dim=20)
+        layer1 = nimble.Init('Dropout', rate=0.5)
+        layer2 = nimble.Init('Dense', units=1, activation='sigmoid')
+        layers = [layer0, layer1, layer2]
+
+        mym = nimble.train('keras.Sequential', trainX=x_train, trainY=y_train, optimizer=optimizer,
+                           layers=layers, loss='binary_crossentropy', metrics=['accuracy'],
+                           epochs=20, batch_size=128, useLog=False)
+
+        applied1 = mym.apply(testX=x_train, useLog=False)
+
+
+        nimble.random.setSeed(1234, useLog=False)
+        x_data = nimble.random.numpyRandom.random((1000, 20))
+        y_data = nimble.random.numpyRandom.randint(2, size=(1000, 1))
+        x_train = nimble.data('Matrix', x_data, useLog=False)
+        y_train = nimble.data('Matrix', y_data, convertToType=float, useLog=False)
+
+        layer0 = nimble.Init('Dense', units=64, activation='relu', input_dim=20)
+        layer1 = nimble.Init('Dropout', rate=0.5)
+        layer2 = nimble.Init('Dense', units=1, activation='sigmoid')
+        layers = [layer0, layer1, layer2]
+
+        mym = nimble.train('keras.Sequential', trainX=x_train, trainY=y_train, optimizer=optimizer,
+                           layers=layers, loss='binary_crossentropy', metrics=['accuracy'],
+                           epochs=20, batch_size=128, useLog=False)
+
+        applied2 = mym.apply(testX=x_train, useLog=False)
+
+        assert applied1 == applied2


### PR DESCRIPTION
Modified randomness.py to better support randomness applied within interfaces (Shogun and Keras):
- Changed the design of the `_saved` variable
  - Now a dictionary containing each instantiated randomness object as keys and another dictionary as values identifying the saved state and the object methods to needed to manipulate random seeds and states.
  - This approach allows for deferred instantiation for randomness in interfaces, preventing the need to import interface modules on nimble instantiation.
- Moved Shogun randomness instantiation to Shogun Interface
  - Since shogun cannot use None as a random seed. There was a need to wrap the method used to set the seed. To accomplish this, the `_ShogunRandom` object was created to wrap shogun's randomness object. This approach was also applied in the Keras interface.
  - `_ShogunRandom` is not added to `_saved` until the Shogun interface will be used.

Added randomness control for Keras using Tensorflow2
- Tensorflow1 does not allow for reproducibility. Some new randomness support was added in 1.14 but the `set_seed` function that provides the reproducible result was not added until Tensorflow2. For this reason, a warning is issued that reproducibility cannot be guaranteed with Tensorflow1 and randomness control was only added for Tensorflow 2.
- The `_TensorFlowRandom` object in the keras interface is used to wrap Tensorflow2's random module so that we can use nimble randomness controls.


Notes:
- Was also getting other errors for getScores tests in universal_integration_test.py. This was from the `CategoricalNB` in scikit-learn which was failing because the data in testX did not contain the same categories as the trainX data. To adjust for this, the error is caught and the trainX data is used instead of testX to ensure that the categories align.  Also, made some updates to those tests to decrease code repetition.
- For Shogun and Keras, the random "state" is not really accessible. In Shogun, we can get the seed, but this will only serve to restart the randomness from its initial point, not the current state. In tensorflow, only `set_seed` allows for reproducibility, so while a state can be created, I don't believe this adjusts as random operations are applied so it has the same effect as Shogun. I don't see any other option in Shogun and have tried many things in tensorflow with no success. I do not think this is overly concerning since we primarily use the altered states of randomness in testing and is likely the best we can do at this point, but just wanted to mention it.