### PR TITLE
add linting to test suite

### DIFF
--- a/nimble/_utility.py
+++ b/nimble/_utility.py
@@ -348,6 +348,6 @@ def removeDuplicatesNative(cooObj):
     if len(dataNP) > 0 and isinstance(dataNP[0], numpy.flexible):
         dataNP = numpy.array(data, dtype='O')
     cooNew = scipy.sparse.coo_matrix((dataNP, (rows, cols)),
-                                      shape=cooObj.shape)
+                                     shape=cooObj.shape)
 
     return cooNew

--- a/nimble/core/_createHelpers.py
+++ b/nimble/core/_createHelpers.py
@@ -767,7 +767,7 @@ def elementTypeConvert(data, convertToType):
                 colMask = data.col == col
                 if _parseDatetime(convType):
                     feature = _numpyArrayDatetimeParse(data.data[colMask],
-                                                      convType)
+                                                       convType)
                     data.data[colMask] = feature
                 data.data[colMask] = data.data[colMask].astype(convType)
         elif _isPandasDataFrame(data):

--- a/nimble/core/data/sparse.py
+++ b/nimble/core/data/sparse.py
@@ -176,7 +176,7 @@ class Sparse(Base):
                 currRet = toTransform(val, pID, fID)
 
             self._data.data = modifyNumpyArrayValue(self._data.data, index,
-                                                   currRet)
+                                                    currRet)
 
         self._data.eliminate_zeros()
 

--- a/nimble/core/learn.py
+++ b/nimble/core/learn.py
@@ -267,7 +267,7 @@ def normalizeData(learnerName, trainX, trainY=None, testX=None, arguments=None,
     merged = mergeArguments(arguments, kwarguments)
 
     tl = train(learnerName, trainX, trainY, arguments=merged,
-                      randomSeed=randomSeed, useLog=False)
+               randomSeed=randomSeed, useLog=False)
     normalizedTrain = tl.apply(trainX, useLog=False)
 
     if normalizedTrain.getTypeString() != trainX.getTypeString():
@@ -539,7 +539,7 @@ def crossValidate(learnerName, X, Y, performanceFunction, arguments=None,
         validateLearningArguments(X, Y, arguments=arguments,
                                   scoreMode=scoreMode)
     kfcv = KFoldCrossValidator(learnerName, X, Y, performanceFunction,
-                               arguments, folds, scoreMode,randomSeed,
+                               arguments, folds, scoreMode, randomSeed,
                                useLog, **kwarguments)
     handleLogging(useLog, 'crossVal', kfcv.learnerName, kfcv.arguments,
                   kfcv.performanceFunction, kfcv._allResults, kfcv.folds,

--- a/tests/lintingTest.py
+++ b/tests/lintingTest.py
@@ -1,0 +1,26 @@
+"""
+Test that the code meets the minimum linter requirements.
+"""
+import os
+
+from nose.plugins.attrib import attr
+
+import nimble
+from lint import analyzeWarnings, sortWarnings, printWarnings
+
+@attr('slow')
+def testLinterPasses():
+    """Test minimum linter requirements are met."""
+    configOptions = [nimble.nimblePath]
+    config = os.path.abspath('.pylintrc')
+    configOptions.append('--rcfile={0}'.format(config))
+    configOptions.append('--output-format=json')
+
+    command = " ".join(configOptions)
+
+    getWarnings = analyzeWarnings(command)
+    errors, required, _ = sortWarnings(getWarnings)
+    lintMsg = 'LINTER: {0} {1}'
+    printWarnings(required, lintMsg.format(len(required), 'REQUIRED CHANGES'))
+    printWarnings(errors, lintMsg.format(len(errors), 'ERRORS'))
+    assert not errors and not required


### PR DESCRIPTION
Added a test to check that the minimum linter requirements are met. lint.py still works the same, the changes in that file were abstracting parts from `printWarningSummary` so that they could be imported to lintingTest.py. The test will print any required warnings and errors when the test fails, so it is not necessary to re-run the linter when the test fails. It does not print the "consider changes", those are only included when calling lint.py as `__main__`.

For whatever reason, adding this test uncovered a few additional linting warnings (all whitespace errors) so those were fixed as well.