### PR TITLE
more liberal automatic featureName detection

### DIFF
--- a/nimble/core/_createHelpers.py
+++ b/nimble/core/_createHelpers.py
@@ -139,9 +139,8 @@ def autoDetectNamesFromRaw(pointNames, featureNames, firstValues,
     if featureNames is False:
         return (failPN, failFN)
 
-    def typeEqual(double):
-        x, y = double
-        return not isinstance(x, type(y))
+    def isNum(value):
+        return isinstance(value, (bool, int, float, numpy.number))
 
     def noDuplicates(row):
         return len(row) == len(set(row))
@@ -151,14 +150,14 @@ def autoDetectNamesFromRaw(pointNames, featureNames, firstValues,
         allText = (all(map(lambda x: isinstance(x, str),
                            firstValues[1:]))
                    and noDuplicates(firstValues[1:]))
-        allDiff = all(map(typeEqual, zip(firstValues[1:], secondValues[1:])))
+        anyNum = any(map(isNum, secondValues[1:]))
     else:
         allText = (all(map(lambda x: isinstance(x, str),
                            firstValues))
                    and noDuplicates(firstValues[1:]))
-        allDiff = all(map(typeEqual, zip(firstValues, secondValues)))
+        anyNum = any(map(isNum, secondValues))
 
-    if featureNames == 'automatic' and allText and allDiff:
+    if featureNames == 'automatic' and allText and anyNum:
         featureNames = True
     # At this point, there is no chance to resolve 'automatic' to True
     if featureNames == 'automatic':

--- a/tests/match/test_match.py
+++ b/tests/match/test_match.py
@@ -91,7 +91,7 @@ def backend_match_anyAll(anyOrAll, func, data):
             else:
                 assert func(feature)
         # test by point
-        toTest = nimble.data(t, data.T, useLog=False)
+        toTest.transpose(useLog=False)
         for i, point in enumerate(toTest.points):
             # index 0 never contains any matching values
             if i == 0:

--- a/tests/testData.py
+++ b/tests/testData.py
@@ -978,19 +978,28 @@ def test_automaticByType_fnames_rawAndCSV():
     availableRaw = ['csv', 'pythonlist', 'numpyarray', 'numpymatrix', 'scipycoo']
     for (rawT, retT) in itertools.product(availableRaw, returnTypes):
         # example which triggers automatic removal
-        correctRaw = "fname0,fname1,fname2\n1,2,3\n"
-        correct = helper_auto(correctRaw, rawT, retT, pointNames='automatic', featureNames='automatic')
-        assert correct.features.getNames() == ['fname0','fname1','fname2']
+        simpleRaw = "fname0,fname1,fname2\n1,2,3\n"
+        simple = helper_auto(simpleRaw, rawT, retT, pointNames='automatic',
+                              featureNames='automatic')
+        assert simple.features.getNames() == ['fname0','fname1','fname2']
 
-        # example where first line contains a non-string interpretable value
-        nonStringFail1Raw = "fname0,1.0,fname2\n1,2,3"
-        fail1 = helper_auto(nonStringFail1Raw, rawT, retT, pointNames='automatic', featureNames='automatic')
-        assert all(map(lambda x: x.startswith(DEFAULT_PREFIX), fail1.features.getNames()))
+        # first line contains all strings, second line contains only one number
+        oneNumRaw = "fname0,fname1,fname2\ndata1,2,data3"
+        oneNum = helper_auto(oneNumRaw, rawT, retT,
+                             pointNames='automatic', featureNames='automatic')
+        assert oneNum.features.getNames() == ['fname0','fname1','fname2']
 
-        # example where the first line contains all strings, but second line also contains strings
-        sameTypeFail2Raw = "fname0,fname1,fname2\n1,data2,3"
-        fail2 = helper_auto(sameTypeFail2Raw, rawT, retT, pointNames='automatic', featureNames='automatic')
-        assert all(map(lambda x: x.startswith(DEFAULT_PREFIX), fail2.features.getNames()))
+        # first line contains a non-string interpretable value
+        nonStringHeadRaw = "fname0,1.0,fname2\n1,2,3"
+        fail1 = helper_auto(nonStringHeadRaw, rawT, retT,
+                           pointNames='automatic', featureNames='automatic')
+        assert fail1.features._getNamesNoGeneration() is None
+
+        # first line contains a non-string interpretable value
+        allStringRaw = "fname0,1.0,fname2\nf1,f2,f3"
+        fail2 = helper_auto(allStringRaw, rawT, retT,
+                            pointNames='automatic', featureNames='automatic')
+        assert fail2.features._getNamesNoGeneration() is None
 
 
 def test_userOverrideOfAutomaticByType_fnames_rawAndCSV():


### PR DESCRIPTION
Change featureName automatic detection to identify header any time the first row is all unique strings and the second row contains at least one numeric value. 

Previously the approach was very conservative, requiring a different type between the values at the same index in the first and second rows. This meant that featureNames were not detected anytime there was one or more string features. Instead, this takes a more liberal approach, identifying featureNames provided the first row is unique strings and the second row contains at least one numeric value.

At the point this helper is used, any conversion to numeric types has already been attempted so it is only necessary to check if any values in the second row are numeric.