### PR TITLE
use parser for version checking

### DIFF
--- a/nimble/core/interfaces/keras_interface.py
+++ b/nimble/core/interfaces/keras_interface.py
@@ -5,6 +5,7 @@ Relies on being keras 2.0.8
 import os
 import logging
 import warnings
+from packaging.version import parse as versionParse
 
 import numpy
 
@@ -38,7 +39,7 @@ class Keras(PredefinedInterface):
             # that drown out anything else on standard out
             logging.getLogger('tensorflow').disabled = True
             # os.environ['TF_CPP_MIN_LOG_LEVEL'] = '2'
-            if self.tensorflow.__version__[:2] == '1.':
+            if versionParse(self.tensorflow.__version__) < versionParse('2'):
                 msg = "Randomness is outside of Nimble's control for version "
                 msg += "1 of Tensorflow. Reproducible results cannot be "
                 msg += "guaranteed"

--- a/nimble/core/interfaces/scikit_learn_interface.py
+++ b/nimble/core/interfaces/scikit_learn_interface.py
@@ -10,6 +10,7 @@ import warnings
 from unittest import mock
 import pkgutil
 import abc
+from packaging.version import parse as versionParse
 
 import numpy
 
@@ -341,8 +342,7 @@ class SciKitLearn(_SciKitLearnAPI):
                                               'sklearn.utils.testing')
 
         version = self.version()
-        self._versionSplit = list(map(int, version.split('.')))
-        if self._versionSplit[0] < 1 and self._versionSplit[1] < 19:
+        if versionParse(version) < versionParse("0.19"):
             msg = "nimble was tested using sklearn 0.19 and above, we cannot "
             msg += "be sure of success for version {0}".format(version)
             warnings.warn(msg)


### PR DESCRIPTION
Encountered bug when scikit-learn version was `'0.22.0.post1'` because the version includes non integer values. Switched to use of built-in `packaging.version.parse` for version comparisons since it is much more robust than our manual approach.