### PR TITLE
Replace default object names with unique object id attribute

### DIFF
--- a/nimble/core/data/_dataHelpers.py
+++ b/nimble/core/data/_dataHelpers.py
@@ -26,22 +26,6 @@ DEFAULT_PREFIX = "_DEFAULT_#"
 DEFAULT_PREFIX2 = DEFAULT_PREFIX+'%s'
 DEFAULT_PREFIX_LENGTH = len(DEFAULT_PREFIX)
 
-DEFAULT_NAME_PREFIX = "OBJECT_#"
-
-class _DefaultNumber:
-    """
-    For storing the next available number for a default name.
-    """
-    number = 0
-
-
-def nextDefaultObjectName():
-    """
-    Get the next available default name for an object.
-    """
-    _DefaultNumber.number += 1
-    return DEFAULT_NAME_PREFIX + str(_DefaultNumber.number - 1)
-
 
 def binaryOpNamePathMerge(caller, other, ret, nameSource, pathSource):
     """
@@ -58,7 +42,7 @@ def binaryOpNamePathMerge(caller, other, ret, nameSource, pathSource):
     if nameSource == 'self':
         ret._name = caller._name
     else:
-        ret._name = nextDefaultObjectName()
+        ret._name = None
 
     if pathSource == 'self':
         ret._absPath = caller.absolutePath

--- a/nimble/core/data/axis.py
+++ b/nimble/core/data/axis.py
@@ -32,7 +32,7 @@ from nimble._utility import inspectArguments
 from .points import Points
 from .features import Features
 from ._dataHelpers import DEFAULT_PREFIX, DEFAULT_PREFIX2
-from ._dataHelpers import DEFAULT_PREFIX_LENGTH, DEFAULT_NAME_PREFIX
+from ._dataHelpers import DEFAULT_PREFIX_LENGTH
 from ._dataHelpers import valuesToPythonList, constructIndicesList
 from ._dataHelpers import validateInputString
 from ._dataHelpers import operatorDict
@@ -826,7 +826,7 @@ class Axis(ABC):
             if title is True:
                 title = ''
                 objName = False if self._base.name is None else self._base.name
-                if objName and not objName.startswith(DEFAULT_NAME_PREFIX):
+                if objName is not None:
                     title += "{}: ".format(objName)
                 title += "Feature Comparison"
 

--- a/nimble/core/data/sparse.py
+++ b/nimble/core/data/sparse.py
@@ -13,7 +13,6 @@ from nimble.exceptions import PackageException
 from nimble._utility import inheritDocstringsFactory
 from nimble._utility import scipy, pd
 from nimble._utility import sparseMatrixToArray, removeDuplicatesNative
-from . import _dataHelpers
 from .base import Base
 from .views import BaseView
 from .sparseAxis import SparsePoints, SparsePointsView
@@ -1364,7 +1363,7 @@ class SparseView(BaseView, Sparse):
         """ Perform element wise absolute value on this object """
         ret = self.copy(to="Sparse")
         numpy.absolute(ret._data.data, out=ret._data.data)
-        ret._name = _dataHelpers.nextDefaultObjectName()
+        ret._name = None
 
         return ret
 

--- a/nimble/core/learn.py
+++ b/nimble/core/learn.py
@@ -261,7 +261,6 @@ def normalizeData(learnerName, trainX, trainY=None, testX=None, arguments=None,
         )
     """
     startTime = time.process_time()
-    _, trueLearnerName = _unpackLearnerName(learnerName)
     if trackEntry.isEntryPoint:
         validateLearningArguments(trainX, trainY, testX, False)
     merged = mergeArguments(arguments, kwarguments)
@@ -277,8 +276,6 @@ def normalizeData(learnerName, trainX, trainY=None, testX=None, arguments=None,
         trainXFtNames = trainX.features._getNamesNoGeneration()
         normalizedTrain.features.setNames(trainXFtNames, useLog=False)
 
-    normalizedTrain.name = trainX.name + " " + trueLearnerName
-
     # return normalized trainX when testX is not included otherwise return will
     # be a tuple (normalizedTrain, normalizedTest)
     if testX is None:
@@ -290,8 +287,6 @@ def normalizeData(learnerName, trainX, trainY=None, testX=None, arguments=None,
         if len(normalizedTest.features) == len(testX.features):
             testXFtNames = testX.features._getNamesNoGeneration()
             normalizedTest.features.setNames(testXFtNames, useLog=False)
-
-        normalizedTest.name = testX.name + " " + trueLearnerName
 
         ret = (normalizedTrain, normalizedTest)
 

--- a/nimble/core/logger/session_logger.py
+++ b/nimble/core/logger/session_logger.py
@@ -931,32 +931,32 @@ def _buildRunLogString(timestamp, entry):
     fullLog += '\n{0}("{1}")\n'.format(entry['function'], entry["learner"])
     # train and test data
     fullLog += _formatSessionLine("Data", "# points", "# features")
-    if entry.get("trainData", False):
-        if entry["trainData"].startswith("OBJECT_#"):
+    if "trainData" in entry:
+        if entry["trainData"] is None:
             fullLog += _formatSessionLine("trainX", entry["trainDataPoints"],
                                           entry["trainDataFeatures"])
         else:
             fullLog += _formatSessionLine(entry["trainData"],
                                           entry["trainDataPoints"],
                                           entry["trainDataFeatures"])
-    if entry.get("trainLabels", False):
-        if entry["trainLabels"].startswith("OBJECT_#"):
+    if "trainLabels" in entry:
+        if entry["trainLabels"] is None:
             fullLog += _formatSessionLine("trainY", entry["trainLabelsPoints"],
                                           entry["trainLabelsFeatures"])
         else:
             fullLog += _formatSessionLine(entry["trainLabels"],
                                           entry["trainLabelsPoints"],
                                           entry["trainLabelsFeatures"])
-    if entry.get("testData", False):
-        if entry["testData"].startswith("OBJECT_#"):
+    if "testData" in entry:
+        if entry["testData"] is None:
             fullLog += _formatSessionLine("testX", entry["testDataPoints"],
                                           entry["testDataFeatures"])
         else:
             fullLog += _formatSessionLine(entry["testData"],
                                           entry["testDataPoints"],
                                           entry["testDataFeatures"])
-    if entry.get("testLabels", False):
-        if entry["testLabels"].startswith("OBJECT_#"):
+    if "testLabels" in entry:
+        if entry["testLabels"] is None:
             fullLog += _formatSessionLine("testY", entry["testLabelsPoints"],
                                           entry["testLabelsFeatures"])
         else:
@@ -1088,7 +1088,10 @@ def _buildArgDict(func, *args, **kwargs):
         if callable(arg):
             nameArgMap[name] = _extractFunctionString(arg)
         elif isinstance(arg, nimble.core.data.Base):
-            nameArgMap[name] = arg.name
+            if arg.name is not None:
+                nameArgMap[name] = arg.name
+            else:
+                nameArgMap[name] = arg.getTypeString()
         else:
             nameArgMap[name] = str(arg)
 

--- a/tests/data/high_dimension_backend.py
+++ b/tests/data/high_dimension_backend.py
@@ -676,10 +676,10 @@ class HighDimensionModifying(DataTestObject):
             '__floordiv__', '__rfloordiv__', '__ifloordiv__', '__mod__',
             '__rmod__', '__imod__', '__pow__', '__rpow__', '__ipow__',
             '__str__', '__repr__', '__pos__', '__neg__', '__abs__', '__copy__',
-            '__deepcopy__', 'nameIsDefault', 'isApproximatelyEqual',
-            'trainAndTestSets', 'summaryReport', 'isIdentical', 'writeFile',
-            'getTypeString', 'pointView', 'view', 'validate', 'containsZero',
-            'save', 'toString', 'show', 'copy', 'flatten', 'unflatten',))
+            '__deepcopy__', 'isApproximatelyEqual', 'trainAndTestSets',
+            'summaryReport', 'isIdentical', 'writeFile', 'getTypeString',
+            'pointView', 'view', 'validate', 'containsZero', 'save',
+            'toString', 'show', 'copy', 'flatten', 'unflatten',))
         baseDisallowed = baseUser.difference(baseAllowed)
 
         for method in baseDisallowed:

--- a/tests/data/high_level_backend.py
+++ b/tests/data/high_level_backend.py
@@ -246,7 +246,7 @@ class HighLevelDataSafe(DataTestObject):
         assert toTest.absolutePath == preserveAPath
         assert toTest.relativePath == preserveRPath
 
-        assert ret.nameIsDefault()
+        assert ret.name is None
         assert ret.absolutePath == preserveAPath
         assert ret.relativePath == preserveRPath
 
@@ -615,7 +615,7 @@ class HighLevelDataSafe(DataTestObject):
         assert toTest.absolutePath == preserveAPath
         assert toTest.relativePath == preserveRPath
 
-        assert ret.nameIsDefault()
+        assert ret.name is None
         assert ret.absolutePath == preserveAPath
         assert ret.relativePath == preserveRPath
 
@@ -851,7 +851,7 @@ class HighLevelDataSafe(DataTestObject):
         assert toTest.absolutePath == preserveAPath
         assert toTest.relativePath == preserveRPath
 
-        assert ret.nameIsDefault()
+        assert ret.name is None
         assert ret.absolutePath == preserveAPath
         assert ret.relativePath == preserveRPath
 
@@ -1155,7 +1155,7 @@ class HighLevelDataSafe(DataTestObject):
         assert toTest.absolutePath == preserveAPath
         assert toTest.relativePath == preserveRPath
 
-        assert ret.nameIsDefault()
+        assert ret.name is None
         assert ret.absolutePath == preserveAPath
         assert ret.relativePath == preserveRPath
 
@@ -1261,7 +1261,7 @@ class HighLevelDataSafe(DataTestObject):
         assert toTest.absolutePath == preserveAPath
         assert toTest.relativePath == preserveRPath
 
-        assert ret.nameIsDefault()
+        assert ret.name is None
         assert ret.absolutePath == preserveAPath
         assert ret.relativePath == preserveRPath
 
@@ -1587,6 +1587,18 @@ class HighLevelDataSafe(DataTestObject):
 
         assert trX == trY
         assert teX == teY
+
+    def test_trainAndTestSets_objectNameCreation(self):
+        data = [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]]
+
+        toTest = self.constructor(data)
+
+        trX, trY, teX, teY = toTest.trainAndTestSets(.5, 0)
+
+        assert trX.name == 'trainX'
+        assert trY.name == 'trainY'
+        assert teX.name == 'testX'
+        assert teY.name == 'testY'
 
     def test_trainAndTestSets_nameAppend_PathPreserve(self):
         data = [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]]
@@ -2320,7 +2332,7 @@ class HighLevelDataSafe(DataTestObject):
         assert matchPositive.absolutePath == preserveAPath
         assert matchPositive.relativePath == preserveRPath
         assert matchPositive.name != preserveName
-        assert matchPositive.nameIsDefault()
+        assert matchPositive.name is None
 
     #####################################
     # points/features matching backends #
@@ -2441,7 +2453,7 @@ class HighLevelDataSafe(DataTestObject):
         assert allNeg.absolutePath == preserveAPath
         assert allNeg.relativePath == preserveRPath
         assert allNeg.name != preserveName
-        assert allNeg.nameIsDefault()
+        assert allNeg.name is None
 
     #####################
     # features.matching #
@@ -2490,7 +2502,7 @@ class HighLevelDataSafe(DataTestObject):
         assert allZeros.absolutePath == preserveAPath
         assert allZeros.relativePath == preserveRPath
         assert allZeros.name != preserveName
-        assert allZeros.nameIsDefault()
+        assert allZeros.name is None
 
 
 class HighLevelModifying(DataTestObject):

--- a/tests/data/low_level_backend.py
+++ b/tests/data/low_level_backend.py
@@ -8,7 +8,7 @@ of directly instantiating a Base object. This function temporarily fills in
 that missing implementation.
 
 Methods tested in this file (none modify the data):
-_pointNameDifference, _featureNameDifference, points._nameIntersection,
+ID, _pointNameDifference, _featureNameDifference, points._nameIntersection,
 features._nameIntersection, _pointNameSymmetricDifference,
 _featureNameSymmetricDifference, _pointNameUnion, _featureNameUnion,
 points.setName, features.setName, points.setNames, features.setNames,
@@ -33,7 +33,6 @@ from nimble.core.data import available
 from nimble._utility import inheritDocstringsFactory, numpy2DArray
 from nimble._utility import pd
 from nimble.core.data._dataHelpers import DEFAULT_PREFIX
-from nimble.core.data._dataHelpers import DEFAULT_NAME_PREFIX
 from nimble.core.data._dataHelpers import constructIndicesList
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
 from nimble.exceptions import InvalidArgumentValueCombination, ImproperObjectAction
@@ -94,6 +93,21 @@ class LowLevelBackend(object):
     def test_objectValidationSetup(self):
         """ Test that object validation has been setup """
         assert hasattr(Base, 'objectValidation')
+
+    #######
+    # _id #
+    #######
+    def test_id_allUnique(self):
+        a = self.constructor()
+        b = self.constructor()
+        c = self.constructor()
+        d = self.constructor()
+        # The _id for returned objects will not always increment by one, but
+        # no additional internal objects are created during a call to
+        # constructor() so here each new object _id will increment by one
+        assert b._id == a._id + 1
+        assert c._id == b._id + 1
+        assert d._id == c._id + 1
 
     ##########################
     # _pointNameDifference() #
@@ -880,23 +894,6 @@ class LowLevelBackend(object):
         assert not toTest2._equalFeatureNames(toTest1)
 
 
-    ########################
-    # default Object names #
-    ########################
-
-    def test_default_object_names(self):
-        """ Test that default object names increment correctly """
-        toTest0 = self.constructor(featureNames=['a', '2'])
-        toTest1 = self.constructor(pointNames=['1b', '2'])
-        toTest2 = self.constructor(featureNames=['c', '2'])
-
-        firstNumber = int(toTest0.name[len(DEFAULT_NAME_PREFIX):])
-        second = firstNumber + 1
-        third = second + 1
-
-        assert toTest1.name == DEFAULT_NAME_PREFIX + str(second)
-        assert toTest2.name == DEFAULT_NAME_PREFIX + str(third)
-
     ###################
     # points.getNames #
     ###################
@@ -1347,7 +1344,7 @@ class LowLevelBackend(object):
         fNames = ['f' + str(i) for i in range(1, 16)]
         toTest3D = self.constructor(shape=(3, 3, 5), pointNames=pNames,
                                     featureNames=fNames)
-        assert toTest3D.nameIsDefault()
+        assert toTest3D.name is None
         assert toTest3D.points.getNames() == pNames
         assert toTest3D.features.getNames() == fNames
 

--- a/tests/data/numerical_backend.py
+++ b/tests/data/numerical_backend.py
@@ -82,7 +82,7 @@ def back_unary_NamePath_preservations(callerCon, op):
     ret = toCall()
 
     assert ret.name != preserveName
-    assert ret.nameIsDefault()
+    assert ret.name is None
     assert caller.name == preserveName
     assert ret.absolutePath == preserveAPath
     assert caller.absolutePath == preserveAPath
@@ -135,7 +135,7 @@ def back_binaryscalar_NamePath_preservations(callerCon, op):
         assert ret.name == preserveName
     else:
         assert ret.name != preserveName
-        assert ret.nameIsDefault()
+        assert ret.name is None
     assert ret.absolutePath == preserveAPath
     assert ret.path == preserveAPath
     assert ret.relativePath == preserveRPath
@@ -389,7 +389,7 @@ def back_binaryelementwise_NamePath_preservations(callerCon, attr1, inplace, att
     caller = callerCon(data)
     other = callerCon(data, name=preserveNameOther, path=preservePairOther)
 
-    assert caller.nameIsDefault()
+    assert caller.name is None
     assert caller.absolutePath is None
     assert caller.relativePath is None
 
@@ -403,14 +403,14 @@ def back_binaryelementwise_NamePath_preservations(callerCon, attr1, inplace, att
     # name should be default, path should be pulled from other
     if ret is not None and ret != NotImplemented:
         assert ret.name != preserveNameOther
-        assert ret.nameIsDefault()
+        assert ret.name is None
         assert ret.absolutePath == preserveAPathOther
         assert ret.path == preserveAPathOther
         assert ret.relativePath == preserveRPathOther
 
     # if in place, ret == caller. if not, then values should be unchanged
     if not inplace:
-        assert caller.nameIsDefault()
+        assert caller.name is None
         assert caller.absolutePath is None
         assert caller.path is None
         assert caller.relativePath is None
@@ -439,7 +439,7 @@ def back_binaryelementwise_NamePath_preservations(callerCon, attr1, inplace, att
             assert ret.name == preserveName
         else:
             assert ret.name != preserveName
-            assert ret.nameIsDefault()
+            assert ret.name is None
 
         assert ret.absolutePath == preserveAPath
         assert ret.path == preserveAPath
@@ -453,7 +453,7 @@ def back_binaryelementwise_NamePath_preservations(callerCon, attr1, inplace, att
         assert caller.relativePath == preserveRPath
 
     # confirm that othe remains unchanged
-    assert other.nameIsDefault()
+    assert other.name is None
     assert other.absolutePath is None
     assert other.path is None
     assert other.relativePath is None
@@ -479,7 +479,7 @@ def back_binaryelementwise_NamePath_preservations(callerCon, attr1, inplace, att
         #			assert ret.path == "TestAbsPathOther"
         #			assert ret.relativePath == "TestRelPathOther"
         else:
-            assert ret.nameIsDefault()
+            assert ret.name is None
         assert ret.absolutePath is None
         assert ret.path is None
         assert ret.relativePath is None
@@ -1831,7 +1831,7 @@ class NumericalDataSafe(DataTestObject):
         assert boolsInvert.absolutePath == preserveAPath
         assert boolsInvert.relativePath == preserveRPath
         assert boolsInvert.name != preserveName
-        assert boolsInvert.nameIsDefault()
+        assert boolsInvert.name is None
 
 
 class NumericalModifying(DataTestObject):

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -792,7 +792,7 @@ class QueryBackend(DataTestObject):
         pView = toTest.pointView(0)
 
         assert isinstance(pView, BaseView)
-        assert pView.name != toTest.name
+        assert pView.name is None
         assert len(pView.points) == 1
         assert len(pView.features) == 3
         assert len(pView) == len(toTest.features)
@@ -825,7 +825,7 @@ class QueryBackend(DataTestObject):
         fView = toTest.featureView('one')
 
         assert isinstance(fView, BaseView)
-        assert fView.name != toTest.name
+        assert fView.name is None
         assert len(fView.points) == 3
         assert len(fView.features) == 1
         assert len(fView) == len(toTest.points)
@@ -1794,7 +1794,7 @@ class QueryBackend(DataTestObject):
             assert orig.absolutePath == preserveAPath
             assert orig.relativePath == preserveRPath
 
-            assert ret.nameIsDefault()
+            assert ret.name is None
             assert ret.absolutePath == preserveAPath
             assert ret.relativePath == preserveRPath
 
@@ -2243,7 +2243,7 @@ class QueryBackend(DataTestObject):
             assert orig.absolutePath == preserveAPath
             assert orig.relativePath == preserveRPath
 
-            assert ret.nameIsDefault()
+            assert ret.name is None
             assert ret.absolutePath == preserveAPath
             assert ret.relativePath == preserveRPath
 

--- a/tests/data/structure_backend.py
+++ b/tests/data/structure_backend.py
@@ -802,7 +802,7 @@ class StructureDataSafe(StructureShared):
 
         ext1 = toTest.points.copy(0)
 
-        assert ext1.nameIsDefault()
+        assert ext1.name is None
         assert ext1.path == 'testAbsPath'
         assert ext1.absolutePath == 'testAbsPath'
         assert ext1.relativePath == 'testRelPath'
@@ -942,7 +942,7 @@ class StructureDataSafe(StructureShared):
         assert toTest.absolutePath == "testAbsPath"
         assert toTest.relativePath == 'testRelPath'
 
-        assert ext.nameIsDefault()
+        assert ext.name is None
         assert ext.absolutePath == 'testAbsPath'
         assert ext.relativePath == 'testRelPath'
 
@@ -1027,7 +1027,7 @@ class StructureDataSafe(StructureShared):
         assert toTest.absolutePath == "testAbsPath"
         assert toTest.relativePath == 'testRelPath'
 
-        assert ret.nameIsDefault()
+        assert ret.name is None
         assert ret.absolutePath == 'testAbsPath'
         assert ret.relativePath == 'testRelPath'
 
@@ -1543,7 +1543,7 @@ class StructureDataSafe(StructureShared):
         assert toTest.absolutePath == 'testAbsPath'
         assert toTest.relativePath == 'testRelPath'
 
-        assert ext1.nameIsDefault()
+        assert ext1.name is None
         assert ext1.absolutePath == 'testAbsPath'
         assert ext1.relativePath == 'testRelPath'
 
@@ -1716,7 +1716,7 @@ class StructureDataSafe(StructureShared):
         assert toTest.absolutePath == "testAbsPath"
         assert toTest.relativePath == 'testRelPath'
 
-        assert ext.nameIsDefault()
+        assert ext.name is None
         assert ext.absolutePath == 'testAbsPath'
         assert ext.relativePath == 'testRelPath'
 
@@ -1830,7 +1830,7 @@ class StructureDataSafe(StructureShared):
         assert toTest.absolutePath == "testAbsPath"
         assert toTest.relativePath == 'testRelPath'
 
-        assert ret.nameIsDefault()
+        assert ret.name is None
         assert ret.absolutePath == 'testAbsPath'
         assert ret.relativePath == 'testRelPath'
 
@@ -3748,7 +3748,7 @@ class StructureModifying(StructureShared):
 
         ext1 = toTest.points.extract(0)
 
-        assert ext1.nameIsDefault()
+        assert ext1.name is None
         assert ext1.path == 'testAbsPath'
         assert ext1.absolutePath == 'testAbsPath'
         assert ext1.relativePath == 'testRelPath'
@@ -3896,7 +3896,7 @@ class StructureModifying(StructureShared):
         assert toTest.absolutePath == "testAbsPath"
         assert toTest.relativePath == 'testRelPath'
 
-        assert ext.nameIsDefault()
+        assert ext.name is None
         assert ext.absolutePath == 'testAbsPath'
         assert ext.relativePath == 'testRelPath'
 
@@ -3978,7 +3978,7 @@ class StructureModifying(StructureShared):
         assert toTest.absolutePath == "testAbsPath"
         assert toTest.relativePath == 'testRelPath'
 
-        assert ret.nameIsDefault()
+        assert ret.name is None
         assert ret.absolutePath == 'testAbsPath'
         assert ret.relativePath == 'testRelPath'
 
@@ -4456,7 +4456,7 @@ class StructureModifying(StructureShared):
         assert toTest.absolutePath == 'testAbsPath'
         assert toTest.relativePath == 'testRelPath'
 
-        assert ext1.nameIsDefault()
+        assert ext1.name is None
         assert ext1.absolutePath == 'testAbsPath'
         assert ext1.relativePath == 'testRelPath'
 
@@ -4642,7 +4642,7 @@ class StructureModifying(StructureShared):
         assert toTest.absolutePath == "testAbsPath"
         assert toTest.relativePath == 'testRelPath'
 
-        assert ext.nameIsDefault()
+        assert ext.name is None
         assert ext.absolutePath == 'testAbsPath'
         assert ext.relativePath == 'testRelPath'
 
@@ -4756,7 +4756,7 @@ class StructureModifying(StructureShared):
         assert toTest.absolutePath == "testAbsPath"
         assert toTest.relativePath == 'testRelPath'
 
-        assert ret.nameIsDefault()
+        assert ret.name is None
         assert ret.absolutePath == 'testAbsPath'
         assert ret.relativePath == 'testRelPath'
 

--- a/tests/logger/testLoggingCount.py
+++ b/tests/logger/testLoggingCount.py
@@ -111,7 +111,7 @@ random_tested = list(map(prefixAdder('nimble.random'), random_funcs))
 #  The functionality of these functions is untested, but a test of their
 #  expected log count can be found in this script:
 #      copy, featureReport, summaryReport, getTypeString, groupByFeature,
-#      hashCode, nameIsDefault, show, validate
+#      hashCode, show, validate
 base_logged = [
     'calculateOnElements', 'featureReport', 'flatten', 'groupByFeature',
     'matchingElements', 'merge', 'replaceFeatureWithBinaryFeatures',
@@ -123,7 +123,7 @@ base_notLogged = [
     'containsZero', 'copy', 'countElements', 'countUniqueElements',
     'featureView', 'getTypeString', 'hashCode', 'inverse',
     'isApproximatelyEqual', 'isIdentical', 'iterateElements', 'matrixMultiply',
-    'matrixPower', 'nameIsDefault', 'plotHeatMap', 'plotFeatureAgainstFeature',
+    'matrixPower', 'plotHeatMap', 'plotFeatureAgainstFeature',
     'plotFeatureAgainstFeatureRollingAverage', 'plotFeatureDistribution',
     'plotFeatureGroupMeans', 'plotFeatureGroupStatistics', 'pointView',
     'save', 'show', 'solveLinearSystem', 'toString', 'validate', 'view',
@@ -258,12 +258,6 @@ def test_hashCode_logCount():
     for rType in nimble.core.data.available:
         obj = nimble.data(rType, [[1,2,3],[4,5,6]], useLog=False)
         hash = obj.hashCode()
-
-@noLogEntryExpected
-def test_nameIsDefault_logCount():
-    for rType in nimble.core.data.available:
-        obj = nimble.data(rType, [[1,2,3],[4,5,6]], useLog=False)
-        isDefault = obj.nameIsDefault()
 
 @noLogEntryExpected
 def test_show_logCount():

--- a/tests/logger/testLoggingIO.py
+++ b/tests/logger/testLoggingIO.py
@@ -462,7 +462,7 @@ def testPrepTypeFunctionsUseLog():
     mergeObj = nimble.data('Matrix', mData, pointNames=mPtNames,
                            featureNames=mFtNames, useLog=False)
     dataObj.merge(mergeObj, point='intersection', feature='union')
-    checkLogContents('merge', "Matrix", {"other": mergeObj.name,
+    checkLogContents('merge', "Matrix", {"other": 'Matrix',
                                          "point": 'intersection'})
 
     # transformElements
@@ -620,12 +620,12 @@ def testPrepTypeFunctionsUseLog():
     toInsert = nimble.data("Matrix", insertData, useLog=False)
     dataObj.points.insert(0, toInsert)
     checkLogContents('points.insert', "Matrix", {'insertBefore': 0,
-                                                 'toInsert': toInsert.name})
+                                                 'toInsert': 'Matrix'})
 
     # features.insert
     dataObj = nimble.data("Matrix", data, useLog=False)
     insertData = numpy.zeros((18,1))
-    toInsert = nimble.data("Matrix", insertData, useLog=False)
+    toInsert = nimble.data("Matrix", insertData, name='insert', useLog=False)
     dataObj.features.insert(0, toInsert)
     checkLogContents('features.insert', "Matrix", {'insertBefore': 0,
                                                    'toInsert': toInsert.name})
@@ -635,12 +635,12 @@ def testPrepTypeFunctionsUseLog():
     appendData = [["d", 4, 4], ["d", 4, 4], ["d", 4, 4], ["d", 4, 4], ["d", 4, 4], ["d", 4, 4]]
     toAppend = nimble.data("Matrix", appendData, useLog=False)
     dataObj.points.append(toAppend)
-    checkLogContents('points.append', "Matrix", {'toAppend': toAppend.name})
+    checkLogContents('points.append', "Matrix", {'toAppend': 'Matrix'})
 
     # features.append
     dataObj = nimble.data("Matrix", data, useLog=False)
     appendData = numpy.zeros((18,1))
-    toAppend = nimble.data("Matrix", appendData, useLog=False)
+    toAppend = nimble.data("Matrix", appendData, name='append', useLog=False)
     dataObj.features.append(toAppend)
     checkLogContents('features.append', "Matrix", {'toAppend': toAppend.name})
 

--- a/tests/testData.py
+++ b/tests/testData.py
@@ -1568,7 +1568,7 @@ def test_data_CSV_passedOpen():
             # just to verify that closing openFile also closes namelessOpenFile
             assert namelessOpenFile.closed
 
-            assert fromCSV.name.startswith(nimble.core.data._dataHelpers.DEFAULT_NAME_PREFIX)
+            assert fromCSV.name is None
             assert fromCSV.path is None
             assert fromCSV.absolutePath is None
             assert fromCSV.relativePath is None
@@ -1606,8 +1606,7 @@ def test_data_MTXArr_passedOpen():
                 assert not openFile.closed
                 assert not namelessOpenFile.closed
 
-            assert fromMTXArr.name.startswith(
-                nimble.core.data._dataHelpers.DEFAULT_NAME_PREFIX)
+            assert fromMTXArr.name is None
             assert fromMTXArr.path is None
             assert fromMTXArr.absolutePath is None
             assert fromMTXArr.relativePath is None
@@ -1644,8 +1643,7 @@ def test_data_MTXCoo_passedOpen():
                 assert not openFile.closed
                 assert not namelessOpenFile.closed
 
-            assert fromMTXCoo.name.startswith(
-                nimble.core.data._dataHelpers.DEFAULT_NAME_PREFIX)
+            assert fromMTXCoo.name is None
             assert fromMTXCoo.path is None
             assert fromMTXCoo.absolutePath is None
             assert fromMTXCoo.relativePath is None

--- a/tests/testNormalizeData.py
+++ b/tests/testNormalizeData.py
@@ -66,9 +66,6 @@ def test_normalizeData_namesChanged():
     norms = nimble.normalizeData('scikitlearn.PCA', trainX, testX=testX,
                                  n_components=2)
 
-    assert norms[0].name == 'trainX PCA'
-    assert norms[1].name == 'testX PCA'
-
 @logCountAssertionFactory(2)
 def test_normalizeData_logCount():
     data1 = [[0, 1, 3], [-1, 1, 2], [1, 2, 2]]


### PR DESCRIPTION
1) Object names are now set to None by default. Default names have been completely removed.
2) Added `_id` attribute for Base class to generate unique id numbers for instances. When a Base instance is instantiated, it sets the instance `_id` attribute to the current `Base._id`, then increments `Base._id` by one. 
3) For `normalizeData`, because it is an inplace operation, names are no longer modified or set.
4) For `trainAndTestSets`, when the calling object has no name, the new objects will be named according to the data they contain. This includes a change to using the names 'train' and 'test' for the two-tuple case, instead of 'trainX' and 'testX', since we cannot be sure the data is only X data and does not also contain the labels. The change to setting a name from appending to a default name also causes the name to display for `__repr__`. I think this is an improvement as it makes the object name that we have set more visible to the user.
5) Moved code from "helper" functions for Base properties to within the property definitions.