### PR TITLE
Axis calculate efficiency

### DIFF
--- a/nimble/core/data/list.py
+++ b/nimble/core/data/list.py
@@ -49,8 +49,7 @@ class List(Base):
 
     def __init__(self, data, featureNames=None, reuseData=False, shape=None,
                  checkAll=True, **kwds):
-        if (not (isinstance(data, list) or is2DArray(data))
-                and 'PassThrough' not in str(type(data))):
+        if not (isinstance(data, (list, ListPassThrough)) or is2DArray(data)):
             msg = "the input data can only be a list, a two-dimensional numpy "
             msg += "array, or ListPassThrough."
             raise InvalidArgumentType(msg)
@@ -74,7 +73,7 @@ class List(Base):
                 if shape is None:
                     shape = (1, len(data))
                 data = [data]
-            elif isinstance(data[0], list) or hasattr(data[0], 'setLimit'):
+            elif isinstance(data[0], (list, FeatureViewer)):
             #case3: data=[[1,2,3], ['a', 'b', 'c']] or [[]] or [[], []].
             # self.data will be = data, shape will be (len(data), len(data[0]))
             #case4: data=[FeatureViewer]
@@ -685,35 +684,31 @@ class ListView(BaseView, List):
             return listForm
 
     def _convertUnusableTypes(self, convertTo, usableTypes, returnCopy=True):
-        # We do not want to change the data attribute for ListView!
-        # This converts the data types of the source object's data attribute
-        # Note: Though this is a view object, we allow this modification since
-        # all the values remain equal and only the types change.
+        # need to override the Base level function because self.data is a
+        # ListPassThrough. If returnCopy, can return a list otherwise need to
+        # modify the self._source.data the ListPassThrough references
         try:
-            ret = self._source._convertUnusableTypes_implementation(
-                convertTo, usableTypes)
+            ret = self._convertUnusableTypes_implementation(convertTo,
+                                                            usableTypes)
         except (ValueError, TypeError):
             msg = 'Unable to coerce the data to the type required for this '
             msg += 'operation.'
             raise ImproperObjectAction(msg)
         if returnCopy:
             return ret
-        self._source.data = ret
+        pRange = slice(self._pStart, self._pEnd)
+        fRange = slice(self._fStart, self._fEnd)
+        for i, pt in enumerate(self._source.data[pRange]):
+            pt[fRange] = ret[i]
 
 class FeatureViewer(object):
     """
     View by feature axis for list.
     """
-    def __init__(self, source, fStart, fEnd):
+    def __init__(self, source, fStart, fEnd, pIndex):
         self.source = source
         self.fStart = fStart
         self.fRange = fEnd - fStart
-        self.limit = None
-
-    def setLimit(self, pIndex):
-        """
-        Limit to a given point in the feature.
-        """
         self.limit = pIndex
 
     def __getitem__(self, key):
@@ -731,8 +726,7 @@ class FeatureViewer(object):
     def __eq__(self, other):
         if len(self) != len(other):
             return False
-        for i, sVal in enumerate(self):
-            oVal = other[i]
+        for sVal, oVal in zip(self, other):
             # check element equality - which is only relevant if one
             # of the elements is non-NaN
             if sVal != oVal and (sVal == sVal or oVal == oVal):
@@ -755,15 +749,14 @@ class ListPassThrough(object):
         self.fEnd = fEnd
 
     def __getitem__(self, key):
-        self.fviewer = FeatureViewer(self.source, self.fStart,
-                                     self.fEnd)
         if key < 0 or key >= self.pRange:
             msg = "The given index " + str(key) + " is outside of the "
             msg += "range  of possible indices in the point axis (0 "
             msg += "to " + str(self.pRange - 1) + ")."
             raise IndexError(msg)
 
-        self.fviewer.setLimit(key + self.pStart)
+        self.fviewer = FeatureViewer(self.source, self.fStart,
+                                     self.fEnd, key + self.pStart)
         return self.fviewer
 
     def __len__(self):


### PR DESCRIPTION
Tested calculate for each data object type to identify whether a type-specific implementation was necessary.  Initial concern was that `SparseView` creation was more computationally expensive so it may require its own implementation. However, this is not the case. Below are the `timeit` results of a call to pointView.
```
List - 25.7 µs ± 891 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
Matrix - 12.8 µs ± 226 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
Sparse - 47.7 µs ± 1.51 µs per loop (mean ± std. dev. of 7 runs, 10000 loops each)
DataFrame - 207 µs ± 5.69 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

`timeit` results for `points/features.calculate` showed similar results except `List` was much slower. This was due to `_convertUnusableTypes`, that is reimplemented for `ListView`, checking and/or converting the entire source object types each time, rather than only the types of the source values included in the view. Limiting this to only the view values makes it competitive with the other data objects.
```
List Before: 16.7 s ± 30.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
List After: 512 ms ± 13.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

Matrix: 289 ms ± 8.65 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
Sparse: 562 ms ± 14.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
DataFrame: 990 ms ± 11 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

In `FeatureViewer`,  removed the `setLimit` method in favor of setting it during `__init__` and used `zip` over `enumerate` in `__eq__`.  In `List` `__init__`, used `isinstance` to streamline identifying `ListPassThrough` and `FeatureViewer`.