### PR TITLE
query string updates

### DIFF
--- a/nimble/core/data/_dataHelpers.py
+++ b/nimble/core/data/_dataHelpers.py
@@ -852,88 +852,30 @@ def csvCommaFormat(name):
         return '"{0}"'.format(name)
     return name
 
-operatorDict = {'!=': operator.ne, '==': operator.eq, '=': operator.eq,
-                '<=': operator.le, '>=': operator.ge,
-                '<': operator.lt, '>': operator.gt}
+operatorDict = {'!=': operator.ne, '==': operator.eq, '<=': operator.le,
+                '>=': operator.ge, '<': operator.lt, '>': operator.gt}
 
-def isQueryString(value, startswithOperator=True):
+def elementQueryFunction(value):
     """
-    If a value is a query string, returns match object from re module if
-    so. startswithOperator denotes whether the operator is expected at
-    the beginning (excluding whitespace) of the string, ">=0", or if it
-    can be within the string, "ft0<1".
+    Convert the value to an element input function, if possible.
+
+    None is returned for all other cases as functions using this helper
+    vary in how they proceed when the value is not a query string.
     """
     if not isinstance(value, str):
-        return False
+        return None
 
-    pattern = r'==|=|!=|>=|>|<=|<'
-    if startswithOperator:
-        match = re.match(pattern, value.strip())
-    else:
-        match = re.search(pattern, value.strip())
-    return match if match else False
+    match = re.match(r'(==|!=|>=|>|<=|<)(.+)', value.strip())
+    if match:
+        func = operatorDict[match.group(1)]
+        matchVal = match.group(2).strip()
+        try:
+            matchVal = float(matchVal)
+        except ValueError:
+            pass
+        return lambda elem: func(elem, matchVal)
 
-def elementQueryFunction(match):
-    """
-    Convert a re module match object to an element input function.
-    """
-    func = operatorDict[match.string[:match.end()]]
-    matchVal = match.string[match.end():].strip()
-    try:
-        matchVal = float(matchVal)
-    except ValueError:
-        pass
-    return lambda elem: func(elem, matchVal)
-
-def axisQueryFunction(match, axis, nameChecker):
-    """
-    Convert a re module match object to an axis input function.
-    """
-    # to set in for loop
-    nameOfPtOrFt = None
-    valueOfPtOrFt = None
-    optrOperator = None
-
-    optr = match.string[match.start():match.end()]
-    targetList = match.string.split(optr)
-    #after splitting at the optr, list must have 2 items
-    if len(targetList) != 2:
-        msg = "the target({0}) is a ".format(match.string)
-        msg += "query string but there is an error"
-        raise InvalidArgumentValue(msg)
-    nameOfPtOrFt = targetList[0]
-    valueOfPtOrFt = targetList[1]
-    nameOfPtOrFt = nameOfPtOrFt.strip()
-    valueOfPtOrFt = valueOfPtOrFt.strip()
-
-    #when point, check if the feature exists or not
-    #when feature, check if the point exists or not
-    if not nameChecker(nameOfPtOrFt):
-        if axis == 'point':
-            offAxis = 'feature'
-        else:
-            offAxis = 'point'
-        msg = "the {0} ".format(offAxis)
-        msg += "'{0}' doesn't exist".format(nameOfPtOrFt)
-        raise InvalidArgumentValue(msg)
-
-    optrOperator = operatorDict[optr]
-    # convert valueOfPtOrFt from a string, if possible
-    try:
-        valueOfPtOrFt = float(valueOfPtOrFt)
-    except ValueError:
-        pass
-    #convert query string to a function
-    def target_f(vector):
-        return optrOperator(vector[nameOfPtOrFt], valueOfPtOrFt)
-
-    target_f.vectorized = True
-    target_f.nameOfPtOrFt = nameOfPtOrFt
-    target_f.valueOfPtOrFt = valueOfPtOrFt
-    target_f.optr = optrOperator
-    target = target_f
-
-    return target
+    return None
 
 def limitedTo2D(method):
     @wraps(method)

--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -40,7 +40,7 @@ from ._dataHelpers import createDataNoValidation
 from ._dataHelpers import csvCommaFormat
 from ._dataHelpers import validateElementFunction, wrapMatchFunctionFactory
 from ._dataHelpers import ElementIterator1D
-from ._dataHelpers import isQueryString, elementQueryFunction
+from ._dataHelpers import elementQueryFunction
 from ._dataHelpers import limitedTo2D
 from ._dataHelpers import pyplotRequired, plotOutput, plotFigureHandling
 from ._dataHelpers import plotUpdateAxisLimits, plotAxisLimits
@@ -936,11 +936,13 @@ class Base(object):
 
         Parameters
         ----------
-        toMatch
+        toMatch: value, function, query
             * value - elements equal to the value return True
-            * function - in the form of toMatch(elementValue) that
-              returns True, False, 0 or 1.
-            * str - a comparison operator and a value (i.e ">=0")
+            * function - accepts an element as its only argument and
+              returns a boolean value to indicate if the element is a
+              match
+            * query - string in the format 'OPERATOR VALUE' (i.e "< 10")
+              where OPERATOR can be ==, !=, <, >, <=, or >=
         points : point, list of points
             The subset of points to limit the matching to. If None,
             the matching will apply to all points.
@@ -994,9 +996,9 @@ class Base(object):
         """
         matchArg = toMatch # preserve toMatch in original state for log
         if not callable(matchArg):
-            query = isQueryString(matchArg)
-            if query:
-                func = elementQueryFunction(query)
+            query = elementQueryFunction(matchArg)
+            if query is not None:
+                func = query
             # if not a comparison string, element must equal matchArg
             else:
                 matchVal = matchArg
@@ -1100,12 +1102,12 @@ class Base(object):
 
         Parameters
         ----------
-        condition : function
-            function - may take two forms:
-            a) a function that accepts an element value as input and
-            will return True if it is to be counted
-            b) a filter function, as a string, containing a comparison
-            operator and a value
+        condition : function, query
+            * function - accepts an element as its only argument and
+              returns a boolean value to indicate if the element should
+              be counted
+            * query - string in the format 'OPERATOR VALUE' (i.e "< 10")
+              where OPERATOR can be ==, !=, <, >, <=, or >=
 
         Returns
         -------
@@ -1132,9 +1134,9 @@ class Base(object):
         >>> numLessThanOne
         20
         """
-        query = isQueryString(condition)
-        if query:
-            condition = elementQueryFunction(query)
+        query = elementQueryFunction(condition)
+        if query is not None:
+            condition = query
         elif not hasattr(condition, '__call__'):
             msg = 'condition can only be a function or string containing a '
             msg += 'comparison operator and a value'

--- a/nimble/core/data/features.py
+++ b/nimble/core/data/features.py
@@ -269,14 +269,16 @@ class Features(object):
 
         Parameters
         ----------
-        toCopy : identifier, list of identifiers, function
+        toCopy : identifier, list of identifiers, function, query
             * identifier - a name or index
             * list of identifiers - an iterable container of identifiers
-            * function - may take two forms:
-              a) a function that when given a feature will return True
-              if it is to be copied
-              b) a filter function, as a string, containing a comparison
-              operator between a point name and a value (i.e "pt1<10")
+            * function - accepts a feature as its only argument and
+              returns a boolean value to indicate if the feature should
+              be copied
+            * query - string in the format 'POINTNAME OPERATOR VALUE'
+              (i.e "pt1 < 10") where OPERATOR is ==, !=, <, >, <=, or >=
+              and is separated from the POINTNAME and VALUE by
+              whitespace characters
         start, end : identifier
             Parameters indicating range based copying. Begin the copying
             at the location of ``start``. Finish copying at the
@@ -350,7 +352,7 @@ class Features(object):
             pointNames={'a':0, 'b':1, 'c':2, 'd':3}
             featureNames={'1':0, '2':1}
             )
-        >>> strFunc = data.features.copy("a>=3")
+        >>> strFunc = data.features.copy("a >= 3")
         >>> strFunc
         Matrix(
             [[3 4]
@@ -407,14 +409,16 @@ class Features(object):
 
         Parameters
         ----------
-        toExtract : identifier, list of identifiers, function
+        toExtract : identifier, list of identifiers, function, query
             * identifier - a name or index
             * list of identifiers - an iterable container of identifiers
-            * function - may take two forms:
-              a) a function that when given a feature will return True
-              if it is to be extracted
-              b) a filter function, as a string, containing a comparison
-              operator between a point name and a value (i.e "pt1<10")
+            * function - accepts a feature as its only argument and
+              returns a boolean value to indicate if the feature should
+              be extracted
+            * query - string in the format 'POINTNAME OPERATOR VALUE'
+              (i.e "pt1 < 10") where OPERATOR is ==, !=, <, >, <=, or >=
+              and is separated from the POINTNAME and VALUE by
+              whitespace characters
         start, end : identifier
             Parameters indicating range based extraction. Begin the
             extraction at the location of ``start``. Finish extracting
@@ -511,7 +515,7 @@ class Features(object):
             featureNames={'a':0, 'b':1}
             )
 
-        Extract feature when the string filter function returns True.
+        Extract feature when the query string returns True.
 
         >>> data = nimble.identity('List', 3,
         ...                        featureNames=['a', 'b', 'c'],
@@ -611,14 +615,16 @@ class Features(object):
 
         Parameters
         ----------
-        toDelete : identifier, list of identifiers, function
+        toDelete : identifier, list of identifiers, function, query
             * identifier - a name or index
             * list of identifiers - an iterable container of identifiers
-            * function - may take two forms:
-              a) a function that when given a feature will return True
-              if it is to be extracted
-              b) a filter function, as a string, containing a comparison
-              operator between a point name and a value (i.e "pt1<10")
+            * function - accepts a feature as its only argument and
+              returns a boolean value to indicate if the feature should
+              be deleted
+            * query - string in the format 'POINTNAME OPERATOR VALUE'
+              (i.e "pt1 < 10") where OPERATOR is ==, !=, <, >, <=, or >=
+              and is separated from the POINTNAME and VALUE by
+              whitespace characters
         start, end : identifier
             Parameters indicating range based deletion. Begin the
             deletion at the location of ``start``. Finish deleting at
@@ -690,7 +696,7 @@ class Features(object):
             featureNames={'a':0, 'b':1}
             )
 
-        Delete feature when the string filter function returns True.
+        Delete feature when the query string returns True.
 
         >>> data = nimble.identity('List', 3,
         ...                        featureNames=['a', 'b', 'c'],
@@ -760,14 +766,16 @@ class Features(object):
 
         Parameters
         ----------
-        toRetain : identifier, list of identifiers, function
+        toRetain : identifier, list of identifiers, function, query
             * identifier - a name or index
             * list of identifiers - an iterable container of identifiers
-            * function - may take two forms:
-              a) a function that when given a feature will return True
-              if it is to be extracted
-              b) a filter function, as a string, containing a comparison
-              operator between a point name and a value (i.e "pt1<10")
+            * function - accepts a feature as its only argument and
+              returns a boolean value to indicate if the feature should
+              be retained
+            * query - string in the format 'POINTNAME OPERATOR VALUE'
+              (i.e "pt1 < 10") where OPERATOR is ==, !=, <, >, <=, or >=
+              and is separated from the POINTNAME and VALUE by
+              whitespace characters
         start, end : identifier
             Parameters indicating range based retention. Begin the
             retention at the location of ``start``. Finish retaining at
@@ -839,7 +847,7 @@ class Features(object):
             featureNames={'c':0}
             )
 
-        Retain feature when the string filter function returns True.
+        Retain feature when the query string returns True.
 
         >>> data = nimble.identity('List', 3,
         ...                        featureNames=['a', 'b', 'c'],
@@ -903,13 +911,14 @@ class Features(object):
 
         Parameters
         ----------
-        condition : function
-            May take two forms:
-
-            * a function that when given a feature will return True if
-              it is to be counted
-            * a filter function, as a string, containing a comparison
-              operator and a value (i.e "pt1<10")
+        condition : function, query
+            * function - accepts a feature as its only argument and
+              returns a boolean value to indicate if the feature should
+              be counted
+            * query - string in the format 'POINTNAME OPERATOR VALUE'
+              (i.e "pt1 < 10") where OPERATOR is ==, !=, <, >, <=, or >=
+              and is separated from the POINTNAME and VALUE by
+              whitespace characters
 
         Returns
         -------
@@ -929,7 +938,7 @@ class Features(object):
         >>> data.features.count(sumIsOne)
         3
 
-        Count when the string filter function returns True.
+        Count when the query string returns True.
 
         >>> data = nimble.identity('Matrix', 3,
         ...                        pointNames=['pt1', 'pt2', 'pt3'])

--- a/nimble/core/data/points.py
+++ b/nimble/core/data/points.py
@@ -265,14 +265,16 @@ class Points(object):
 
         Parameters
         ----------
-        toCopy : identifier, list of identifiers, function
+        toCopy : identifier, list of identifiers, function, query
             * identifier - a name or index
             * list of identifiers - an iterable container of identifiers
-            * function - may take two forms:
-              a) a function that when given a point will return True if
-              it is to be copied
-              b) a filter function, as a string, containing a comparison
-              operator between a feature name and a value (i.e "ft1<10")
+            * function - accepts a point as its only argument and
+              returns a boolean value to indicate if the point should
+              be copied
+            * query - string in the format 'FEATURENAME OPERATOR VALUE'
+              (i.e "ft1 < 10") where OPERATOR is ==, !=, <, >, <=, or >=
+              and is separated from the FEATURENAME and VALUE by
+              whitespace characters
         start, end : identifier
             Parameters indicating range based copying. Begin the copying
             at the location of ``start``. Finish copying at the
@@ -339,7 +341,7 @@ class Points(object):
             pointNames={'1':0, '2':1}
             featureNames={'a':0, 'b':1, 'c':2, 'd':3}
             )
-        >>> strFunc = data.points.copy("a>=3")
+        >>> strFunc = data.points.copy("a >= 3")
         >>> strFunc
         Matrix(
             [[3 3 3 3]
@@ -387,14 +389,16 @@ class Points(object):
 
         Parameters
         ----------
-        toExtract : identifier, list of identifiers, function
+        toExtract : identifier, list of identifiers, function, query
             * identifier - a name or index
             * list of identifiers - an iterable container of identifiers
-            * function - may take two forms:
-              a) a function that when given a point will return True if
-              it is to be extracted
-              b) a filter function, as a string, containing a comparison
-              operator between a feature name and a value (i.e "ft1<10")
+            * function - accepts a point as its only argument and
+              returns a boolean value to indicate if the point should
+              be extracted
+            * query - string in the format 'FEATURENAME OPERATOR VALUE'
+              (i.e "ft1 < 10") where OPERATOR is ==, !=, <, >, <=, or >=
+              and is separated from the FEATURENAME and VALUE by
+              whitespace characters
         start, end : identifier
             Parameters indicating range based extraction. Begin the
             extraction at the location of ``start``. Finish extracting
@@ -482,7 +486,7 @@ class Points(object):
             pointNames={'a':0, 'b':1}
             )
 
-        Extract point when the string filter function returns True.
+        Extract point when the query string returns True.
 
         >>> data = nimble.identity('Matrix', 3,
         ...                        pointNames=['a', 'b', 'c'],
@@ -568,14 +572,16 @@ class Points(object):
 
         Parameters
         ----------
-        toDelete : identifier, list of identifiers, function
+        toDelete : identifier, list of identifiers, function, query
             * identifier - a name or index
             * list of identifiers - an iterable container of identifiers
-            * function - may take two forms:
-              a) a function that when given a point will return True if
-              it is to be deleted
-              b) a filter function, as a string, containing a comparison
-              operator between a feature name and a value (i.e "ft1<10")
+            * function - accepts a point as its only argument and
+              returns a boolean value to indicate if the point should
+              be deleted
+            * query - string in the format 'FEATURENAME OPERATOR VALUE'
+              (i.e "ft1 < 10") where OPERATOR is ==, !=, <, >, <=, or >=
+              and is separated from the FEATURENAME and VALUE by
+              whitespace characters
         start, end : identifier
             Parameters indicating range based deletion. Begin the
             deletion at the location of ``start``. Finish deleting at
@@ -643,7 +649,7 @@ class Points(object):
             pointNames={'a':0, 'b':1}
             )
 
-        Delete point when the string filter function returns True.
+        Delete point when the query string returns True.
 
         >>> data = nimble.identity('Matrix', 3,
         ...                        pointNames=['a', 'b', 'c'],
@@ -705,14 +711,16 @@ class Points(object):
 
         Parameters
         ----------
-        toRetain : identifier, list of identifiers, function
+        toRetain : identifier, list of identifiers, function, query
             * identifier - a name or index
             * list of identifiers - an iterable container of identifiers
-            * function - may take two forms:
-              a) a function that when given a point will return True if
-              it is to be retained
-              b) a filter function, as a string, containing a comparison
-              operator between a feature name and a value (i.e "ft1<10")
+            * function - accepts a point as its only argument and
+              returns a boolean value to indicate if the point should
+              be retained
+            * query - string in the format 'FEATURENAME OPERATOR VALUE'
+              (i.e "ft1 < 10") where OPERATOR is ==, !=, <, >, <=, or >=
+              and is separated from the FEATURENAME and VALUE by
+              whitespace characters
         start, end : identifier
             Parameters indicating range based retention. Begin the
             retention at the location of ``start``. Finish retaining at
@@ -779,7 +787,7 @@ class Points(object):
             pointNames={'c':0}
             )
 
-        Retain point when the string filter function returns True.
+        Retain point when the query string returns True.
 
         >>> data = nimble.identity('Matrix', 3,
         ...                        pointNames=['a', 'b', 'c'],
@@ -838,13 +846,14 @@ class Points(object):
 
         Parameters
         ----------
-        condition : function
-            May take two forms:
-
-            * a function that when given a point will return True if
-              it is to be counted
-            * a filter function, as a string, containing a comparison
-              operator and a value (i.e "ft1<10")
+        condition : function, query
+            * function - accepts a point as its only argument and
+              returns a boolean value to indicate if the point should
+              be counted
+            * query - string in the format 'FEATURENAME OPERATOR VALUE'
+              (i.e "ft1 < 10") where OPERATOR is ==, !=, <, >, <=, or >=
+              and is separated from the FEATURENAME and VALUE by
+              whitespace characters
 
         Returns
         -------
@@ -864,7 +873,7 @@ class Points(object):
         >>> data.points.count(sumIsOne)
         3
 
-        Count when the string filter function returns True.
+        Count when the query string returns True.
 
         >>> data = nimble.identity('List', 3,
         ...                        featureNames=['ft1', 'ft2', 'ft3'])

--- a/tests/data/high_level_backend.py
+++ b/tests/data/high_level_backend.py
@@ -1177,7 +1177,7 @@ class HighLevelDataSafe(DataTestObject):
         ret = toTest.countElements('   >=   5   ')
         assert ret == 5
 
-        ret = toTest.countElements('=5')
+        ret = toTest.countElements('==5')
         assert ret == 1
 
         ret = toTest.countElements(lambda x: x % 2 == 1)
@@ -1189,8 +1189,9 @@ class HighLevelDataSafe(DataTestObject):
     @noLogEntryExpected
     def test_points_count(self):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-        toTest = self.constructor(data, pointNames=['one', 'two', 'three'], featureNames=['a', 'b', 'c'])
-        ret = toTest.points.count('b>=5')
+        toTest = self.constructor(data, pointNames=['one', 'two', 'three'],
+                                  featureNames=['a', 'b', 'c'])
+        ret = toTest.points.count('b >= 5')
         assert ret == 2
 
         ret = toTest.points.count(lambda x: x['b'] >= 5)
@@ -1202,8 +1203,9 @@ class HighLevelDataSafe(DataTestObject):
     @noLogEntryExpected
     def test_features_count(self):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-        toTest = self.constructor(data, pointNames=['one', 'two', 'three'], featureNames=['a', 'b', 'c'])
-        ret = toTest.features.count('two>=5')
+        toTest = self.constructor(data, pointNames=['one', 'two', 'three'],
+                                  featureNames=['a', 'b', 'c'])
+        ret = toTest.features.count('two >= 5')
         assert ret == 2
 
         ret = toTest.features.count(lambda x: x['two'] >= 5)
@@ -2094,16 +2096,11 @@ class HighLevelDataSafe(DataTestObject):
     def test_matchingElements_comparisonStringInput(self):
         raw = [[1, 2, 3], [-1, -2, -3], [0, 0, 0]]
         obj = self.constructor(raw)
-        ['==', '=', '!=', '>', '<', '>=', '<=']
+
         match1 = obj.matchingElements(lambda x: x == 0)
         match2 = obj.matchingElements('==0')
         ws1, ws2, ws3 = [' ' * numpy.random.randint(1, 5) for _ in range(3)]
         match3 = obj.matchingElements(ws1 + '==' + ws2 + '0' + ws3)
-        assert match1 == match2 == match3
-
-        match2 = obj.matchingElements('=0')
-        ws1, ws2, ws3 = [' ' * numpy.random.randint(1, 5) for _ in range(3)]
-        match3 = obj.matchingElements(ws1 + '=' + ws2 + '0' + ws3)
         assert match1 == match2 == match3
 
         match1 = obj.matchingElements(lambda x: x != 0)

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -28,6 +28,7 @@ from nimble import loadData
 from nimble.core.data import BaseView
 from nimble.core.data._dataHelpers import formatIfNeeded
 from nimble.core.data._dataHelpers import DEFAULT_PREFIX
+from nimble.core.data._dataHelpers import elementQueryFunction
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
 from nimble.exceptions import InvalidArgumentValueCombination
 from nimble.exceptions import ImproperObjectAction
@@ -36,6 +37,7 @@ from .baseObject import DataTestObject
 from tests.helpers import noLogEntryExpected, oneLogEntryExpected
 from tests.helpers import assertNoNamesGenerated
 from tests.helpers import CalledFunctionException, calledException
+from tests.helpers import assertExpectedException
 
 
 preserveName = "PreserveTestName"
@@ -3076,6 +3078,138 @@ class QueryBackend(DataTestObject):
         for retLine, expLine in zip(ret.split('\n'), expLines):
             assert retLine == expLine
 
+    ######################
+    # _axisQueryFunction #
+    ######################
+    def test__axisQueryFunction(self):
+        """tests both axes for the _axisQueryFunction helper"""
+
+        def constructObjAndGetAxis(axis, data, offAxisNames):
+            if axis == 'points':
+                obj = self.constructor(data, featureNames=offAxisNames)
+            else:
+                obj = self.constructor(numpy.array(data).T,
+                                       pointNames=offAxisNames)
+            return getattr(obj, axis)
+
+        def operatorAssertions(axisObj, query, optr):
+            equal = axisObj[0]
+            notEqual1 = axisObj[1]
+            notEqual2 = axisObj[2]
+
+            func = axisObj._axisQueryFunction(query)
+            if '=' in optr:
+                if '==' in optr:
+                    assert func(equal)
+                    assert not func(notEqual2)
+                    assert not func(notEqual1)
+                elif '!' in optr:
+                    assert not func(equal)
+                    assert func(notEqual2)
+                    assert func(notEqual1)
+                else:
+                    assert func(equal)
+            if '<' in optr:
+                assert func(notEqual2)
+                assert not func(notEqual1)
+            elif '>' in optr:
+                assert func(notEqual1)
+                assert not func(notEqual2)
+
+        for axis in ['points', 'features']:
+            # Success #
+            data = [[0, 1, 2], [3, 4, 5], [-1, -2, -3]]
+            offNames = ['one', 'two', 'three']
+            primaryAxis = constructObjAndGetAxis(axis, data, offNames)
+            for optr in [' == ', ' != ', ' < ', ' <= ', ' > ', ' >= ']:
+                query = 'one' + optr + '0'
+                operatorAssertions(primaryAxis, query, optr)
+
+            offNames = ['vec one', 'vec two', 'vec three']
+            primaryAxis = constructObjAndGetAxis(axis, data, offNames)
+            for optr in [' == ', ' != ', ' < ', ' <= ', ' > ', ' >= ']:
+                query = 'vec two' + optr + '1'
+                operatorAssertions(primaryAxis, query, optr)
+
+            offNames = ['<one>', '<two>', '<three>']
+            primaryAxis = constructObjAndGetAxis(axis, data, offNames)
+            for optr in [' == ', ' != ', ' < ', ' <= ', ' > ', ' >= ']:
+                query = '<three>' + optr + '2'
+                operatorAssertions(primaryAxis, query, optr)
+
+            data = [['a', 'a b', '>=2'], ['b', 'b c', '<2'], ['c', 'c d', '<2']]
+            offNames = ['one', 'two', 'three']
+            primaryAxis = constructObjAndGetAxis(axis, data, offNames)
+            for optr in [' == ', ' != ']:
+                query = 'one' + optr + 'a'
+                operatorAssertions(primaryAxis, query, optr)
+
+                query = 'two' + optr + 'a b'
+                operatorAssertions(primaryAxis, query, optr)
+
+                query = 'three' + optr + '>=2'
+                operatorAssertions(primaryAxis, query, optr)
+
+            offNames = ['vec one', 'vec two', 'vec three']
+            primaryAxis = constructObjAndGetAxis(axis, data, offNames)
+            for optr in [' == ', ' != ']:
+                query = 'vec one' + optr + 'a'
+                operatorAssertions(primaryAxis, query, optr)
+
+            offNames = ['<one>', '<two>', '<three>']
+            primaryAxis = constructObjAndGetAxis(axis, data, offNames)
+            for optr in [' == ', ' != ']:
+                query = '<one>' + optr + 'a'
+                operatorAssertions(primaryAxis, query, optr)
+
+                query = '<three>' + optr + '>=2'
+                operatorAssertions(primaryAxis, query, optr)
+
+            # Exceptions #
+            data = [[0, 1, 2], [3, 4, 5], [6, 7, 8]]
+            offNames = ['one', 'two', 'three']
+            primaryAxis = constructObjAndGetAxis(axis, data, offNames)
+            func = primaryAxis._axisQueryFunction
+            # bad whitespace padding on operator
+            assertExpectedException(InvalidArgumentValue, func,'one== 6',
+                                    messageIncludes='nor a valid query')
+            assertExpectedException(InvalidArgumentValue, func, 'two!=4',
+                                    messageIncludes='nor a valid query')
+            assertExpectedException(InvalidArgumentValue, func, 'three >7',
+                                    messageIncludes='nor a valid query')
+            # not a feature name
+            assertExpectedException(InvalidArgumentValue, func, 'four == 4',
+                                    messageIncludes='does not exist')
+            assertExpectedException(InvalidArgumentValue, func, ' == 4',
+                                    messageIncludes='does not exist')
+            # no operator
+            assertExpectedException(InvalidArgumentValue, func, 'two = 4',
+                                    messageIncludes='nor a valid query')
+            assertExpectedException(InvalidArgumentValue, func, 'hello',
+                                    messageIncludes='nor a valid query')
+
+            data = [[0, '> 250k', '== 2'], [3, '> 250k', '!= 2'], [6, '< 250k', '!= 2']]
+            offNames = ['one', 'two', 'three']
+            primaryAxis = constructObjAndGetAxis(axis, data, offNames)
+            func = primaryAxis._axisQueryFunction
+            # invalid query value
+            assertExpectedException(InvalidArgumentValue, func, 'two == > 250k',
+                                    messageIncludes='Multiple operators')
+            assertExpectedException(InvalidArgumentValue, func, 'three != == 2',
+                                    messageIncludes='Multiple operators')
+            # invalid query feature name
+            offNames = ['< one >', '< two >', '< three >']
+            primaryAxis = constructObjAndGetAxis(axis, data, offNames)
+            func = primaryAxis._axisQueryFunction
+            assertExpectedException(InvalidArgumentValue, func, '< one > < 4',
+                                    messageIncludes='Multiple operators')
+            assertExpectedException(InvalidArgumentValue, func, '< one > == 4',
+                                    messageIncludes='Multiple operators')
+            # invalid name and value
+            assertExpectedException(InvalidArgumentValue, func, '< two > == > 250k',
+                                    messageIncludes='Multiple operators')
+            assertExpectedException(InvalidArgumentValue, func, '< three > != == 2',
+                                    messageIncludes='Multiple operators')
 
 ###########
 # Helpers #
@@ -3166,3 +3300,77 @@ def checkToStringRet(ret, data, includeNames, maxWidth, maxHeight):
                     truncatedLen = len(fnames[cDataIndex]) - 3
                     fromIndexFname = fromIndexFname[:truncatedLen]
                 assert fromIndexFname == fnames[cDataIndex]
+
+
+def test_elementQueryFunction():
+    for optr in ['==', '!=', '<', '<=', '>', '>=']:
+        func1 = elementQueryFunction(optr + '0')
+        func2 = elementQueryFunction(optr + ' ' + '0')
+        if '=' in optr:
+            if '!' in optr:
+                assert not func1(0)
+                assert not func2(0)
+            else:
+                assert func1(0)
+                assert func2(0)
+        if '>' in optr:
+            assert func1(1)
+            assert func2(1)
+        if '<' in optr:
+            assert func1(-1)
+            assert func2(-1)
+
+        if optr in ['==', '!=']:
+            func3 = elementQueryFunction(optr + 'hi')
+            func4 = elementQueryFunction(optr + ' ' + 'hi')
+            if '!' in optr:
+                assert func3('hello')
+                assert not func3('hi')
+                assert func4('hello')
+                assert not func4('hi')
+            else:
+                assert func3('hi')
+                assert not func3('hello')
+                assert func4('hi')
+                assert not func4('hello')
+
+            func5 = elementQueryFunction(optr + 'hi hello')
+            func6 = elementQueryFunction(optr + ' ' + 'hi hello')
+            if '!' in optr:
+                assert func5('hello hi')
+                assert not func5('hi hello')
+                assert func6('hello hi')
+                assert not func6('hi hello')
+            else:
+                assert func5('hi hello')
+                assert not func5('hello hi')
+                assert func6('hi hello')
+                assert not func6('hello hi')
+
+        whitespace = ' ' * numpy.random.randint(3, 7)
+        query = whitespace + optr + whitespace + '0' + whitespace
+        func7 = elementQueryFunction(query)
+        if '=' in optr:
+            if '!' in optr:
+                assert not func7(0)
+            else:
+                assert func7(0)
+        if '>' in optr:
+            assert func7(1)
+        elif '<' in optr:
+            assert func7(-1)
+
+        if optr in ['==', '!=']:
+            query = whitespace + optr + whitespace + 'hi' + whitespace
+            func8 = elementQueryFunction(query)
+            if '!' in optr:
+                assert func8('hello')
+                assert not func8('hi')
+            else:
+                assert func8('hi')
+                assert not func8('hello')
+
+    # invalid query strings should return None
+    assert elementQueryFunction(lambda x: 5) is None
+    assert elementQueryFunction('=0') is None
+    assert elementQueryFunction('= 0') is None

--- a/tests/data/structure_backend.py
+++ b/tests/data/structure_backend.py
@@ -1110,98 +1110,11 @@ class StructureDataSafe(StructureShared):
         assert expectedRet.isIdentical(ret)
         assert expectedTest.isIdentical(toTest)
 
+
     def test_points_copy_handmadeString(self):
         featureNames = ["one", "two", "three"]
         pointNames = ['1', '4', '7']
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-
-        #test featureName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.copy('one=1')
-        expectedRet = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName==value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.copy('one==1')
-        expectedRet = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.copy('one<2')
-        expectedRet = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.copy('one<=1')
-        expectedRet = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.copy('one>4')
-        expectedRet = self.constructor([[7, 8, 9]], pointNames=pointNames[-1:], featureNames=featureNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.copy('one>=7')
-        expectedRet = self.constructor([[7, 8, 9]], pointNames=pointNames[-1:], featureNames=featureNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName!=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.copy('one!=4')
-        expectedRet = self.constructor([[1, 2, 3], [7, 8, 9]], pointNames=[pointNames[0], pointNames[-1]],
-                                       featureNames=featureNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back an empty
-        assert expectedTest.isIdentical(toTest)
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.copy('one<1')
-        expectedRet = self.constructor([], featureNames=featureNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back all data
-        assert expectedTest.isIdentical(toTest)
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.copy('one>0')
-        expectedRet = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-    def test_points_copy_handmadeStringWithOperatorWhitespace(self):
-        featureNames = ["one", "two", "three"]
-        pointNames = ['1', '4', '7']
-        data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-
-        #test featureName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.copy('one = 1')
-        expectedRet = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
 
         #test featureName==value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
@@ -1275,17 +1188,9 @@ class StructureDataSafe(StructureShared):
         pointNames = ['1', '4', '7']
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        #test featureName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.copy('feature one=1')
-        expectedRet = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
         #test featureName=value with operator whitespace
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.copy('feature one = 1')
+        ret = toTest.points.copy('feature one == 1')
         expectedRet = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
         expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         assert expectedRet.isIdentical(ret)
@@ -1309,7 +1214,55 @@ class StructureDataSafe(StructureShared):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.copy('four=1')
+        ret = toTest.points.copy('four == 1')
+
+    def test_points_copy_handmadeString_extraWhitespace(self):
+        featureNames = ["one", "two", "three"]
+        pointNames = ['1', '4', '7']
+        data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
+        ret = toTest.points.copy('    one   ==    1    ')
+        expectedRet = self.constructor([[1, 2, 3]], pointNames=pointNames[:1],
+                                       featureNames=featureNames)
+        expectedTest = self.constructor(data, pointNames=pointNames,
+                                        featureNames=featureNames)
+        assert expectedRet.isIdentical(ret)
+        assert expectedTest.isIdentical(toTest)
+
+    def test_points_copy_handmadeString_multipleOperators_success(self):
+        featureNames = ["one", "two", "<three>"]
+        pointNames = ['1', '4', '7']
+        data = [[1, 2, '<3'], [4, 5, '>3'], [7, 8, '=3']]
+
+        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
+        ret = toTest.points.copy('<three> == <3')
+        expectedRet = self.constructor([[1, 2, '<3']], pointNames=pointNames[:1],
+                                       featureNames=featureNames)
+        expectedTest = self.constructor(data, pointNames=pointNames,
+                                        featureNames=featureNames)
+        assert expectedRet.isIdentical(ret)
+        assert expectedTest.isIdentical(toTest)
+
+    @raises(InvalidArgumentValue)
+    def test_points_copy_handmadeString_multipleOperators_nameException(self):
+        featureNames = ["one", "two", "three >"]
+        pointNames = ['1', '4', '7']
+        data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
+
+        toTest = self.constructor(data, pointNames=pointNames,
+                                  featureNames=featureNames)
+        ret = toTest.points.copy('three > == 3')
+
+    @raises(InvalidArgumentValue)
+    def test_points_copy_handmadeString_multipleOperators_valueException(self):
+        featureNames = ["one", "two", "three"]
+        pointNames = ['1', '4', '7']
+        data = [[1, 2, '> 3'], [4, 5, '< 3'], [7, 8, '= 3']]
+
+        toTest = self.constructor(data, pointNames=pointNames,
+                                  featureNames=featureNames)
+        ret = toTest.points.copy('three == < 3')
 
     def test_points_copy_numberOnly(self):
         self.back_copy_numberOnly('point')
@@ -1915,92 +1868,7 @@ class StructureDataSafe(StructureShared):
         pointNames = ['p1', 'p2', 'p3']
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        #test pointName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.copy('p2=5')
-        expectedRet = self.constructor([[2], [5], [8]], pointNames=pointNames, featureNames=[featureNames[1]])
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName==value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.copy('p1==1')
-        expectedRet = self.constructor([[1], [4], [7]], pointNames=pointNames, featureNames=[featureNames[0]])
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.copy('p3<9')
-        expectedRet = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.copy('p3<=8')
-        expectedRet = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.copy('p3>8')
-        expectedRet = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.copy('p3>8.5')
-        expectedRet = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName!=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.copy('p1!=1.0')
-        expectedRet = self.constructor([[2, 3], [5, 6], [8, 9]], pointNames=pointNames, featureNames=featureNames[1:])
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back an empty
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.copy('p1<1')
-        expectedRet = self.constructor([], pointNames=pointNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back all data
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.copy('p1>0')
-        expectedRet = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-    def test_features_copy_handmadeStringWithOperatorWhitespace(self):
-        featureNames = ["one", "two", "three"]
-        pointNames = ['p1', 'p2', 'p3']
-        data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-
-        #test pointName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.copy('p2 = 5')
-        expectedRet = self.constructor([[2], [5], [8]], pointNames=pointNames, featureNames=[featureNames[1]])
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName==value
+        #test pointName==value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         ret = toTest.features.copy('p1 == 1')
         expectedRet = self.constructor([[1], [4], [7]], pointNames=pointNames, featureNames=[featureNames[0]])
@@ -2008,7 +1876,7 @@ class StructureDataSafe(StructureShared):
         assert expectedRet.isIdentical(ret)
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName<value
+        #test pointName<value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         ret = toTest.features.copy('p3 < 9')
         expectedRet = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
@@ -2016,7 +1884,7 @@ class StructureDataSafe(StructureShared):
         assert expectedRet.isIdentical(ret)
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName<=value
+        #test pointName<=value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         ret = toTest.features.copy('p3 <= 8')
         expectedRet = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
@@ -2024,7 +1892,7 @@ class StructureDataSafe(StructureShared):
         assert expectedRet.isIdentical(ret)
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName>value
+        #test pointName>value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         ret = toTest.features.copy('p3 > 8')
         expectedRet = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
@@ -2032,7 +1900,7 @@ class StructureDataSafe(StructureShared):
         assert expectedRet.isIdentical(ret)
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName>=value
+        #test pointName>=value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         ret = toTest.features.copy('p3 > 8.5')
         expectedRet = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
@@ -2040,7 +1908,7 @@ class StructureDataSafe(StructureShared):
         assert expectedRet.isIdentical(ret)
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName!=value
+        #test pointName!=value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         ret = toTest.features.copy('p1 != 1.0')
         expectedRet = self.constructor([[2, 3], [5, 6], [8, 9]], pointNames=pointNames, featureNames=featureNames[1:])
@@ -2048,7 +1916,7 @@ class StructureDataSafe(StructureShared):
         assert expectedRet.isIdentical(ret)
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName<value and return back an empty
+        #test pointName<value and return back an empty
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         ret = toTest.features.copy('p1 < 1')
         expectedRet = self.constructor([], pointNames=pointNames)
@@ -2056,7 +1924,7 @@ class StructureDataSafe(StructureShared):
         assert expectedRet.isIdentical(ret)
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName<value and return back all data
+        #test pointName<value and return back all data
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         ret = toTest.features.copy('p1 > 0')
         expectedRet = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
@@ -2069,17 +1937,9 @@ class StructureDataSafe(StructureShared):
         pointNames = ['pt 1', 'pt 2', 'pt 3']
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        #test pointName=value with no operator whitespace
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.copy('pt 2=5')
-        expectedRet = self.constructor([[2], [5], [8]], pointNames=pointNames, featureNames=[featureNames[1]])
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
         #test pointName=value with operator whitespace
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.copy('pt 2 = 5')
+        ret = toTest.features.copy('pt 2 == 5')
         expectedRet = self.constructor([[2], [5], [8]], pointNames=pointNames, featureNames=[featureNames[1]])
         expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         assert expectedRet.isIdentical(ret)
@@ -2103,7 +1963,7 @@ class StructureDataSafe(StructureShared):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.copy('5=1')
+        ret = toTest.features.copy('5 == 1')
 
     def test_features_copy_numberOnly(self):
         self.back_copy_numberOnly('feature')
@@ -4206,94 +4066,6 @@ class StructureModifying(StructureShared):
         pointNames = ['1', '4', '7']
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        #test featureName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.extract('one=1')
-        expectedRet = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-        expectedTest = self.constructor([[4, 5, 6], [7, 8, 9]], pointNames=pointNames[1:], featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName==value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.extract('one==1')
-        expectedRet = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-        expectedTest = self.constructor([[4, 5, 6], [7, 8, 9]], pointNames=pointNames[1:], featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.extract('one<2')
-        expectedRet = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-        expectedTest = self.constructor([[4, 5, 6], [7, 8, 9]], pointNames=pointNames[1:], featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.extract('one<=1')
-        expectedRet = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-        expectedTest = self.constructor([[4, 5, 6], [7, 8, 9]], pointNames=pointNames[1:], featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.extract('one>4')
-        expectedRet = self.constructor([[7, 8, 9]], pointNames=pointNames[-1:], featureNames=featureNames)
-        expectedTest = self.constructor([[1, 2, 3], [4, 5, 6]], pointNames=pointNames[:-1], featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.extract('one>=7')
-        expectedRet = self.constructor([[7, 8, 9]], pointNames=pointNames[-1:], featureNames=featureNames)
-        expectedTest = self.constructor([[1, 2, 3], [4, 5, 6]], pointNames=pointNames[:-1], featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName!=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.extract('one!=4')
-        expectedRet = self.constructor([[1, 2, 3], [7, 8, 9]], pointNames=[pointNames[0], pointNames[-1]],
-                                       featureNames=featureNames)
-        expectedTest = self.constructor([[4, 5, 6]], pointNames=[pointNames[1]], featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back an empty
-        assert expectedTest.isIdentical(toTest)
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.extract('one<1')
-        expectedRet = self.constructor([], featureNames=featureNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back all data
-        assert expectedTest.isIdentical(toTest)
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.extract('one>0')
-        expectedRet = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        expectedTest = self.constructor([], featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-    def test_points_extract_handmadeStringWithOperatorWhitespace(self):
-        featureNames = ["one", "two", "three"]
-        pointNames = ['1', '4', '7']
-        data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-
-        #test featureName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.extract('one = 1')
-        expectedRet = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-        expectedTest = self.constructor([[4, 5, 6], [7, 8, 9]], pointNames=pointNames[1:], featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
         #test featureName==value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         ret = toTest.points.extract('one == 1')
@@ -4366,17 +4138,9 @@ class StructureModifying(StructureShared):
         pointNames = ['1', '4', '7']
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        #test featureName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.extract('feature one=1')
-        expectedRet = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-        expectedTest = self.constructor([[4, 5, 6], [7, 8, 9]], pointNames=pointNames[1:], featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
         #test featureName=value with operator whitespace
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.extract('feature one = 1')
+        ret = toTest.points.extract('feature one == 1')
         expectedRet = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
         expectedTest = self.constructor([[4, 5, 6], [7, 8, 9]], pointNames=pointNames[1:], featureNames=featureNames)
         assert expectedRet.isIdentical(ret)
@@ -4400,7 +4164,7 @@ class StructureModifying(StructureShared):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.points.extract('four=1')
+        ret = toTest.points.extract('four == 1')
 
     def test_points_extract_numberOnly(self):
         self.back_extract_numberOnly('point')
@@ -5025,179 +4789,14 @@ class StructureModifying(StructureShared):
         assert expectedRet.isIdentical(ret)
         assert expectedTest.isIdentical(toTest)
 
-    def test_features_extract_handmadeString(self):
-        featureNames = ["one", "two", "three"]
-        pointNames = ['p1', 'p2', 'p3']
-        data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-
-        #test pointName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p2=5')
-        expectedRet = self.constructor([[2], [5], [8]], pointNames=pointNames, featureNames=[featureNames[1]])
-        expectedTest = self.constructor([[1, 3], [4, 6], [7, 9]], pointNames=pointNames,
-                                        featureNames=[featureNames[0], featureNames[-1]])
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName==value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p1==1')
-        expectedRet = self.constructor([[1], [4], [7]], pointNames=pointNames, featureNames=[featureNames[0]])
-        expectedTest = self.constructor([[2, 3], [5, 6], [8, 9]], pointNames=pointNames, featureNames=featureNames[1:])
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p3<9')
-        expectedRet = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
-        expectedTest = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p3<=8')
-        expectedRet = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
-        expectedTest = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p3>8')
-        expectedRet = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
-        expectedTest = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p3>8.5')
-        expectedRet = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
-        expectedTest = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName!=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p1!=1.0')
-        expectedRet = self.constructor([[2, 3], [5, 6], [8, 9]], pointNames=pointNames, featureNames=featureNames[1:])
-        expectedTest = self.constructor([[1], [4], [7]], pointNames=pointNames, featureNames=[featureNames[0]])
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back an empty
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p1<1')
-        expectedRet = self.constructor([], pointNames=pointNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back all data
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p1>0')
-        expectedRet = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        expectedTest = self.constructor([], pointNames=pointNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-    def test_features_extract_handmadeStringWithOperatorWhitespace(self):
-        featureNames = ["one", "two", "three"]
-        pointNames = ['p1', 'p2', 'p3']
-        data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-
-        #test pointName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p2 = 5')
-        expectedRet = self.constructor([[2], [5], [8]], pointNames=pointNames, featureNames=[featureNames[1]])
-        expectedTest = self.constructor([[1, 3], [4, 6], [7, 9]], pointNames=pointNames,
-                                        featureNames=[featureNames[0], featureNames[-1]])
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName==value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p1 == 1')
-        expectedRet = self.constructor([[1], [4], [7]], pointNames=pointNames, featureNames=[featureNames[0]])
-        expectedTest = self.constructor([[2, 3], [5, 6], [8, 9]], pointNames=pointNames, featureNames=featureNames[1:])
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p3 < 9')
-        expectedRet = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
-        expectedTest = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p3 <= 8')
-        expectedRet = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
-        expectedTest = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p3 > 8')
-        expectedRet = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
-        expectedTest = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p3 > 8.5')
-        expectedRet = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
-        expectedTest = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName!=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p1 != 1.0')
-        expectedRet = self.constructor([[2, 3], [5, 6], [8, 9]], pointNames=pointNames, featureNames=featureNames[1:])
-        expectedTest = self.constructor([[1], [4], [7]], pointNames=pointNames, featureNames=[featureNames[0]])
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back an empty
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p1 < 1')
-        expectedRet = self.constructor([], pointNames=pointNames)
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back all data
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('p1 > 0')
-        expectedRet = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        expectedTest = self.constructor([], pointNames=pointNames)
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
     def test_features_extract_handmadeStringWithPointWhitespace(self):
         featureNames = ["one", "two", "three"]
         pointNames = ['pt 1', 'pt 2', 'pt 3']
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        #test pointName=value with no operator whitespace
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('pt 2=5')
-        expectedRet = self.constructor([[2], [5], [8]], pointNames=pointNames, featureNames=[featureNames[1]])
-        expectedTest = self.constructor([[1, 3], [4, 6], [7, 9]], pointNames=pointNames,
-                                        featureNames=[featureNames[0], featureNames[-1]])
-        assert expectedRet.isIdentical(ret)
-        assert expectedTest.isIdentical(toTest)
-
         #test pointName=value with operator whitespace
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('pt 2 = 5')
+        ret = toTest.features.extract('pt 2 == 5')
         expectedRet = self.constructor([[2], [5], [8]], pointNames=pointNames, featureNames=[featureNames[1]])
         expectedTest = self.constructor([[1, 3], [4, 6], [7, 9]], pointNames=pointNames,
                                         featureNames=[featureNames[0], featureNames[-1]])
@@ -5222,7 +4821,7 @@ class StructureModifying(StructureShared):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        ret = toTest.features.extract('5=1')
+        ret = toTest.features.extract('5 == 1')
 
     def test_features_extract_numberOnly(self):
         self.back_extract_numberOnly('feature')
@@ -5628,73 +5227,6 @@ class StructureModifying(StructureShared):
         pointNames = ['1', '4', '7']
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        #test featureName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.delete('one=1')
-        expectedTest = self.constructor([[4, 5, 6], [7, 8, 9]], pointNames=pointNames[1:], featureNames=featureNames)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName==value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.delete('one==1')
-        expectedTest = self.constructor([[4, 5, 6], [7, 8, 9]], pointNames=pointNames[1:], featureNames=featureNames)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.delete('one<2')
-        expectedTest = self.constructor([[4, 5, 6], [7, 8, 9]], pointNames=pointNames[1:], featureNames=featureNames)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.delete('one<=1')
-        expectedTest = self.constructor([[4, 5, 6], [7, 8, 9]], pointNames=pointNames[1:], featureNames=featureNames)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.delete('one>4')
-        expectedTest = self.constructor([[1, 2, 3], [4, 5, 6]], pointNames=pointNames[:-1], featureNames=featureNames)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.delete('one>=7')
-        expectedTest = self.constructor([[1, 2, 3], [4, 5, 6]], pointNames=pointNames[:-1], featureNames=featureNames)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName!=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.delete('one!=4')
-        expectedTest = self.constructor([[4, 5, 6]], pointNames=[pointNames[1]], featureNames=featureNames)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back an empty
-        assert expectedTest.isIdentical(toTest)
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.delete('one<1')
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back all data
-        assert expectedTest.isIdentical(toTest)
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.delete('one>0')
-        expectedTest = self.constructor([], featureNames=featureNames)
-        assert expectedTest.isIdentical(toTest)
-
-    def test_points_delete_handmadeStringWithOperatorWhitespace(self):
-        featureNames = ["one", "two", "three"]
-        pointNames = ['1', '4', '7']
-        data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-
-        #test featureName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.delete('one = 1')
-        expectedTest = self.constructor([[4, 5, 6], [7, 8, 9]], pointNames=pointNames[1:], featureNames=featureNames)
-        assert expectedTest.isIdentical(toTest)
-
         #test featureName==value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.points.delete('one == 1')
@@ -5750,15 +5282,9 @@ class StructureModifying(StructureShared):
         pointNames = ['1', '4', '7']
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        #test featureName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.delete('feature one=1')
-        expectedTest = self.constructor([[4, 5, 6], [7, 8, 9]], pointNames=pointNames[1:], featureNames=featureNames)
-        assert expectedTest.isIdentical(toTest)
-
         #test featureName=value with operator whitespace
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.delete('feature one = 1')
+        toTest.points.delete('feature one == 1')
         expectedTest = self.constructor([[4, 5, 6], [7, 8, 9]], pointNames=pointNames[1:], featureNames=featureNames)
         assert expectedTest.isIdentical(toTest)
 
@@ -5778,7 +5304,7 @@ class StructureModifying(StructureShared):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.delete('four=1')
+        toTest.points.delete('four == 1')
 
     def test_points_delete_numberOnly(self):
         self.back_delete_numberOnly('point')
@@ -6306,86 +5832,19 @@ class StructureModifying(StructureShared):
         pointNames = ['p1', 'p2', 'p3']
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        #test pointName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.delete('p2=5')
-        expectedTest = self.constructor([[1, 3], [4, 6], [7, 9]], pointNames=pointNames,
-                                        featureNames=[featureNames[0], featureNames[-1]])
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName==value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.delete('p1==1')
-        expectedTest = self.constructor([[2, 3], [5, 6], [8, 9]], pointNames=pointNames, featureNames=featureNames[1:])
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.delete('p3<9')
-        expectedTest = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.delete('p3<=8')
-        expectedTest = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.delete('p3>8')
-        expectedTest = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.delete('p3>8.5')
-        expectedTest = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName!=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.delete('p1!=1.0')
-        expectedTest = self.constructor([[1], [4], [7]], pointNames=pointNames, featureNames=[featureNames[0]])
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back an empty
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.delete('p1<1')
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back all data
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.delete('p1>0')
-        expectedTest = self.constructor([[], [], []], pointNames=pointNames)
-        assert expectedTest.isIdentical(toTest)
-
-    def test_features_delete_handmadeStringWithOperatorWhitespace(self):
-        featureNames = ["one", "two", "three"]
-        pointNames = ['p1', 'p2', 'p3']
-        data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-
-        #test pointName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.delete('p2 = 5')
-        expectedTest = self.constructor([[1, 3], [4, 6], [7, 9]], pointNames=pointNames,
-                                        featureNames=[featureNames[0], featureNames[-1]])
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName==value
+        #test pointName==value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.features.delete('p1 == 1')
         expectedTest = self.constructor([[2, 3], [5, 6], [8, 9]], pointNames=pointNames, featureNames=featureNames[1:])
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName<value
+        #test pointName<value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.features.delete('p3 < 9')
         expectedTest = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName<=value
+        #test pointName<=value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.features.delete('p3 <= 8')
         expectedTest = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
@@ -6397,25 +5856,25 @@ class StructureModifying(StructureShared):
         expectedTest = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName>=value
+        #test pointName>=value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.features.delete('p3 > 8.5')
         expectedTest = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName!=value
+        #test pointName!=value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.features.delete('p1 != 1.0')
         expectedTest = self.constructor([[1], [4], [7]], pointNames=pointNames, featureNames=[featureNames[0]])
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName<value and return back an empty
+        #test pointName<value and return back an empty
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.features.delete('p1 < 1')
         expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName<value and return back all data
+        #test pointName<value and return back all data
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.features.delete('p1 > 0')
         expectedTest = self.constructor([[],[],[]], pointNames=pointNames)
@@ -6426,16 +5885,9 @@ class StructureModifying(StructureShared):
         pointNames = ['pt 1', 'pt 2', 'pt 3']
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        #test pointName=value with no operator whitespace
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.delete('pt 2=5')
-        expectedTest = self.constructor([[1, 3], [4, 6], [7, 9]], pointNames=pointNames,
-                                        featureNames=[featureNames[0], featureNames[-1]])
-        assert expectedTest.isIdentical(toTest)
-
         #test pointName=value with operator whitespace
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.delete('pt 2 = 5')
+        toTest.features.delete('pt 2 == 5')
         expectedTest = self.constructor([[1, 3], [4, 6], [7, 9]], pointNames=pointNames,
                                         featureNames=[featureNames[0], featureNames[-1]])
         assert expectedTest.isIdentical(toTest)
@@ -6456,7 +5908,7 @@ class StructureModifying(StructureShared):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.delete('5=1')
+        toTest.features.delete('5 == 1')
 
     def test_features_delete_numberOnly(self):
         self.back_delete_numberOnly('feature')
@@ -6871,84 +6323,6 @@ class StructureModifying(StructureShared):
         pointNames = ['1', '4', '7']
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        #test featureName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.retain('one=1')
-        expectedTest = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName==value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.retain('one==1')
-        expectedTest = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.retain('one<2')
-        expectedTest = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.retain('one<=1')
-        expectedTest = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.retain('one>4')
-        expectedTest = self.constructor([[7, 8, 9]], pointNames=pointNames[-1:], featureNames=featureNames)
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.retain('one>=7')
-        expectedTest = self.constructor([[7, 8, 9]], pointNames=pointNames[-1:], featureNames=featureNames)
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName!=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.retain('one!=4')
-        expectedTest = self.constructor([[1, 2, 3], [7, 8, 9]], pointNames=[pointNames[0], pointNames[-1]],
-                                       featureNames=featureNames)
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back an empty
-        assert expectedTest.isIdentical(toTest)
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.retain('one<1')
-        expectedTest = self.constructor([], featureNames=featureNames)
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back all data
-        assert expectedTest.isIdentical(toTest)
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.retain('one>0')
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-
-        assert expectedTest.isIdentical(toTest)
-
-    def test_points_retain_handmadeStringWithOperatorWhitespace(self):
-        featureNames = ["one", "two", "three"]
-        pointNames = ['1', '4', '7']
-        data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-
-        #test featureName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.retain('one = 1')
-        expectedTest = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-
-        assert expectedTest.isIdentical(toTest)
-
         #test featureName==value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.points.retain('one == 1')
@@ -7013,16 +6387,9 @@ class StructureModifying(StructureShared):
         pointNames = ['1', '4', '7']
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        #test featureName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.retain('feature one=1')
-        expectedTest = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
-
-        assert expectedTest.isIdentical(toTest)
-
         #test featureName=value with operator whitespace
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.retain('feature one = 1')
+        toTest.points.retain('feature one == 1')
         expectedTest = self.constructor([[1, 2, 3]], pointNames=pointNames[:1], featureNames=featureNames)
 
         assert expectedTest.isIdentical(toTest)
@@ -7034,7 +6401,7 @@ class StructureModifying(StructureShared):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.points.retain('four=1')
+        toTest.points.retain('four == 1')
 
     def test_points_retain_numberOnly(self):
         self.back_retain_numberOnly('point')
@@ -7587,131 +6954,56 @@ class StructureModifying(StructureShared):
         pointNames = ['p1', 'p2', 'p3']
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        #test pointName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.retain('p2=5')
-        expectedTest = self.constructor([[2], [5], [8]], pointNames=pointNames, featureNames=[featureNames[1]])
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName==value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.retain('p1==1')
-        expectedTest = self.constructor([[1], [4], [7]], pointNames=pointNames, featureNames=[featureNames[0]])
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.retain('p3<9')
-        expectedTest = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.retain('p3<=8')
-        expectedTest = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.retain('p3>8')
-        expectedTest = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName>=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.retain('p3>8.5')
-        expectedTest = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName!=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.retain('p1!=1.0')
-        expectedTest = self.constructor([[2, 3], [5, 6], [8, 9]], pointNames=pointNames, featureNames=featureNames[1:])
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back an empty
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.retain('p1<1')
-        expectedTest = self.constructor([[], [], []], pointNames=pointNames)
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName<value and return back all data
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.retain('p1>0')
-        expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-
-        assert expectedTest.isIdentical(toTest)
-
-    def test_features_retain_handmadeStringWithOperatorWhitespace(self):
-        featureNames = ["one", "two", "three"]
-        pointNames = ['p1', 'p2', 'p3']
-        data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
-
-        #test pointName=value
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.retain('p2 = 5')
-        expectedTest = self.constructor([[2], [5], [8]], pointNames=pointNames, featureNames=[featureNames[1]])
-
-        assert expectedTest.isIdentical(toTest)
-
-        #test featureName==value
+        #test pointName==value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.features.retain('p1 == 1')
         expectedTest = self.constructor([[1], [4], [7]], pointNames=pointNames, featureNames=[featureNames[0]])
 
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName<value
+        #test pointName<value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.features.retain('p3 < 9')
         expectedTest = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
 
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName<=value
+        #test pointName<=value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.features.retain('p3 <= 8')
         expectedTest = self.constructor([[1, 2], [4, 5], [7, 8]], pointNames=pointNames, featureNames=featureNames[:-1])
 
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName>value
+        #test pointName>value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.features.retain('p3 > 8')
         expectedTest = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
 
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName>=value
+        #test pointName>=value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.features.retain('p3 > 8.5')
         expectedTest = self.constructor([[3], [6], [9]], pointNames=pointNames, featureNames=[featureNames[-1]])
 
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName!=value
+        #test pointName!=value
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.features.retain('p1 != 1.0')
         expectedTest = self.constructor([[2, 3], [5, 6], [8, 9]], pointNames=pointNames, featureNames=featureNames[1:])
 
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName<value and return back an empty
+        #test pointName<value and return back an empty
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.features.retain('p1 < 1')
         expectedTest = self.constructor([[], [], []], pointNames=pointNames)
 
         assert expectedTest.isIdentical(toTest)
 
-        #test featureName<value and return back all data
+        #test pointName<value and return back all data
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
         toTest.features.retain('p1 > 0')
         expectedTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
@@ -7723,16 +7015,9 @@ class StructureModifying(StructureShared):
         pointNames = ['pt 1', 'pt 2', 'pt 3']
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        #test pointName=value with no operator whitespace
-        toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.retain('pt 2=5')
-        expectedTest = self.constructor([[2], [5], [8]], pointNames=pointNames, featureNames=[featureNames[1]])
-
-        assert expectedTest.isIdentical(toTest)
-
         #test pointName=value with operator whitespace
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.retain('pt 2 = 5')
+        toTest.features.retain('pt 2 == 5')
         expectedTest = self.constructor([[2], [5], [8]], pointNames=pointNames, featureNames=[featureNames[1]])
 
         assert expectedTest.isIdentical(toTest)
@@ -7744,7 +7029,7 @@ class StructureModifying(StructureShared):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
         toTest = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-        toTest.features.retain('5=1')
+        toTest.features.retain('5 == 1')
 
     def test_features_retain_numberOnly(self):
         self.back_retain_numberOnly('feature')

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -143,3 +143,19 @@ def generateRegressionData(labels, pointsPer, featuresPer):
         addLabelColumn=False)
 
     return ((regressorTrainData, trainLabels), (regressorTestData, testLabels))
+
+def assertExpectedException(exception, func, *args, messageIncludes=None,
+                            **kwargs):
+    """
+    Assert that a given exception is raised when a function is called.
+
+    Optionally can include an exception message or portion of an
+    exception message to validate that the exception raised includes
+    the correct message.
+    """
+    try:
+        func(*args, **kwargs)
+        assert False
+    except exception as e:
+        if messageIncludes is not None:
+            assert messageIncludes in str(e)


### PR DESCRIPTION
Removed `=` as an operator option within a query string and enforced whitespace padded operators for axis-wise queries.

The accepted strings for `elementQueryFunction` have not changed. As long as the first non-whitespace characters match an accepted operator, the string is deemed to be a valid query string. `'==<0'`, for example, will look for values equal to `'<0'`. Values are always converted to numeric when possible.

The accepted strings for `_axisQueryFunction` have changed. The string must be in the order VARIABLE OPERATOR VALUE, with the operator padded by at least one whitespace character and only one whitespace padded operator may exist in the entire string. `'Age == >80'` is acceptable because the operator is unambiguous while `'Age == > 80'` is not accepted. Values are always converted to numeric when possible.

Removed `isQueryString` helper and modified `elementQueryFunction` and `_axisQueryFunction` to include that validation. `_axisQueryFunction` helper is now a method of Axis to allow it access to the object attributes. Tests for these helpers have been added to tests/data/query_backend.py.

Documentation has been updated and all tests previously using single equal sign or unpadded operators have been modified.

Added new tests helper `assertExpectedException`. This helper applies a commonly used test where a failure should occur if the function call is successful. It optionally analyzes the exception message to further validate that the exception was not only the correct type, but that the expected message was displayed. This was a helpful addition for these functions as the same exception type occurs in all situations, but the exception messages are designed to be more case-specific. In addition to reducing duplication, in the past there have been similar tests that have forgotten to add the `assert False` after a successful function call so it is safer to use this helper.