### PR TITLE
Correct DataFrameAxis transform to handle nimble object returns

### DIFF
--- a/nimble/core/data/dataframeAxis.py
+++ b/nimble/core/data/dataframeAxis.py
@@ -10,6 +10,7 @@ import numpy
 import nimble
 from nimble._utility import pd
 from .axis import Axis
+from .base import Base
 from .views import AxisView
 from .points import Points
 from .views import PointsView
@@ -158,6 +159,11 @@ class DataFramePoints(DataFrameAxis, Points):
             if limitTo is not None and i not in limitTo:
                 continue
             currRet = function(pt)
+
+            # Some versions of pandas require 1-d inputs, and fail when
+            # given nimble objects or 2d arrays
+            if isinstance(currRet, Base):
+                currRet = currRet.copy("numpyarray", outputAs1D=True)
 
             self._base._data.iloc[i, :] = currRet
 


### PR DESCRIPTION
For some pandas versions there are errors relating to the type and shape of assignment via iloc, which was guaranteed to occur due to how some other methods were using transform as a backend. Now, if a nimble object return value is encountered, it is copied to a flattened numpy array.

This error was observed with pandas version 0.25.3