### PR TITLE
Update PythonSearcher and interface warning catching

### DIFF
--- a/nimble/core/interfaces/autoimpute_interface.py
+++ b/nimble/core/interfaces/autoimpute_interface.py
@@ -3,6 +3,7 @@ Interface to autoimpute package.
 """
 
 import types
+import logging
 
 import nimble
 from nimble.exceptions import InvalidArgumentValue
@@ -13,6 +14,7 @@ from .scikit_learn_interface import _SciKitLearnAPI
 from ._interface_helpers import modifyImportPathAndImport
 from ._interface_helpers import PythonSearcher
 
+logging.getLogger('theano.configdefaults').setLevel(logging.ERROR)
 
 @inheritDocstringsFactory(UniversalInterface)
 class Autoimpute(_SciKitLearnAPI, PredefinedInterface, UniversalInterface):
@@ -47,8 +49,7 @@ class Autoimpute(_SciKitLearnAPI, PredefinedInterface, UniversalInterface):
 
         self.randomParam = 'seed'
 
-        self._searcher = PythonSearcher(
-            self.autoimpute, self.autoimpute.__all__, {}, isLearner, 1)
+        self._searcher = PythonSearcher(self.autoimpute, isLearner, 1)
 
         super(Autoimpute, self).__init__()
 

--- a/nimble/core/interfaces/keras_interface.py
+++ b/nimble/core/interfaces/keras_interface.py
@@ -70,8 +70,7 @@ class Keras(PredefinedInterface, UniversalInterface):
 
             return True
 
-        self._searcher = PythonSearcher(self.keras, self.keras.__all__, {},
-                                        isLearner, 2)
+        self._searcher = PythonSearcher(self.keras, isLearner, 2)
 
         super(Keras, self).__init__()
 

--- a/nimble/core/interfaces/mlpy_interface.py
+++ b/nimble/core/interfaces/mlpy_interface.py
@@ -48,8 +48,7 @@ class Mlpy(PredefinedInterface, UniversalInterface):
                 return True
             return False
 
-        self._searcher = PythonSearcher(self.mlpy, dir(self.mlpy), {},
-                                        isLearner, 1)
+        self._searcher = PythonSearcher(self.mlpy, isLearner, 1)
 
         super(Mlpy, self).__init__()
 

--- a/nimble/core/interfaces/scikit_learn_interface.py
+++ b/nimble/core/interfaces/scikit_learn_interface.py
@@ -372,7 +372,8 @@ class SciKitLearn(_SciKitLearnAPI, PredefinedInterface, UniversalInterface):
             return ret
 
         with warnings.catch_warnings():
-            warnings.simplefilter('ignore', DeprecationWarning)
+            warnings.simplefilter('ignore', (DeprecationWarning,
+                                             FutureWarning))
             with mock.patch('pkgutil.walk_packages', mockWalkPackages):
                 try:
                     kwargs = {'include_dont_test': True}

--- a/nimble/core/interfaces/shogun_interface.py
+++ b/nimble/core/interfaces/shogun_interface.py
@@ -64,17 +64,17 @@ class Shogun(PredefinedInterface, UniversalInterface):
             # needs more to be able to distinguish between things that are
             # runnable and partial implementations. get_machine_problem_type()?
             try:
-                instantiated = obj()
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore', RuntimeWarning)
+                    instantiated = obj()
                 instantiated.get_machine_problem_type()
             except (SystemError, TypeError):
                 return False
 
             return True
 
-        self.hasAll = hasattr(self.shogun, '__all__')
-        contents = self.shogun.__all__ if self.hasAll else dir(self.shogun)
-        self._searcher = PythonSearcher(self.shogun, contents, {}, isLearner,
-                                        2)
+        self._hasAll = hasattr(self.shogun, '__all__')
+        self._searcher = PythonSearcher(self.shogun, isLearner, 2)
 
         super(Shogun, self).__init__()
 
@@ -89,7 +89,7 @@ class Shogun(PredefinedInterface, UniversalInterface):
         # If shogun has an __all__ attribute, it is in the old style of
         # organization, where things are separated into submodules. They need
         # to be loaded before access.
-        if self.hasAll:
+        if self._hasAll:
             if hasattr(self.shogun, module):
                 submod = getattr(self.shogun, module)
             else:


### PR DESCRIPTION
Updated `PythonSearcher` and individual interfaces to prevent warnings or potential unwanted import issues.

PythonSearcher
- Simplified `__init__` 
  - Removed `baseContents`. All interfaces use the backend package's `__all__` attribute when available or `dir(package)`. Rather than determine this within each interface, it's now determined by `PythonSearcher`'s new `_getContents` method.
  - Removed `specialCases` as it was not being utilized by any of the interfaces.
- `_findInPackageRecursive` modified to recurse only when an attribute is a module.
  - Previously, this function would unnecessarily traverse the `dir` of all attributes.
- Note: There was a comment stating that we wanted to store learners **and their parents** in `_locationCache`. We were only storing learners, but storing their parents seems unnecessary. If we stored the parents, we would be storing the submodule containing the learner, but we never search using a submodule as a parent so these would never be used. Our use of parent is when the parent is the learner object and we are searching it for parameters and default values.

Interfaces
- Added `FutureWarning` to warnings ignored for `scikit-learn`.
- Set logging level for `theano.configdefaults` used by `pymc3` dependency in `autoimpute` to prevent warnings it issues.
- Ignore `RuntimeWarning`s issued when instantiating certain `shogun` objects.
