### PR TITLE
object for training functions parameter validation

### DIFF
--- a/nimble/_utility.py
+++ b/nimble/_utility.py
@@ -68,14 +68,14 @@ def mergeArguments(argumentsParam, kwargsParam):
     throw an exception if the two inputs have contradictory values for
     the same key.
     """
+    if not (argumentsParam or kwargsParam):
+        return {}
+    if not argumentsParam:
+        return kwargsParam.copy()
+    if not kwargsParam:
+        return argumentsParam.copy()
+
     ret = {}
-    if argumentsParam is None:
-        argumentsParam = {}
-    # UniversalInterface uses this helper to merge params a little differently,
-    # arguments (which might be None) is passed as kwargsParam so in that case
-    # we need to set kwargsParam to {}.
-    if kwargsParam is None:
-        kwargsParam = {}
     if len(argumentsParam) < len(kwargsParam):
         smaller = argumentsParam
         larger = kwargsParam

--- a/tests/test_train_apply_test_frontends.py
+++ b/tests/test_train_apply_test_frontends.py
@@ -174,7 +174,7 @@ def test_TrainedLearnerApply_pointNamePreservation():
                        matchTestPoints=False)
 
     exp2 = nimble.data('Matrix', [0])
-    
+
     out2 = tl2.apply(testObjData)
     assert out2 == exp2
 
@@ -713,7 +713,7 @@ def test_trainAndTestOnTrainingData_logCount_withCV_noDeep():
     back_logCount(wrapped)
 
 @raises(CalledFunctionException)
-@mock.patch('nimble.core.interfaces.TrainedLearner._validTestData', calledException)
+@mock.patch('nimble.core.interfaces.TrainedLearner._validTestDataShape', calledException)
 def test_trainAndApply_testXValidation():
     variables = ["x1", "x2", "x3", "label"]
     numPoints = 20
@@ -733,7 +733,7 @@ def test_trainAndApply_testXValidation():
     out = nimble.trainAndApply(learner, trainObj, 3, testObjNoLabels)
 
 @raises(CalledFunctionException)
-@mock.patch('nimble.core.interfaces.TrainedLearner._validTestData', calledException)
+@mock.patch('nimble.core.interfaces.TrainedLearner._validTestDataShape', calledException)
 def test_trainAndTest_testXValidation():
     variables = ["x1", "x2", "x3", "label"]
     numPoints = 20
@@ -756,7 +756,7 @@ def test_trainAndTest_testXValidation():
                               testObjLabels, perfFunc)
 
 @raises(CalledFunctionException)
-@mock.patch('nimble.core.interfaces.TrainedLearner._validTestData', calledException)
+@mock.patch('nimble.core.interfaces.TrainedLearner._validTestDataShape', calledException)
 def test_TL_apply_testXValidation():
     variables = ["x1", "x2", "x3", "label"]
     numPoints = 20
@@ -777,7 +777,7 @@ def test_TL_apply_testXValidation():
     out = tl.apply(testObjNoLabels)
 
 @raises(CalledFunctionException)
-@mock.patch('nimble.core.interfaces.TrainedLearner._validTestData', calledException)
+@mock.patch('nimble.core.interfaces.TrainedLearner._validTestDataShape', calledException)
 def test_TL_test_testXValidation():
     variables = ["x1", "x2", "x3", "label"]
     numPoints = 20
@@ -800,7 +800,7 @@ def test_TL_test_testXValidation():
     out = tl.test(testObjData, testObjLabels, perfFunc)
 
 @raises(CalledFunctionException)
-@mock.patch('nimble.core.interfaces.TrainedLearner._validTestData', calledException)
+@mock.patch('nimble.core.interfaces.TrainedLearner._validTestDataShape', calledException)
 def test_TL_getScores_testXValidation():
     variables = ["x1", "x2", "x3", "label"]
     numPoints = 20
@@ -820,7 +820,7 @@ def test_TL_getScores_testXValidation():
     # Expected outcomes
     # trainY is ID, testX does not contain labels; test int
     tl = nimble.train(learner, trainObj, trainObjLabels)
-    out = tl.getScores(testObjData, testObjLabels)
+    out = tl.getScores(testObjData)
 
 
 def test_trainAndTestOneVsOne():


### PR DESCRIPTION
Remove parameter validation tracking parameters from nimble.train by using the new `TrainValidator` object.

Eliminates `doneValidData`, `doneValidArguments1`, `doneValidArguments2`, `doneValidMultiClassStrategy`, `done2dOutputFlagCheck` and `storeLog` parameters from the `nimble.train` signature. Instead, these are managed by passing a `TrainValidator` instance through the `useLog` parameter.

When functions identify that `useLog` is a `TrainValidator`, it signals that this call was made internally by another nimble function, not the user. The `TrainValidator` records which validations have already been performed since the instantiation of the object, so completed validations are not repeated in the current function unnecessarily. This eliminates the need for the `done*` parameters. Additionally, the `useLog` value is stored in the `TrainValidator` for top-level functions to eliminate the `storeLog` parameter while still providing `nimble.train` access to the user-provided `useLog` parameter to use during cross-validation.

This object has also been incorporated into some `TrainedLearner` methods to prevent repeat validation there as well. For these methods, cross-validation is not allowed so new `TrainValidator` instances do not require instantiation with a `useLog` value.

The former helper functions `_validData`, `_validArguments`, `_validScoreMode`, `_validMulticlassStrategy`, and `_2dOutputFlagCheck` were moved into `TrainValidator` to create the validation methods with some small changes. 
`_validData` was split into two methods, `validateTrainData` and `validateTestData`. This helps support validation in `TrainedLearner` methods where train data is not a part of the provided parameters. `validateArguments` does not validate `kwarguments` because `kwarguments` is always a `dict` so the validation is not necessary.  `mergeArguments` was also modified to more quickly handle cases when one or both of the parameters are None or empty.