### PR TITLE
dynamically generated __all__

### DIFF
--- a/nimble/__init__.py
+++ b/nimble/__init__.py
@@ -32,6 +32,7 @@ from nimble.core.learn import Init
 from nimble.core.logger import log
 from nimble.core.logger import showLog
 from nimble.core.interfaces import CustomLearner
+from nimble._utility import _setAll
 
 # import core (not in __all__)
 from nimble import core
@@ -44,7 +45,7 @@ from nimble import match
 from nimble import fill
 from nimble import exceptions
 
-# load settings from configuration file
+# load settings from configuration file (comments below for Sphinx docstring)
 #: User control over configurable options
 #:
 #: See Also
@@ -58,10 +59,4 @@ core.interfaces.initInterfaceSetup()
 # initialize the logging file
 core.logger.initLoggerAndLogConfig()
 
-__all__ = ['calculate', 'crossValidate', 'CustomLearner', 'CV', 'data',
-           'exceptions', 'fill', 'fillMatching', 'identity', 'Init',
-           'learnerDefaultValues', 'learnerParameters', 'learners',
-           'learnerType', 'listLearners', 'loadData', 'loadTrainedLearner',
-           'log', 'match', 'nimblePath', 'normalizeData', 'ones',
-           'settings', 'showLog', 'random', 'train', 'trainAndApply',
-           'trainAndTest', 'trainAndTestOnTrainingData', 'zeros']
+__all__ = _setAll(vars(), includeModules=True, ignore=['core'])

--- a/nimble/_utility.py
+++ b/nimble/_utility.py
@@ -10,6 +10,7 @@ import inspect
 import importlib
 import numbers
 import datetime
+from types import ModuleType
 
 import numpy
 
@@ -351,3 +352,20 @@ def removeDuplicatesNative(cooObj):
                                       shape=cooObj.shape)
 
     return cooNew
+
+def _setAll(variables, includeModules=False, ignore=()):
+    """
+    Will add any attribute in the directory without a leading underscore
+    to the list for __all__, except modules when includeModules is False.
+
+    Note: Does not follow standard nimble leading underscore conventions
+    because it should not be included in __all__.
+    """
+    inAll = []
+    for name, obj in variables.items():
+        if name.startswith('_') or name in ignore:
+            continue
+        isMod = isinstance(obj, ModuleType)
+        if (isMod and includeModules) or not isMod:
+            inAll.append(name)
+    return sorted(inAll)

--- a/nimble/calculate/__init__.py
+++ b/nimble/calculate/__init__.py
@@ -59,19 +59,6 @@ from .normalize import meanNormalize
 from .normalize import meanStandardDeviationNormalize
 from .normalize import range0to1Normalize
 from .normalize import percentileNormalize
+from .._utility import _setAll
 
-
-__all__ = ['balancedAccuracy', 'confusionMatrix', 'correlation',
-           'cosineSimilarity', 'count', 'covariance', 'detectBestResult',
-           'elementwiseMultiply', 'elementwisePower', 'f1Score',
-           'falseNegative', 'falsePositive', 'fractionCorrect',
-           'fractionIncorrect', 'inverse', 'leastSquaresSolution', 'maximum',
-           'mean', 'meanAbsoluteError', 'meanFeaturewiseRootMeanSquareError',
-           'meanNormalize', 'meanStandardDeviationNormalize', 'median',
-           'minimum', 'mode', 'percentileNormalize', 'precision',
-           'proportionMissing', 'proportionZero', 'pseudoInverse', 'quartiles',
-           'range0to1Normalize', 'rSquared', 'recall', 'residuals',
-           'rootMeanSquareError', 'solve', 'specificity', 'standardDeviation',
-           'sum', 'trueNegative', 'truePositive', 'uniqueCount',
-           'varianceFractionRemaining',
-           ]
+__all__ = _setAll(vars())

--- a/nimble/exceptions/__init__.py
+++ b/nimble/exceptions/__init__.py
@@ -12,7 +12,6 @@ from .exceptions import PackageException
 from .exceptions import FileFormatException
 from .exceptions import _prettyListString
 from .exceptions import _prettyDictString
+from .._utility import _setAll
 
-__all__ = ['NimbleException', 'InvalidArgumentType', 'InvalidArgumentValue',
-           'InvalidArgumentTypeCombination', 'InvalidArgumentValueCombination',
-           'ImproperObjectAction', 'PackageException', 'FileFormatException']
+__all__ = _setAll(vars())

--- a/nimble/fill/__init__.py
+++ b/nimble/fill/__init__.py
@@ -10,7 +10,6 @@ from .fill import mode
 from .fill import forwardFill
 from .fill import backwardFill
 from .fill import interpolate
+from .._utility import _setAll
 
-
-__all__ = ['backwardFill', 'constant', 'forwardFill', 'interpolate', 'mean',
-           'median', 'mode',]
+__all__ = _setAll(vars())

--- a/nimble/learners/__init__.py
+++ b/nimble/learners/__init__.py
@@ -8,6 +8,6 @@ from .multioutput_ridge_regression import MultiOutputRidgeRegression
 from .multioutput_linear_regression import MultiOutputLinearRegression
 from .ridge_regression import RidgeRegression
 from .knn_imputation import KNNImputation
+from .._utility import _setAll
 
-__all__ = ['KNNClassifier', 'KNNImputation', 'MultiOutputLinearRegression',
-           'MultiOutputRidgeRegression', 'RidgeRegression']
+__all__ = _setAll(vars())

--- a/nimble/match/__init__.py
+++ b/nimble/match/__init__.py
@@ -39,13 +39,6 @@ from .match import anyTrue
 from .match import allTrue
 from .match import anyFalse
 from .match import allFalse
+from .._utility import _setAll
 
-
-__all__ = ['allBoolean', 'allFalse', 'allInfinity', 'allMissing',
-           'allNegative', 'allNonNumeric', 'allNonZero', 'allNumeric',
-           'allPositive', 'allTrue', 'allValues', 'allZero', 'anyBoolean',
-           'anyFalse', 'anyInfinity', 'anyMissing', 'anyNegative',
-           'anyNonNumeric', 'anyNonZero', 'anyNumeric', 'anyPositive',
-           'anyTrue', 'anyValues', 'anyZero', 'boolean', 'false', 'infinity',
-           'missing', 'negative', 'nonNumeric', 'nonZero', 'numeric',
-           'positive', 'true', 'zero']
+__all__ = _setAll(vars())

--- a/nimble/random/__init__.py
+++ b/nimble/random/__init__.py
@@ -9,6 +9,6 @@ from .randomness import setSeed
 from .randomness import _generateSubsidiarySeed
 from .randomness import _startAlternateControl
 from .randomness import _endAlternateControl
+from .._utility import _setAll
 
-
-__all__ = ['data', 'numpyRandom', 'pythonRandom', 'setSeed']
+__all__ = _setAll(vars())

--- a/tests/testConfig.py
+++ b/tests/testConfig.py
@@ -1,6 +1,6 @@
 """
 Tests to check the loading, writing, and usage of nimble.settings, along
-with the undlying structures being used.
+with the underlying structures being used.
 """
 
 import tempfile

--- a/tests/testUtility.py
+++ b/tests/testUtility.py
@@ -11,6 +11,7 @@ from nimble._utility import DeferredModuleImport
 from nimble._utility import mergeArguments
 from nimble._utility import inspectArguments
 from nimble._utility import numpy2DArray, is2DArray
+from nimble._utility import _setAll
 
 def test_DeferredModuleImport_numpy():
     optNumpy = DeferredModuleImport('numpy')
@@ -164,3 +165,28 @@ def test_is2DArray():
     raw3D = [[[1, 2, 3]]]
     arr3D = numpy.array(raw3D)
     assert not is2DArray(arr3D)
+
+def test_setAll():
+    import sys as _sys # always ignored module
+    from os import path # module
+    from re import search, match, findall, compile # functions
+
+    _variable = '_variable' # always ignored local variable
+    variable = 'variable'
+
+    variables = vars().copy()
+
+    all1 = _setAll(variables)
+    assert all1 == ['compile', 'findall', 'match', 'search', 'variable']
+
+    all2 = _setAll(variables, includeModules=True)
+    assert all2 == ['compile', 'findall', 'match', 'path', 'search',
+                    'variable']
+
+    all3 = _setAll(variables, ignore=['match'])
+    assert all3 == ['compile', 'findall', 'search', 'variable']
+
+    # ignore takes precedence over includeModules
+    all4 = _setAll(variables, ignore=['variable', 'path'],
+                   includeModules=True)
+    assert all4 == ['compile', 'findall', 'match', 'search']


### PR DESCRIPTION
Dynamically generating `__all__`. The helper, `_setAll`, ignores anything with a leading underscore, ignores submodules by default and optionally ignores any specific attributes. Something like `from .loss import fractionIncorrect` also makes `loss` an attribute of the submodule, so in submodules (calculate, match, etc.) we  ignore these but at the top-level submodules are included. Testing was added for the new helper.