### PR TITLE
learnerParameters as list not set

### DIFF
--- a/nimble/core/interfaces/universal_interface.py
+++ b/nimble/core/interfaces/universal_interface.py
@@ -611,8 +611,9 @@ class UniversalInterface(metaclass=abc.ABCMeta):
         ret = self._getParameterNamesBackend(name)
         if ret is not None:
             # Backend may contain duplicates but only one value can be assigned
-            # to a parameter so we use a set.
-            ret = [set(lst) for lst in ret]
+            # to a parameter so we use sets to remove duplicates and sorted
+            # to convert the sets back to lists with a consistent order
+            ret = [sorted(set(lst)) for lst in ret]
 
         return ret
 
@@ -634,8 +635,9 @@ class UniversalInterface(metaclass=abc.ABCMeta):
         ret = self._getLearnerParameterNamesBackend(learnerName)
         if ret is not None:
             # Backend may contain duplicates but only one value can be assigned
-            # to a parameter so we use a set.
-            ret = [set(lst) for lst in ret]
+            # to a parameter so we use sets to remove duplicates and sorted
+            # to convert the sets back to lists with a consistent order
+            ret = [sorted(set(lst)) for lst in ret]
 
         return ret
 

--- a/tests/interfaces/universal_integration_test.py
+++ b/tests/interfaces/universal_integration_test.py
@@ -432,20 +432,20 @@ def test_getParametersAndDefaultsReturnTypes():
 
             if params is not None:
                 assert isinstance(params, list)
-                assert all(isinstance(option, set) for option in params)
+                assert all(isinstance(option, list) for option in params)
                 assert isinstance(defaults, list)
                 assert all(isinstance(option, dict) for option in defaults)
 
             assert isinstance(learnerParams, list)
-            assert all(isinstance(option, set) for option in learnerParams)
+            assert all(isinstance(option, list) for option in learnerParams)
             assert isinstance(defaultParams, list)
             assert all(isinstance(option, dict) for option in defaultParams)
 
             # top-level will not be nested in list if only one item in list
-            if isinstance(paramsFromTop, list):
-                assert all(isinstance(option, set) for option in paramsFromTop)
-            else:
-                assert isinstance(paramsFromTop, set)
+            assert isinstance(paramsFromTop, list)
+            if len(learnerParams) > 1:
+                assert all(isinstance(option, list) for option in paramsFromTop)
+
             if isinstance(defaultsFromTop, list):
                 assert all(isinstance(option, dict) for option in defaultsFromTop)
             else:

--- a/tests/testCustomLearnerRegistration.py
+++ b/tests/testCustomLearnerRegistration.py
@@ -70,8 +70,8 @@ def testCustomPackage():
     assert 'LoveAtFirstSightClassifier' in nimble.listLearners("custom")
     assert 'UncallableLearner' in nimble.listLearners("custom")
 
-    assert nimble.learnerParameters("custom.LoveAtFirstSightClassifier") == set()
-    assert nimble.learnerParameters("custom.UncallableLearner") == {'foo', 'bar'}
+    assert nimble.learnerParameters("custom.LoveAtFirstSightClassifier") == []
+    assert nimble.learnerParameters("custom.UncallableLearner") == ['bar', 'foo']
 
 @configSafetyWrapper
 def testNimblePackage():
@@ -88,8 +88,8 @@ def testNimblePackage():
     assert 'RidgeRegression' in nimble.listLearners("nimble")
     assert 'KNNClassifier' in nimble.listLearners("nimble")
 
-    assert nimble.learnerParameters("nimble.RidgeRegression") == {'lamb'}
-    assert nimble.learnerParameters("nimble.KNNClassifier") == {'k'}
+    assert nimble.learnerParameters("nimble.RidgeRegression") == ['lamb']
+    assert nimble.learnerParameters("nimble.KNNClassifier") == ['k']
 
 
 # test that registering a sample custom learner with option names
@@ -173,7 +173,7 @@ def test_learnerQueries():
     lType = nimble.learnerType(UncallableLearner)
     lst = nimble.listLearners("custom")
 
-    assert params == {'foo', 'bar'}
+    assert params == ['bar', 'foo']
     assert defaults == {'bar': None}
     assert lType == 'classification'
     assert lst == ['UncallableLearner']
@@ -182,6 +182,6 @@ def test_learnerQueries():
     defaults = nimble.learnerDefaultValues(KNNClassifier)
     lType = nimble.learnerType(KNNClassifier)
 
-    assert params == {'k',}
+    assert params == ['k']
     assert defaults == {'k': 5}
     assert lType == 'classification'


### PR DESCRIPTION
Change `getLearnerParameterNames` and `_getParameterNames ` to use lists that do not contain duplicates instead of sets. The use of set to remove duplicates appears to be the fastert method for removing duplicates. `sorted()` was used to create the lists because `list(set(...))` does not consistently return the same list. This solves issues in testing and consistent output for users from these functions is probably preferable as well.