### PR TITLE
DataFrame retain heterogeneous feature data types

### DIFF
--- a/nimble/core/data/_dataHelpers.py
+++ b/nimble/core/data/_dataHelpers.py
@@ -329,8 +329,7 @@ def denseAxisUniqueArray(obj, axis):
     """
     validateAxis(axis)
     if obj.getTypeString() == 'DataFrame':
-        # faster than numpy.array(obj._data)
-        data = obj._data.values
+        data = obj._asNumpyArray()
     else:
         data = numpy.array(obj._data, dtype=numpy.object_)
     if axis == 'feature':
@@ -1260,7 +1259,6 @@ def numpyArrayFromList(data):
 
     return ret
 
-
 def modifyNumpyArrayValue(arr, index, newVal):
     """
     Change a single value in a numpy array.
@@ -1277,3 +1275,27 @@ def modifyNumpyArrayValue(arr, index, newVal):
     arr[index] = newVal
 
     return arr
+
+def getFeatureDtypes(obj):
+    """
+    Get a dtype for each feature in the object.
+
+    DataFrames and Lists can return a tuple of heterogeneous types,
+    Matrix and Sparse will be homogeneous.
+    """
+    if hasattr(obj._data, 'dtypes'):
+        return tuple(obj._data.dtypes)
+    if hasattr(obj._data, 'dtype'):
+        return (obj._data.dtype,) * len(obj.features)
+
+    dtypeList = []
+    floatDtype = numpy.dtype(float)
+    # _data is list or ListPassThrough
+    for ft in zip(*obj._data):
+        dtype = max(map(numpy.dtype, map(type, ft)))
+        if dtype > floatDtype:
+            dtypeList.append(numpy.object_)
+        else:
+            dtypeList.append(dtype)
+
+    return tuple(dtypeList)

--- a/nimble/core/data/listAxis.py
+++ b/nimble/core/data/listAxis.py
@@ -213,12 +213,11 @@ class ListPoints(ListAxis, Points):
         self._base._data = tmpData.tolist()
         self._base._numFeatures = numRetFeatures
 
-    def _combineByExpandingFeatures_implementation(self, uniqueDict, namesIdx,
-                                                   uniqueNames, numRetFeatures,
-                                                   numExpanded):
+    def _combineByExpandingFeatures_implementation(
+        self, uniqueDict, namesIdx, valuesIdx, uniqueNames, numRetFeatures):
         tmpData = fillArrayWithExpandedFeatures(uniqueDict, namesIdx,
                                                 uniqueNames, numRetFeatures,
-                                                numExpanded)
+                                                len(valuesIdx))
 
         self._base._data = tmpData.tolist()
         self._base._numFeatures = numRetFeatures

--- a/nimble/core/data/matrixAxis.py
+++ b/nimble/core/data/matrixAxis.py
@@ -189,12 +189,11 @@ class MatrixPoints(MatrixAxis, Points):
 
         self._base._data = numpy2DArray(tmpData)
 
-    def _combineByExpandingFeatures_implementation(self, uniqueDict, namesIdx,
-                                                   uniqueNames, numRetFeatures,
-                                                   numExpanded):
+    def _combineByExpandingFeatures_implementation(
+        self, uniqueDict, namesIdx, valuesIdx, uniqueNames, numRetFeatures):
         tmpData = fillArrayWithExpandedFeatures(uniqueDict, namesIdx,
                                                 uniqueNames, numRetFeatures,
-                                                numExpanded)
+                                                len(valuesIdx))
 
         self._base._data = numpy2DArray(tmpData)
 

--- a/nimble/core/data/points.py
+++ b/nimble/core/data/points.py
@@ -1819,10 +1819,8 @@ class Points(ABC):
                           + (len(uniqueNames) * numExpanded)
                           - (1 + numExpanded))
 
-        self._combineByExpandingFeatures_implementation(unique, namesIdx,
-                                                        uniqueNames,
-                                                        numRetFeatures,
-                                                        numExpanded)
+        self._combineByExpandingFeatures_implementation(
+            unique, namesIdx, valuesIdx, uniqueNames, numRetFeatures)
 
         self._base._featureCount = numRetFeatures
         self._base._pointCount = len(unique)
@@ -2274,8 +2272,7 @@ class Points(ABC):
 
     @abstractmethod
     def _combineByExpandingFeatures_implementation(
-            self, uniqueDict, namesIdx, uniqueNames, numRetFeatures,
-            numExpanded):
+        self, uniqueDict, namesIdx, valuesIdx, uniqueNames, numRetFeatures):
         pass
 
     @abstractmethod

--- a/nimble/core/data/sparseAxis.py
+++ b/nimble/core/data/sparseAxis.py
@@ -407,12 +407,12 @@ class SparsePoints(SparseAxis, Points):
             (tmpData, (tmpRow, tmpCol)), shape=(numRetPoints, numRetFeatures))
         self._base._resetSorted()
 
-    def _combineByExpandingFeatures_implementation(self, uniqueDict, namesIdx,
-                                                   uniqueNames, numRetFeatures,
-                                                   numExpanded):
+    def _combineByExpandingFeatures_implementation(
+        self, uniqueDict, namesIdx, valuesIdx, uniqueNames, numRetFeatures):
         tmpData = []
         tmpRow = []
         tmpCol = []
+        numExpanded = len(valuesIdx)
         numNewFts = len(uniqueNames) * numExpanded
         for idx, point in enumerate(uniqueDict):
             tmpPoint = list(point[:namesIdx])

--- a/tests/data/data_specific_backend.py
+++ b/tests/data/data_specific_backend.py
@@ -2,8 +2,10 @@
 Define data test objects for methods of properties specific to the type
 
 """
-
 from unittest.mock import patch
+
+import numpy
+
 from tests.helpers import CalledFunctionException, calledException
 from .baseObject import DataTestObject
 
@@ -32,3 +34,285 @@ class SparseSpecific(DataTestObject):
 
         # Confirm the desired action actually took place
         assert obj._sorted['indices'] is not None
+
+
+class DataFrameSpecificDataSafe(DataTestObject):
+
+    def test_dtypes_binaryOperators(self):
+        data = [[1, 2, 3.], [-1, -2, -3.], [9, 8, 7.]]
+        obj = self.constructor(data)
+        startDtypes = tuple(obj._data.dtypes)
+
+        assert startDtypes == (numpy.dtype(int), numpy.dtype(int),
+                               numpy.dtype(float))
+
+        # truediv and pow will always convert to floats
+        floatDtypes = (numpy.dtype(float),) * 3
+
+        ret = obj + 2
+        assert tuple(obj._data.dtypes) == startDtypes
+        assert tuple(ret._data.dtypes) == startDtypes
+
+        ret = obj - 2
+        assert tuple(obj._data.dtypes) == startDtypes
+        assert tuple(ret._data.dtypes) == startDtypes
+
+        ret = obj * 2
+        assert tuple(obj._data.dtypes) == startDtypes
+        assert tuple(ret._data.dtypes) == startDtypes
+
+        ret = obj // 2
+        assert tuple(obj._data.dtypes) == startDtypes
+        assert tuple(ret._data.dtypes) == startDtypes
+
+        ret = obj / 2
+        assert tuple(obj._data.dtypes) == startDtypes
+        assert tuple(ret._data.dtypes) == floatDtypes
+
+        ret = obj ** 2
+        assert tuple(obj._data.dtypes) == startDtypes
+        assert tuple(ret._data.dtypes) == floatDtypes
+
+        ret = obj ** -1
+        assert tuple(obj._data.dtypes) == startDtypes
+        assert tuple(ret._data.dtypes) == floatDtypes
+
+        ret = obj + obj
+        assert tuple(obj._data.dtypes) == startDtypes
+        assert tuple(ret._data.dtypes) == startDtypes
+
+        ret = obj - obj
+        assert tuple(obj._data.dtypes) == startDtypes
+        assert tuple(ret._data.dtypes) == startDtypes
+
+        ret = obj * obj
+        assert tuple(obj._data.dtypes) == startDtypes
+        assert tuple(ret._data.dtypes) == startDtypes
+
+        ret = obj // obj
+        assert tuple(obj._data.dtypes) == startDtypes
+        assert tuple(ret._data.dtypes) == startDtypes
+
+        ret = obj / obj
+        assert tuple(obj._data.dtypes) == startDtypes
+        assert tuple(ret._data.dtypes) == floatDtypes
+
+        ret = obj ** obj
+        assert tuple(obj._data.dtypes) == startDtypes
+        assert tuple(ret._data.dtypes) == floatDtypes
+
+        multObj = obj.copy()
+        # square multipication can be misleading, use a different shape
+        multObj.features.append(obj.copy())
+        ret = obj.matrixMultiply(multObj)
+        assert tuple(obj._data.dtypes) == startDtypes
+        assert tuple(ret._data.dtypes) == floatDtypes * 2
+
+    def test_dtypes_copy(self):
+        data = [[1, 2, 3.], [-1, -2, -3.], [9, 8, 7.]]
+        obj = self.constructor(data)
+        startDtypes = tuple(obj._data.dtypes)
+        copy = obj.copy()
+
+        assert tuple(copy._data.dtypes) == startDtypes
+
+class DataFrameSpecificDataModifying(DataTestObject):
+
+    def test_dtypes_binaryOperators_inplace(self):
+        data = [[1, 2, 3.], [-1, -2, -3.], [9, 8, 7.]]
+        obj = self.constructor(data)
+        startDtypes = tuple(obj._data.dtypes)
+
+        assert startDtypes == (numpy.dtype(int), numpy.dtype(int),
+                               numpy.dtype(float))
+
+        # truediv and pow will always convert to floats
+        floatDtypes = (numpy.dtype(float),) * 3
+
+        toTest = obj.copy()
+        toTest += 2
+        assert tuple(toTest._data.dtypes) == startDtypes
+
+        toTest = obj.copy()
+        toTest -= 2
+        assert tuple(toTest._data.dtypes) == startDtypes
+
+        toTest = obj.copy()
+        toTest *= 2
+        assert tuple(toTest._data.dtypes) == startDtypes
+
+        toTest = obj.copy()
+        toTest //= 2
+        assert tuple(toTest._data.dtypes) == startDtypes
+
+        toTest = obj.copy()
+        toTest /= 2
+        assert tuple(toTest._data.dtypes) == floatDtypes
+
+        toTest = obj.copy()
+        toTest **= 2
+        assert tuple(toTest._data.dtypes) == floatDtypes
+
+        toTest = obj.copy()
+        toTest **= -1
+        assert tuple(toTest._data.dtypes) == floatDtypes
+
+        toTest = obj.copy()
+        toTest += toTest
+        assert tuple(toTest._data.dtypes) == startDtypes
+
+        toTest = obj.copy()
+        toTest -= toTest
+        assert tuple(toTest._data.dtypes) == startDtypes
+
+        toTest = obj.copy()
+        toTest *= toTest
+        assert tuple(toTest._data.dtypes) == startDtypes
+
+        toTest = obj.copy()
+        toTest //= toTest
+        assert tuple(obj._data.dtypes) == startDtypes
+
+        toTest = obj.copy()
+        toTest /= toTest
+        assert tuple(toTest._data.dtypes) == floatDtypes
+
+        toTest = obj.copy()
+        toTest **= toTest
+        assert tuple(toTest._data.dtypes) == floatDtypes
+
+    def test_dtypes_replaceRectangle(self):
+        data = [[1, 2, 3.], [-1, -2, -3.], [9, 8, 7.]]
+        obj = self.constructor(data)
+        startDtypes = tuple(obj._data.dtypes)
+        replace = self.constructor([[22, 33], [-22, -33]])
+
+        obj.replaceRectangle(replace, 1, 1, 2, 2)
+        assert tuple(obj._data.dtypes) == startDtypes
+
+        obj = self.constructor(data)
+        replace = self.constructor([[11., 22], [-11., -22]])
+
+        obj.replaceRectangle(replace, 0, 0, 1, 1)
+        expDtypes = (numpy.dtype(float), numpy.dtype(int), numpy.dtype(float))
+        assert tuple(obj._data.dtypes) == expDtypes
+
+    def test_dtypes_flattenUnflatten(self):
+        data = [[1, 2, 3.], [-1, -2, -3.], [9, 8, 7.]]
+        obj = self.constructor(data)
+        startDtypes = tuple(obj._data.dtypes)
+        obj.flatten('feature')
+
+        expDtypes = tuple(startDtypes[0:2]) * 3 + (startDtypes[2],) * 3
+        assert tuple(obj._data.dtypes) == expDtypes
+
+        obj.unflatten((3, 3), 'feature')
+        assert tuple(obj._data.dtypes) == startDtypes
+
+        obj.flatten('point')
+        assert tuple(obj._data.dtypes) == startDtypes * 3
+
+        obj.unflatten((3, 3), 'point')
+        assert tuple(obj._data.dtypes) == startDtypes
+
+
+    def test_dtypes_structural(self):
+        data = [[1, 2, 3., 4.], [-1, -2, -3., -4.],
+                [9, 8, 7., 6.], [-9, -8, -7., -6.]]
+        obj = self.constructor(data)
+        startDtypes = tuple(obj._data.dtypes)
+        ftExpDtypes = (numpy.dtype(int), numpy.dtype(float))
+
+        ptCp = obj.points.copy([1, 2])
+        assert tuple(ptCp._data.dtypes) == startDtypes
+
+        ftCp = obj.features.copy([1, 2])
+        assert tuple(ftCp._data.dtypes) == ftExpDtypes
+
+        toTest = obj.copy()
+        ptEx = toTest.points.extract([1, 3])
+        assert tuple(toTest._data.dtypes) == startDtypes
+        assert tuple(ptEx._data.dtypes) == startDtypes
+
+        toTest = obj.copy()
+
+        ftEx = toTest.features.extract([1, 3])
+        assert tuple(toTest._data.dtypes) == ftExpDtypes
+        assert tuple(ftEx._data.dtypes) == ftExpDtypes
+
+        toTest = obj.copy()
+        toTest.points.retain([1, 3])
+        assert tuple(toTest._data.dtypes) == startDtypes
+
+        toTest = obj.copy()
+        toTest.features.retain([1, 3])
+        assert tuple(toTest._data.dtypes) == ftExpDtypes
+
+        toTest = obj.copy()
+        toTest.points.delete([1, 3])
+        assert tuple(toTest._data.dtypes) == startDtypes
+
+        toTest = obj.copy()
+        toTest.features.delete([1, 3])
+        assert tuple(toTest._data.dtypes) == ftExpDtypes
+
+    def test_dtypes_repeat(self):
+        data = [[1, 2, 3.], [-1, -2, -3.], [9, 8, 7.]]
+        obj = self.constructor(data)
+        startDtypes = tuple(obj._data.dtypes)
+
+        rep = obj.points.repeat(2, False)
+        assert tuple(rep._data.dtypes) == startDtypes
+
+        rep = obj.points.repeat(2, True)
+        assert tuple(rep._data.dtypes) == startDtypes
+
+        rep = obj.features.repeat(2, False)
+        assert tuple(rep._data.dtypes) == startDtypes * 2
+
+        rep = obj.features.repeat(2, True)
+        expDtypes = (numpy.dtype(int),) * 4 + (numpy.dtype(float),) * 2
+        assert tuple(rep._data.dtypes) == expDtypes
+
+    def test_dtypes_splitByCollapsingFeatures(self):
+        data = [[0,0,1,2,3,4], [1,1,5,6,7,8], [2,2,-1,-2,-3,-4]]
+        ptNames = ["0", "1", "2"]
+        ftNames = ["ret0", "ret1", "coll0", "coll1", "coll2", "coll3"]
+        toTest = self.constructor(data, pointNames=ptNames,
+                                  featureNames=ftNames)
+
+        toCollapse = ["coll0", "coll1", "coll2", "coll3"]
+        toTest.points.splitByCollapsingFeatures(toCollapse, "ftNames",
+                                                "ftValues")
+        expDtypes = (numpy.dtype(int), numpy.dtype(int), numpy.dtype(object),
+                     numpy.dtype(int))
+        assert tuple(toTest._data.dtypes) == expDtypes
+
+    def test_dtypes_combineByExpandingFeatures(self):
+        data = [["p1", 100, 'r1', 9.5], ["p1", 100, 'r2', 9.9],
+                ["p2", 100, 'r1', 6.5], ["p2", 100, 'r2', 6.0],
+                ["p3", 100, 'r1', 11], ["p3", 100, 'r2', 11.2],
+                ["p1", 200, 'r1', 18.1], ["p1", 200, 'r2', 20.1]]
+        pNames = [str(i) for i in range(8)]
+        fNames = ['type', 'dist', 'run', 'time']
+        toTest = self.constructor(data, pointNames=pNames, featureNames=fNames)
+
+        expDtypes = (numpy.dtype(object), numpy.dtype(int), numpy.dtype(float),
+                     numpy.dtype(float))
+        toTest.points.combineByExpandingFeatures('run', 'time')
+        assert tuple(toTest._data.dtypes) == expDtypes
+
+    def test_dtypes_splitByParsing(self):
+        data = [[0, "a1", 0.], [1, "b2", 1.], [2, "c3", 2.]]
+        pNames = ["0", "1", "2"]
+        fNames = ["f0", "merged", "f1"]
+        toTest = self.constructor(data, pointNames=pNames, featureNames=fNames)
+
+        toTest.features.splitByParsing(1, 1, ["split0", "split1"])
+        expDtypes = (numpy.dtype(int), numpy.dtype(object),
+                     numpy.dtype(object), numpy.dtype(float))
+        assert tuple(toTest._data.dtypes) == expDtypes
+
+class DataFrameSpecificAll(DataFrameSpecificDataSafe,
+                           DataFrameSpecificDataModifying):
+    """Tests for DataFrame implementation details """

--- a/tests/data/numerical_backend.py
+++ b/tests/data/numerical_backend.py
@@ -709,8 +709,8 @@ def makeAllData(constructor, rhsCons, numPts, numFts, sparsity):
     randomrf = nimble.random.data('Matrix', numPts, numFts, sparsity, useLog=False)
     lhsf = randomlf.copy(to="numpyarray")
     rhsf = randomrf.copy(to="numpyarray")
-    lhsi = numpy.array(numpyRandom.random_integers(1, 10, (numPts, numFts)), dtype=float)
-    rhsi = numpy.array(numpyRandom.random_integers(1, 10, (numPts, numFts)), dtype=float)
+    lhsi = numpy.array(numpyRandom.random_integers(1, 10, (numPts, numFts)))
+    rhsi = numpy.array(numpyRandom.random_integers(1, 10, (numPts, numFts)))
 
     lhsfObj = constructor(lhsf)
     lhsiObj = constructor(lhsi)
@@ -746,6 +746,8 @@ def back_autoVsNumpyObjCallee(constructor, opName, nimbleinplace, sparsity):
             npOp = opName
 
         resultf = getattr(lhsf, npOp)(rhsf)
+        if 'itruediv' in opName: # can't do inplace truediv with int dtype
+            lhsi = lhsi.astype(float)
         resulti = getattr(lhsi, npOp)(rhsi)
         resfObj = getattr(lhsfObj, opName)(rhsfObj)
         resiObj = getattr(lhsiObj, opName)(rhsiObj)
@@ -759,6 +761,11 @@ def back_autoVsNumpyObjCallee(constructor, opName, nimbleinplace, sparsity):
         else:
             assert expfObj.isApproximatelyEqual(resfObj)
             assert expiObj.isIdentical(resiObj)
+            # data type in object should not change unless required or inplace
+            if not ('truediv' in opName or 'pow' in opName):
+                assert isinstance(lhsiObj[0, 0], (int, numpy.integer))
+                assert isinstance(rhsiObj[0, 0], (int, numpy.integer))
+
         assertNoNamesGenerated(lhsfObj)
         assertNoNamesGenerated(lhsiObj)
         assertNoNamesGenerated(rhsfObj)
@@ -780,6 +787,8 @@ def back_autoVsNumpyScalar(constructor, opName, nimbleinplace, sparsity):
         (lhsf, rhsf, lhsi, rhsi, lhsfObj, rhsfObj, lhsiObj, rhsiObj) = datas
 
         resultf = getattr(lhsf, opName)(scalar)
+        if 'itruediv' in opName: # can't do inplace truediv with int dtype
+            lhsi = lhsi.astype(float)
         resulti = getattr(lhsi, opName)(scalar)
         resfObj = getattr(lhsfObj, opName)(scalar)
         resiObj = getattr(lhsiObj, opName)(scalar)
@@ -793,6 +802,10 @@ def back_autoVsNumpyScalar(constructor, opName, nimbleinplace, sparsity):
         else:
             assert expfObj.isApproximatelyEqual(resfObj)
             assert expiObj.isIdentical(resiObj)
+            # data type in object should not change unless required or inplace
+            if not ('truediv' in opName or 'pow' in opName):
+                assert isinstance(lhsiObj[0, 0], (int, numpy.integer))
+
         assertNoNamesGenerated(lhsfObj)
         assertNoNamesGenerated(lhsiObj)
         assertNoNamesGenerated(resfObj)
@@ -823,6 +836,8 @@ def back_autoVsNumpyObjCalleeDiffTypes(constructor, opName, nimbleinplace, spars
         else:
             npOp = opName
         resultf = getattr(lhsf, npOp)(rhsf)
+        if 'itruediv' in opName: # can't do inplace truediv with int dtype
+            lhsi = lhsi.astype(float)
         resulti = getattr(lhsi, npOp)(rhsi)
         resfObj = getattr(lhsfObj, opName)(rhsfObj)
         resiObj = getattr(lhsiObj, opName)(rhsiObj)
@@ -841,6 +856,11 @@ def back_autoVsNumpyObjCalleeDiffTypes(constructor, opName, nimbleinplace, spars
                 assert isinstance(resfObj, nimble.core.data.Base)
             if type(resiObj) != type(lhsiObj):
                 assert isinstance(resiObj, nimble.core.data.Base)
+
+            # data type in object should not change unless required or inplace
+            if not ('truediv' in opName or 'pow' in opName):
+                assert isinstance(lhsiObj[0, 0], (int, numpy.integer))
+                assert isinstance(rhsiObj[0, 0], (int, numpy.integer))
 
         assertNoNamesGenerated(lhsfObj)
         assertNoNamesGenerated(lhsiObj)

--- a/tests/data/testObjects.py
+++ b/tests/data/testObjects.py
@@ -38,6 +38,8 @@ from .high_dimension_backend import HighDimensionAll
 from .high_dimension_backend import HighDimensionSafe
 
 from .data_specific_backend import SparseSpecific
+from .data_specific_backend import DataFrameSpecificAll
+from .data_specific_backend import DataFrameSpecificDataSafe
 
 class BaseViewChildTests(HighLevelDataSafe, NumericalDataSafe, QueryBackend,
                    StructureDataSafe, ViewAccess, StretchDataSafe,
@@ -65,7 +67,7 @@ class TestSparseView(BaseViewChildTests):
         super(TestSparseView, self).__init__('SparseView')
 
 
-class TestDataFrameView(BaseViewChildTests):
+class TestDataFrameView(BaseViewChildTests, DataFrameSpecificDataSafe):
     def __init__(self):
         super(TestDataFrameView, self).__init__('DataFrameView')
 
@@ -85,7 +87,7 @@ class TestSparse(BaseChildTests, SparseSpecific):
         super(TestSparse, self).__init__('Sparse')
 
 
-class TestDataFrame(BaseChildTests):
+class TestDataFrame(BaseChildTests, DataFrameSpecificAll):
     def __init__(self):
         super(TestDataFrame, self).__init__('DataFrame')
 


### PR DESCRIPTION
Many functions in `DataFrame` convert the data to a `numpy` array, which casts all of the data to a single type. This results a loss of the heterogenous data types that may have been created upon object instantiation. The use of `numpy` provides consistent results across object types, so rather than avoid its use, it is better to reassign each feature `dtype` after the operation. Pandas provides some methods for dtype reassignment (`infer_objects` and `convert_dtypes`) but these operations are very slow as they need to determine the dtype. It is always possible for each operation to determine the final dtypes based on initial dtypes and much faster than using Panda's options. The helpers, `getFeatureDTypes` and `_setDtypes` were added to facilitate getting and setting the best dtypes for the operation.

There were many different uses of `pandas.DataFrame.values` to obtain various numpy arrays with different dtypes. The `_asNumpyArray` helper method was created as a clearer replacement for all uses of `pandas.DataFrame.values`. This will determine an appropriate dtype for the numpy array, keeping a numeric dtype if possible, otherwise casting to object dtype. 

Each method using the `asNumpyArray` helper now includes a test that the dtypes of the result match expectations. These tests are found in tests/data/data_specific_backend.py as they only apply to `DataFrame`.
 
This change also highlighted that object dtypes were being modified in binary operations even if the operation was not inplace. Now a copy is made unless the operation is not inplace so the original object dtypes are unchanged.