### PR TITLE
adjustments for failing tests

### DIFF
--- a/nimble/core/data/matrixAxis.py
+++ b/nimble/core/data/matrixAxis.py
@@ -55,9 +55,6 @@ class MatrixAxis(Axis):
             ret = self._base.data[:, targetList]
 
         if structure != 'copy':
-            if len(targetList) == 1:
-                targetList = targetList[0]
-            # numpy.delete can be faster by passing an integer when possible
             self._base.data = numpy.delete(self._base.data,
                                            targetList, axisVal)
 


### PR DESCRIPTION
Removed attempted speed improvement in `_structuralBackend_implementation` because it was causing an error in an `mlpy` test. This provided some improvement in `numpy.delete` when deleting a single feature, but the improvement is not so significant that it warrants being possibly unstable.

Account for `IndexError` in `testDataIntegrityTLApply`. For the tests in `testLearnDataIntegrity`, the `generateClassificationData` function generates features where the first half of the values are 0 and the second half are 1, then adds some small amount of noise to each value. Occassionally, this process creates a feature with all values less than 1 and if this feature is converted to integer values, as `sklearn.CategoricalNB` looks to do, the feature will contain all 0 values. If the test data then contains any 1 values in that feature an `IndexError` occurs. To account for this, the `IndexError` is caught and the data is transformed using `round` so that each feature definitely contains 0s and 1s.