### PR TITLE
Adjust getScores format tests to handle binary classifer exceptions

### DIFF
--- a/tests/interfaces/universal_integration_test.py
+++ b/tests/interfaces/universal_integration_test.py
@@ -53,7 +53,7 @@ def test__getScoresFormat():
     """
     for i in [2, 4]:
         data = generateClassificationData(i, 4, 3)
-        ((trainX, trainY), (testX, testY)) = data
+        ((trainX, trainY), (testX, _)) = data
         for interface in nimble.core.interfaces.available.values():
             interfaceName = interface.getCanonicalName()
 
@@ -67,6 +67,12 @@ def test__getScoresFormat():
                         # this is to catch learners that have required arguments.
                         # we have to skip them in that case
                         continue
+                    except ValueError as VE:
+                        # this will catch strictly binary classification
+                        # learners, and skip them when i == 4
+                        if i == 4:
+                            continue
+                        raise VE
                     (transTrainX, _, transTestX, _) = interface._inputTransformation(
                         lName, trainX, None, testX, {}, tl._customDict)
                     try:
@@ -92,7 +98,7 @@ def testGetScoresFormat():
     """
     for i in [2, 4]:
         data = generateClassificationData(i, 4, 2)
-        ((trainX, trainY), (testX, testY)) = data
+        ((trainX, trainY), (testX, _)) = data
         for interface in nimble.core.interfaces.available.values():
             interfaceName = interface.getCanonicalName()
             learners = interface.listLearners()
@@ -105,6 +111,13 @@ def testGetScoresFormat():
                         # this is to catch learners that have required arguments.
                         # we have to skip them in that case
                         continue
+                    except ValueError as VE:
+                        # this will catch strictly binary classification
+                        # learners, and skip them when i == 4
+                        if i == 4:
+                            continue
+                        raise VE
+
                     try:
                         scores = tl.getScores(testX)
                     except IndexError:


### PR DESCRIPTION
After the refactoring of `test__getScoresFormat` and `testGetScoresFormat` in PR291, the breadth of exception catching when training learners on multiclass classification data was tightened to be the same as when training on binary classification data. This meant that strict binary classifiers would raise exceptions in the `i == 4` case and cause the test to fail. I observed this problem with mlpy's golub classifier; after this change the tests now pass on my system in a variety of environments with different interface combinations.