### PR TITLE
linter adjustments and linter up to date

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -143,7 +143,8 @@ disable=print-statement,
         comprehension-escape,
         useless-object-inheritance,
         protected-access,
-        protected-member
+        protected-member,
+        comparison-with-itself
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/documentation/source/examples/outputs/traffic_train_output.txt
+++ b/documentation/source/examples/outputs/traffic_train_output.txt
@@ -1,8 +1,8 @@
-REGEX: sklearn.LinearRegression root mean square error: 1795\.[0-9]+
-REGEX: sklearn.Ridge root mean square error: 1795\.[0-9]+
-REGEX: sklearn.Lasso root mean square error: 1795\.[0-9]+
-REGEX: sklearn.KNeighborsRegressor root mean square error: 799\.[0-9]+
-REGEX: sklearn.RandomForestRegressor root mean square error: 32[0-9]\.[0-9]+
+REGEX: sklearn.LinearRegression root mean square error: 1[78][0-9]{2}\.[0-9]+
+REGEX: sklearn.Ridge root mean square error: 1[78][0-9]{2}\.[0-9]+
+REGEX: sklearn.Lasso root mean square error: 1[78][0-9]{2}\.[0-9]+
+REGEX: sklearn.KNeighborsRegressor root mean square error: [78][0-9]{2}\.[0-9]+
+REGEX: sklearn.RandomForestRegressor root mean square error: 3[1-5][0-9]\.[0-9]+
 REGEX: \{'n_neighbors': 1, 'rootMeanSquareError': 10[0-9]{2}\.[0-9]+\}
 REGEX: \{'n_neighbors': 5, 'rootMeanSquareError': 89[0-9]\.[0-9]+\}
 REGEX: \{'n_neighbors': 11, 'rootMeanSquareError': 9[0-9]{2}\.[0-9]+\}

--- a/nimble/_utility.py
+++ b/nimble/_utility.py
@@ -274,7 +274,7 @@ def isAllowedSingleElement(x):
         return False
 
     #None and np.NaN are allowed
-    if x is None or x != x: # pylint: disable=comparison-with-itself
+    if x is None or x != x:
         return True
 
     return False

--- a/nimble/core/_learnHelpers.py
+++ b/nimble/core/_learnHelpers.py
@@ -444,6 +444,53 @@ def sumAbsoluteDifference(dataOne, dataTwo):
     return sumAbsoluteDifferences
 
 
+def _regressorDataset():
+    """
+    Generates clustered points, where the labels of the points
+    within a single cluster are all very similar, but non-identical.
+    """
+
+    clusterCount = 3
+    pointsPer = 10
+    featuresPer = 5
+
+    #add noise to both the features and the labels
+    regressorTrainData, trainLabels, noiselessTrainLabels = (
+        generateClusteredPoints(clusterCount, pointsPer, featuresPer,
+                                addFeatureNoise=True, addLabelNoise=True,
+                                addLabelColumn=False))
+    regressorTestData, testLabels, noiselessTestLabels = (
+        generateClusteredPoints(clusterCount, 1, featuresPer,
+                                addFeatureNoise=True, addLabelNoise=True,
+                                addLabelColumn=False))
+
+    return ((regressorTrainData, trainLabels, noiselessTrainLabels),
+            (regressorTestData, testLabels, noiselessTestLabels))
+
+def _classifierDataset():
+    """
+    Generates clustered points, hwere the labels of the points
+    within each cluster are all identical.
+    """
+
+    clusterCount = 3
+    pointsPer = 10
+    featuresPer = 5
+
+    #add noise to the features only
+    trainData, trainLabels, noiselessTrainLabels = (
+        generateClusteredPoints(clusterCount, pointsPer, featuresPer,
+                                addFeatureNoise=True, addLabelNoise=False,
+                                addLabelColumn=False))
+    testData, testLabels, noiselessTestLabels = (
+        generateClusteredPoints(clusterCount, 1, featuresPer,
+                                addFeatureNoise=True, addLabelNoise=False,
+                                addLabelColumn=False))
+
+    return ((trainData, trainLabels, noiselessTrainLabels),
+            (testData, testLabels, noiselessTestLabels))
+
+
 class LearnerInspector:
     """
     Class using heirustics to classify the 'type' of problem an
@@ -473,11 +520,10 @@ class LearnerInspector:
         self.EXACT_THRESHHOLD = .00000001
 
         #initialize datasets for tests
-        self.regressorDataTrain, self.regressorDataTest = (
-            self._regressorDataset())
+        self.regressorDataTrain, self.regressorDataTest = _regressorDataset()
         #todo use classifier
         self.classifierDataTrain, self.classifierDataTest = (
-            self._classifierDataset())
+            _classifierDataset())
 
     def learnerType(self, learnerName):
         """
@@ -546,52 +592,6 @@ class LearnerInspector:
         # algorithms, but currently we can only resolve classifiers,
         # regressors, and other.
         return 'other'
-
-    def _regressorDataset(self):
-        """
-        Generates clustered points, where the labels of the points
-        within a single cluster are all very similar, but non-identical.
-        """
-
-        clusterCount = 3
-        pointsPer = 10
-        featuresPer = 5
-
-        #add noise to both the features and the labels
-        regressorTrainData, trainLabels, noiselessTrainLabels = (
-            generateClusteredPoints(clusterCount, pointsPer, featuresPer,
-                                    addFeatureNoise=True, addLabelNoise=True,
-                                    addLabelColumn=False))
-        regressorTestData, testLabels, noiselessTestLabels = (
-            generateClusteredPoints(clusterCount, 1, featuresPer,
-                                    addFeatureNoise=True, addLabelNoise=True,
-                                    addLabelColumn=False))
-
-        return ((regressorTrainData, trainLabels, noiselessTrainLabels),
-                (regressorTestData, testLabels, noiselessTestLabels))
-
-    def _classifierDataset(self):
-        """
-        Generates clustered points, hwere the labels of the points
-        within each cluster are all identical.
-        """
-
-        clusterCount = 3
-        pointsPer = 10
-        featuresPer = 5
-
-        #add noise to the features only
-        trainData, trainLabels, noiselessTrainLabels = (
-            generateClusteredPoints(clusterCount, pointsPer, featuresPer,
-                                    addFeatureNoise=True, addLabelNoise=False,
-                                    addLabelColumn=False))
-        testData, testLabels, noiselessTestLabels = (
-            generateClusteredPoints(clusterCount, 1, featuresPer,
-                                    addFeatureNoise=True, addLabelNoise=False,
-                                    addLabelColumn=False))
-
-        return ((trainData, trainLabels, noiselessTrainLabels),
-                (testData, testLabels, noiselessTestLabels))
 
     def _regressorTrial(self, learnerName):
         """

--- a/nimble/core/data/axis.py
+++ b/nimble/core/data/axis.py
@@ -577,7 +577,7 @@ class Axis(ABC):
         if not callable(fillWith):
             value = fillWith
             # for consistency use numpy.nan for None and nans
-            if value is None or value != value: # pylint: disable=comparison-with-itself
+            if value is None or value != value:
                 value = numpy.nan
             fillFunc = fill.constant
             kwarguments['constantValue'] = value

--- a/nimble/core/data/dataframe.py
+++ b/nimble/core/data/dataframe.py
@@ -340,7 +340,7 @@ class DataFrame(Base):
             else:
                 right = right + numColsL
             matches = self._data.iloc[:, left] == self._data.iloc[:, right]
-            # pylint: disable=comparison-with-itself
+
             nansL = numpy.array([x != x for x in self._data.iloc[:, left]])
             nansR = numpy.array([x != x for x in self._data.iloc[:, right]])
             acceptableValues = matches + nansL + nansR

--- a/nimble/core/data/features.py
+++ b/nimble/core/data/features.py
@@ -1709,6 +1709,7 @@ class Features(ABC):
             zipFeatures = zip(self, applyResultTo.features)
             for i, (ft1, ft2) in enumerate(zipFeatures):
                 if features is None or i in features:
+                    # pylint: disable=cell-var-from-loop
                     norm1, norm2 = function(ft1, ft2)
                     self.transform(lambda _: norm1, features=i, useLog=False)
                     applyResultTo.features.transform(lambda _: norm2,
@@ -2332,4 +2333,8 @@ class Features(ABC):
     def _plotComparison(self, statistic, identifiers, confidenceIntervals,
                         horizontal, outPath, show, figureName, title,
                         xAxisLabel, yAxisLabel, legendTitle, **kwargs):
+        pass
+
+    @abstractmethod
+    def _getNamesNoGeneration(self):
         pass

--- a/nimble/core/data/list.py
+++ b/nimble/core/data/list.py
@@ -178,7 +178,7 @@ class List(Base):
             oPoint = other._data[index]
             if sPoint != oPoint:
                 for sVal, oVal in zip(sPoint, oPoint):
-                    # pylint: disable=comparison-with-itself
+
                     if sVal != oVal and (sVal == sVal or oVal == oVal):
                         return False
         return True
@@ -481,7 +481,7 @@ class List(Base):
                         # fill any nan values in left with the corresponding
                         # right value
                         for i, value in enumerate(ptL):
-                            # pylint: disable=comparison-with-itself
+
                             if value != value and i in matchingFtIdx[0]:
                                 lIdx = matchingFtIdx[0].index(i)
                                 ptL[i] = ptR[matchingFtIdx[1][lIdx]]
@@ -710,7 +710,7 @@ class FeatureViewer(object):
         for sVal, oVal in zip(self, other):
             # check element equality - which is only relevant if one
             # of the elements is non-NaN
-            # pylint: disable=comparison-with-itself
+
             if sVal != oVal and (sVal == sVal or oVal == oVal):
                 return False
         return True

--- a/nimble/core/data/matrix.py
+++ b/nimble/core/data/matrix.py
@@ -335,9 +335,9 @@ class Matrix(Base):
                 for ptR in matchesR:
                     # check for conflicts between matching features
                     matches = ptL[matchingFtIdx[0]] == ptR[matchingFtIdx[1]]
-                    nansL = numpy.array([x != x for x # pylint: disable=comparison-with-itself
+                    nansL = numpy.array([x != x for x
                                          in ptL[matchingFtIdx[0]]])
-                    nansR = numpy.array([x != x for x # pylint: disable=comparison-with-itself
+                    nansR = numpy.array([x != x for x
                                          in ptR[matchingFtIdx[1]]])
                     acceptableValues = matches + nansL + nansR
                     if not all(acceptableValues):
@@ -348,7 +348,7 @@ class Matrix(Base):
                         # fill any nan values in left with the corresponding
                         # right value
                         for i, value in enumerate(ptL[matchingFtIdx[0]]):
-                            if value != value: # pylint: disable=comparison-with-itself
+                            if value != value:
                                 fill = ptR[matchingFtIdx[1]][i]
                                 ptL[matchingFtIdx[0]][i] = fill
                     ptR = numpy.delete(ptR, matchingFtIdx[1])

--- a/nimble/core/data/sparse.py
+++ b/nimble/core/data/sparse.py
@@ -675,7 +675,7 @@ class Sparse(Base):
                         # fill any nan values in left with the corresponding
                         # right value
                         for i, value in enumerate(ptL[matchingFtIdx[0]]):
-                            # pylint: disable=comparison-with-itself
+
                             if value != value:
                                 fill = ptR[matchingFtIdx[1]][i]
                                 ptL[matchingFtIdx[0]][i] = fill
@@ -1337,7 +1337,7 @@ class SparseView(BaseView, Sparse):
         sIt = self.points
         oIt = other.points
         for sPoint, oPoint in zip(sIt, oIt):
-            # pylint: disable=comparison-with-itself
+
             if sPoint != oPoint:
                 return False
             if sPoint != sPoint and oPoint == oPoint:

--- a/nimble/core/data/views.py
+++ b/nimble/core/data/views.py
@@ -468,7 +468,7 @@ class FeaturesView(Features, metaclass=ABCMeta):
         readOnlyException('fill')
 
     @featuresExceptionDoc
-    def normalize(self, subtract=None, divide=None, applyResultTo=None,
+    def normalize(self, function, applyResultTo=None, features=None,
                   useLog=None):
         readOnlyException('normalize')
 

--- a/nimble/core/learn.py
+++ b/nimble/core/learn.py
@@ -4,9 +4,9 @@ nimble import.
 """
 
 from types import ModuleType
+import time
 
 import numpy
-import time
 
 import nimble
 from nimble import match

--- a/nimble/fill/fill.py
+++ b/nimble/fill/fill.py
@@ -353,6 +353,7 @@ def backwardFill(vector, match):
     def filler(vec):
         ret = numpy.empty_like(vector, dtype=numpy.object_)
         numValues = len(vec)
+        # pylint: disable=unsupported-assignment-operation
         for i, (val, fill) in enumerate(zip(reversed(vector),
                                             reversed(toFill))):
             idx = numValues - i - 1
@@ -483,7 +484,7 @@ def statsBackend(vector, match, funcString, statisticsFunction):
         raise InvalidArgumentValue(msg)
 
     stat = statisticsFunction(unmatched)
-    if stat != stat: # pylint: disable=comparison-with-itself
+    if stat != stat:
         msg = statsExceptionInvalidInput(funcString, vector)
         raise InvalidArgumentValue(msg)
 

--- a/nimble/match/match.py
+++ b/nimble/match/match.py
@@ -36,7 +36,7 @@ def missing(value):
     >>> missing('nan')
     False
     """
-    return value is None or value != value # pylint: disable=comparison-with-itself
+    return value is None or value != value
 
 def numeric(value):
     """
@@ -1352,8 +1352,8 @@ def _convertMatchToFunction(match):
                 and not isinstance(match, str)):
             matchList = match
             # if nans in the list, need to include separate check in function
-            if not all([val == val for val in matchList]): # pylint: disable=comparison-with-itself
-                match = lambda x: x != x or x in matchList # pylint: disable=comparison-with-itself
+            if not all([val == val for val in matchList]):
+                match = lambda x: x != x or x in matchList
             else:
                 match = lambda x: x in matchList
         # case2: constant
@@ -1361,8 +1361,8 @@ def _convertMatchToFunction(match):
             matchConstant = match
             if matchConstant is None:
                 match = lambda x: x is None
-            elif matchConstant != matchConstant: # pylint: disable=comparison-with-itself
-                match = lambda x: x != x # pylint: disable=comparison-with-itself
+            elif matchConstant != matchConstant:
+                match = lambda x: x != x
             else:
                 match = lambda x: x == matchConstant
     return match

--- a/tests/data/view_access_backend.py
+++ b/tests/data/view_access_backend.py
@@ -296,7 +296,7 @@ class ViewAccess(DataTestObject):
             assert "disallowed for View objects" in str(e)
 
         try:
-            testObject.features.normalize(subtract=0, divide=1)
+            testObject.features.normalize(lambda x: x)
             assert False # expected TypeError
         except TypeError as e:
             assert "disallowed for View objects" in str(e)

--- a/tests/testData.py
+++ b/tests/testData.py
@@ -1550,9 +1550,9 @@ def test_data_CSV_passedOpen():
             tmpCSV.write("1,2,3\n")
             tmpCSV.flush()
             objName = 'fromCSV'
-            openFile = open(tmpCSV.name, 'r')
-            fromCSV = nimble.data(returnType=t, source=openFile, name=objName)
-            openFile.close()
+            with open(tmpCSV.name, 'r') as openFile:
+                fromCSV = nimble.data(returnType=t, source=openFile, name=objName)
+                assert not openFile.closed
 
             assert fromList == fromCSV
 
@@ -1560,12 +1560,14 @@ def test_data_CSV_passedOpen():
             assert fromCSV.absolutePath == openFile.name
             assert fromCSV.relativePath == os.path.relpath(openFile.name)
 
-            openFile = open(openFile.name, 'r')
-            namelessOpenFile = NamelessFile(openFile)
-            fromCSV = nimble.data(
-                returnType=t, source=namelessOpenFile)
-            openFile.close()
-            namelessOpenFile.close()
+            with open(openFile.name, 'r') as openFile:
+                namelessOpenFile = NamelessFile(openFile)
+                fromCSV = nimble.data(returnType=t, source=namelessOpenFile)
+                assert not openFile.closed
+                assert not namelessOpenFile.closed
+            # just to verify that closing openFile also closes namelessOpenFile
+            assert namelessOpenFile.closed
+
             assert fromCSV.name.startswith(nimble.core.data._dataHelpers.DEFAULT_NAME_PREFIX)
             assert fromCSV.path is None
             assert fromCSV.absolutePath is None
@@ -1585,9 +1587,9 @@ def test_data_MTXArr_passedOpen():
             tmpMTXArr.write("3\n")
             tmpMTXArr.flush()
             objName = 'fromMTXArr'
-            openFile = open(tmpMTXArr.name, 'r')
-            fromMTXArr = nimble.data(returnType=t, source=openFile, name=objName)
-            openFile.close()
+            with open(tmpMTXArr.name, 'r') as openFile:
+                fromMTXArr = nimble.data(returnType=t, source=openFile, name=objName)
+                assert not openFile.closed
 
             if t is None and fromList.getTypeString() != fromMTXArr.getTypeString():
                 assert fromList.isApproximatelyEqual(fromMTXArr)
@@ -1598,12 +1600,12 @@ def test_data_MTXArr_passedOpen():
             assert fromMTXArr.absolutePath == openFile.name
             assert fromMTXArr.relativePath == os.path.relpath(openFile.name)
 
-            openFile = open(tmpMTXArr.name, 'r')
-            namelessOpenFile = NamelessFile(openFile)
-            fromMTXArr = nimble.data(
-                returnType=t, source=namelessOpenFile)
-            openFile.close()
-            namelessOpenFile.close()
+            with open(tmpMTXArr.name, 'r') as openFile:
+                namelessOpenFile = NamelessFile(openFile)
+                fromMTXArr = nimble.data(returnType=t, source=namelessOpenFile)
+                assert not openFile.closed
+                assert not namelessOpenFile.closed
+
             assert fromMTXArr.name.startswith(
                 nimble.core.data._dataHelpers.DEFAULT_NAME_PREFIX)
             assert fromMTXArr.path is None
@@ -1624,9 +1626,8 @@ def test_data_MTXCoo_passedOpen():
             tmpMTXCoo.write("1 3 3\n")
             tmpMTXCoo.flush()
             objName = 'fromMTXCoo'
-            openFile = open(tmpMTXCoo.name, 'r')
-            fromMTXCoo = nimble.data(returnType=t, source=openFile, name=objName)
-            openFile.close()
+            with open(tmpMTXCoo.name, 'r') as openFile:
+                fromMTXCoo = nimble.data(returnType=t, source=openFile, name=objName)
 
             if t is None and fromList.getTypeString() != fromMTXCoo.getTypeString():
                 assert fromList.isApproximatelyEqual(fromMTXCoo)
@@ -1637,12 +1638,12 @@ def test_data_MTXCoo_passedOpen():
             assert fromMTXCoo.absolutePath == openFile.name
             assert fromMTXCoo.relativePath == os.path.relpath(openFile.name)
 
-            openFile = open(tmpMTXCoo.name, 'r')
-            namelessOpenFile = NamelessFile(openFile)
-            fromMTXCoo = nimble.data(
-                returnType=t, source=namelessOpenFile)
-            openFile.close()
-            namelessOpenFile.close()
+            with open(tmpMTXCoo.name, 'r') as openFile:
+                namelessOpenFile = NamelessFile(openFile)
+                fromMTXCoo = nimble.data(returnType=t, source=namelessOpenFile)
+                assert not openFile.closed
+                assert not namelessOpenFile.closed
+
             assert fromMTXCoo.name.startswith(
                 nimble.core.data._dataHelpers.DEFAULT_NAME_PREFIX)
             assert fromMTXCoo.path is None


### PR DESCRIPTION
1) Modified `createDataFromFile` to use `with` statements for all file opening. `_openFileIO` wraps open files so that they can be used within a `with` statement like the other IO types but will not close the file on exit. Tests for open files now verify that they remain open after we have created the object.
2) Moved comparison-with-self warning to ignored and removed any annotations for pylint to ignore those comparisons.
3) Adjusted regex matching for example output in traffic_train.py to allow for a wider range of outputs from scikit-learn while still being sufficiently narrow to continue to follow the logic of the example problem.
4) Changed two methods in `LearnerInspector` to functions as they did not need access to `self`
5) Addressed any linter warnings generated by latests merges, including the numpy related warning in fill.py. 
