### PR TITLE
conda recipe and error fixes from new installs

### DIFF
--- a/conda_recipe/bld.bat
+++ b/conda_recipe/bld.bat
@@ -1,0 +1,2 @@
+"%PYTHON%" setup.py install
+if errorlevel 1 exit 1

--- a/conda_recipe/build.sh
+++ b/conda_recipe/build.sh
@@ -1,0 +1,1 @@
+$PYTHON setup.py install     # Python command to install the script.

--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -1,0 +1,28 @@
+package:
+  name: nimble
+  version: "0.0.0.dev1"
+
+source:
+  path: ../
+
+build:
+  number: 0
+
+
+requirements:
+  build:
+    - python
+    - setuptools
+    - numpy
+    - cython
+
+  run:
+    - python
+    - numpy
+
+test:
+  imports:
+    - nimble
+
+about:
+  home: https://github.com/willfind/nimble

--- a/nimble/core/data/_dataHelpers.py
+++ b/nimble/core/data/_dataHelpers.py
@@ -865,7 +865,11 @@ def elementQueryFunction(value):
             matchVal = float(matchVal)
         except ValueError:
             pass
-        return lambda elem: func(elem, matchVal)
+
+        def elementQuery(elem):
+            return func(elem, matchVal)
+
+        return elementQuery
 
     return None
 

--- a/nimble/core/interfaces/scikit_learn_interface.py
+++ b/nimble/core/interfaces/scikit_learn_interface.py
@@ -314,7 +314,7 @@ class _SciKitLearnAPI(PredefinedInterface):
         pass
 
     @abc.abstractmethod
-    def _initLearner(self, learnerName, trainX, trainY, arguments):
+    def _initLearner(self, learnerName, trainX, trainY, arguments, randomSeed):
         pass
 
     @abc.abstractmethod

--- a/tests/interfaces/autoimpute_interface_test.py
+++ b/tests/interfaces/autoimpute_interface_test.py
@@ -157,13 +157,21 @@ def test_autoimpute_MiLogisticRegression_directMultipleImputer():
         trainX, trainY, testX, testY = data.trainAndTestSets(0.25, labels='y')
         # test data cannot have missing values
         testX.features.fillMatching(fill.mean, match.missing)
-        fc = nimble.trainAndTest('autoimpute.MiLogisticRegression', trainX,
-                                 trainY, testX, testY, fractionCorrect,
-                                 model_lib='sklearn',
-                                 mi=nimble.Init('MultipleImputer', n=1,
-                                            strategy='interpolate'))
+        trainArgs = ['autoimpute.MiLogisticRegression', trainX, trainY, testX,
+                     testY, fractionCorrect,]
+        try:
+            fc = nimble.trainAndTest(*trainArgs, model_lib='sklearn',
+                                     mi=nimble.Init('MultipleImputer', n=1,
+                                                strategy='interpolate'))
+            imputer = 'autoimpute.MultipleImputer'
+        # learners in version >=0.12 require MiceImputer
+        except ValueError:
+            fc = nimble.trainAndTest(*trainArgs, model_lib='sklearn',
+                                     mi=nimble.Init('MiceImputer', n=1,
+                                                strategy='interpolate'))
+            imputer = 'autoimpute.MiceImputer'
 
-        nimble.fillMatching('autoimpute.MultipleImputer', match.missing, trainX,
+        nimble.fillMatching(imputer, match.missing, trainX,
                             n=1, strategy='interpolate')
 
         exp = nimble.trainAndTest('skl.LogisticRegression', trainX, trainY,

--- a/tests/interfaces/scikit_learn_interface_test.py
+++ b/tests/interfaces/scikit_learn_interface_test.py
@@ -321,7 +321,6 @@ def testSciKitLearnRegressionLearners():
         skl = nimble.core._learnHelpers.findBestInterface('scikitlearn')
         sklObj = skl.findCallable(learner)
         sciKitLearnObj = sklObj()
-        seed = _generateSubsidiarySeed()
         arguments = setupSKLArguments(sciKitLearnObj)
         sciKitLearnObj.fit(Xtrain, Ytrain)
         predSKL = sciKitLearnObj.predict(Xtest)
@@ -347,9 +346,9 @@ def testSciKitLearnMultiTaskRegressionLearners():
 
     skl = nimble.core._learnHelpers.findBestInterface('scikitlearn')
 
-    trainX = [[0,0], [1, 1], [2, 2], [0,0], [1, 1], [2, 2]]
+    trainX = [[0., 0.], [1., 1.], [2., 2.], [0., 0.], [1., 1.], [2., 2.]]
     trainY = [[0, 0], [1, 1], [2, 2], [0, 0], [1, 1], [2, 2]]
-    testX = [[2,2], [0,0], [1,1]]
+    testX = [[2., 2.], [0., 0.], [1., 1.]]
 
     trainXObj = nimble.data('Matrix', trainX, useLog=False)
     trainYObj = nimble.data('Matrix', trainY, useLog=False)
@@ -363,12 +362,16 @@ def testSciKitLearnMultiTaskRegressionLearners():
     def compareOutputs(learner):
         sklObj = skl.findCallable(learner)
         sciKitLearnObj = sklObj()
+        arguments = setupSKLArguments(sciKitLearnObj)
         sciKitLearnObj.fit(trainX, trainY)
         predictionSciKit = sciKitLearnObj.predict(testX)
         # convert to nimble Base object for comparison
-        predictionSciKit = nimble.data('Matrix', predictionSciKit, useLog=False)
+        predictionSciKit = nimble.data('Matrix', predictionSciKit,
+                                       useLog=False)
 
-        TL = nimble.train(toCall(learner), trainXObj, trainYObj)
+        seed = adjustRandomParamForNimble(arguments)
+        TL = nimble.train(toCall(learner), trainXObj, trainYObj,
+                          randomSeed=seed)
         predNimble = TL.apply(testXObj)
         predSL = _apply_saveLoad(TL, testXObj)
 


### PR DESCRIPTION
Removed use of `bdist_conda` in favor of using a conda recipe. Conda packages are now built using `conda-build conda_recipe` 

`dateutil` is installed by pip as `python-dateutil` so extras_require needs to use that to properly install.

When running the test suite in an environment with nimble that includes the extensions from Cython, using a lambda function in `elementQueryFunction` prohibited `inspect` from reading the signature because it was a Cython lambda function. Changing this to a standard function fixed this issue.

The latest version of autoimpute `0.12`, introduces a new object which is expected to be used with its learners. The testing was changed to use this object if using the object allowed for previous versions fails.

Scikit-learn version `0.21` has a strange bug which gave a different output between a direct use of the `MultiTaskElasticNetCV` learner and using it through nimble. In the test we fit the sklearn learner with a list, but in nimble it is fit with a numpy array. In version 0.21, a numpy array with an `int` dtype is generating a different output than the list. This is a bug  on sklearn's end and is isolated to only version 0.21, but changing the trainX data allows the test to pass across all versions.

Installing `tensorflow` or `keras` through conda appears to install an additional, hidden, package `tensorflow_core` that is somehow linked to tensorflow.  This caused an issue when testing the hierarchy for loading modules. I am not sure how this works exactly but reloading tensorflow, then reloading tensorflow.keras causes `ImportError: module tensorflow_core.keras not in sys.modules`. Manually deleting the module and re-importing works around this issue. 