### PR TITLE
update nimble.data to support same inputs as fetchFile

### DIFF
--- a/documentation/source/docs/nimble.rst
+++ b/documentation/source/docs/nimble.rst
@@ -105,21 +105,54 @@ machine learning.
 .. autoclass:: nimble.CustomLearner
    :members:
 
-Logging and Configuration
--------------------------
+.. _configuration:
 
-By default, Nimble keeps a running log of the actions taken each session. The
-log can be added to and queried using ``nimble.log`` and ``nimble.showLog``,
-respectively. ``nimble.settings`` allows for querying and changing configuration
-options. These options include the logger settings as well as any options
-related to available interfaces. The settings can be changed temporarily during
-a session, or permanently by saving them to the configuration file.
+Configuration
+-------------
 
-.. autofunction:: nimble.log
-
-.. autofunction:: nimble.showLog
+Nimble has certain settings that can be configured. The default settings load
+when the package is imported and can be changed during the session. Changes to
+configurable settings are made through `nimble.settings`, a
+`SessionConfiguration` object that provides methods for getting and setting
+configurable options. Changes to options can apply to the current session or be
+saved as the new default settings. Currently, :ref:`logging` and :ref:`fetch`
+have sections that can be configured.
 
 .. autodata:: nimble.settings
 
 .. autoclass:: nimble.core.configuration.SessionConfiguration
    :members:
+
+.. _logging:
+
+Logging
+-------
+
+By default, Nimble keeps a running log of the actions taken each session. The
+log can be added to and queried using ``nimble.log`` and ``nimble.showLog``,
+respectively. There are four :ref:`configurable <configuration>` options in the
+"logger" section. By default, the "location" is the current directory and the
+file "name" is "log-nimble". The "enabledByDefault" option is set to "True" and
+"enableCrossValidationDeepLogging" is set to "False".
+
+.. autofunction:: nimble.log
+
+.. autofunction:: nimble.showLog
+
+.. _fetch:
+
+Fetching Files
+--------------
+
+Nimble's `fetchFile` and `fetchFiles` provide efficient means for accessing
+online data sets. When a fetch function downloads a dataset, it stores it
+locally. Once downloaded, future calls to a fetch function for the same data
+will identify that the data is already available locally, avoiding a repeated
+download. The downloaded files are placed in a directory named "nimbleData" in
+a :ref:`configurable <configuration>` local location. The local storage
+location is identified by the "location" option in the "fetch" section and is
+set to the home directory by default.
+
+.. autofunction:: nimble.fetchFile
+
+.. autofunction:: nimble.fetchFiles

--- a/nimble/__init__.py
+++ b/nimble/__init__.py
@@ -55,8 +55,6 @@ from nimble import exceptions
 #: nimble.core.configuration.SessionConfiguration
 settings = core.configuration.loadSettings()
 
-core.configuration.setFetchPath(settings)
-
 # initialize the interfaces
 core.interfaces.initInterfaceSetup()
 

--- a/nimble/core/configuration.py
+++ b/nimble/core/configuration.py
@@ -35,7 +35,16 @@ configErrors = (configparser.NoSectionError, configparser.NoOptionError)
 
 class SessionConfiguration(object):
     """
-    Manage settings during a Session.
+    Manage configurable settings.
+
+    Settings can be changed for the current session only or saved to
+    become the new default settings. Default settings are saved to a
+    file (configuration.ini) and loaded on import.
+
+    Settings are divided into sections and options. Options are the
+    configurable variables and sections define groups of options used
+    for a similar purpose. To see the current settings call
+    ``nimble.settings.get()``.
     """
 
     def __init__(self, path):
@@ -62,7 +71,10 @@ class SessionConfiguration(object):
 
     def get(self, section=None, option=None):
         """
-        Query the contents of a section, or a specific option.
+        Query the current settings.
+
+        Query can be the entire settings object, contents of a section,
+        or the value of a specific option.
         """
         if section is None and option is not None:
             msg = "Must specify a section if specifying an option"
@@ -269,6 +281,10 @@ def loadSettings():
             pass
 
     ret = SessionConfiguration(target)
+    sections = ret.get()
+    if 'fetch' not in sections or 'location' not in sections['fetch']:
+        ret.setDefault('fetch', 'location', str(pathlib.Path.home()))
+
     return ret
 
 
@@ -291,13 +307,3 @@ def setInterfaceOptions(interface, save):
             nimble.settings.set(interfaceName, opName, "")
     if save:
         nimble.settings.saveChanges(interfaceName)
-
-def setFetchPath(settings):
-    """
-    Set a default path for nimble.fetchFiles, if necessary.
-    """
-    try:
-        _ = settings.get('fetch', 'location')
-    except configErrors:
-        settings.setDefault('fetch', 'location',
-                            str(pathlib.Path.home()))

--- a/nimble/core/create.py
+++ b/nimble/core/create.py
@@ -231,7 +231,7 @@ def data(returnType, source, pointNames='automatic', featureNames='automatic',
     # input is an open file or a path to a file
     elif isinstance(source, str) or looksFileLike(source):
         ret = createDataFromFile(
-            returnType=returnType, data=source, pointNames=pointNames,
+            returnType=returnType, source=source, pointNames=pointNames,
             featureNames=featureNames, name=name, keepPoints=keepPoints,
             keepFeatures=keepFeatures, convertToType=convertToType,
             ignoreNonNumericalFeatures=ignoreNonNumericalFeatures,
@@ -566,26 +566,28 @@ def loadTrainedLearner(inputPath, useLog=None):
                   learnerName=ret.learnerName, learnerArgs=ret.arguments)
     return ret
 
-def fetchFile(source, update=False):
+def fetchFile(source, overwrite=False):
     """
     Get a data file from the web or local storage.
 
-    Download a data file from the web and store at a specified location.
-    The file is stored in a directory named 'nimbleData' that is placed,
-    by default, in the home directory (pathlib.Path.home()). The
-    location can be changed in configuration.ini. Any subsequent calls
-    for the same source will identify that the data is locally
-    available. For zip and tar files, extraction will be attempted. If
-    successful, the path to the extracted file will be returned,
-    otherwise the path to the archive file is returned.
+    Downloads a new data file from the web and stores it in a
+    "nimbleData" directory placed in a configurable location (see next
+    paragraph). Once stored, any subsequent calls to fetch the same
+    data will identify that the data is already available locally,
+    avoiding repeated downloads. For zip and tar files, extraction
+    will be attempted. If successful, the path to the extracted file
+    will be returned, otherwise the path to the archive file is
+    returned.
 
-    The paths within the nimbleData directory mirror each url structure.
-    So the exact url to the data source can be determine from the file's
-    location, except when the file was extracted from an archive.
+    The location to place the "nimbleData" directory is configurable
+    through nimble.settings by setting the "location" option in the
+    "fetch" section. By default, the location is the home directory
+    (pathlib.Path.home()). The file path within "nimbleData" matches the
+    the download url, except for files extracted from zip and tar files.
 
     Special support for the UCI repository is included. The ``source``
-    can be ``'uci:<Name of Dataset>'`` or the url to the main page for a
-    specific dataset. This function requires that the UCI repository
+    can be ``'uci::<Name of Dataset>'`` or the url to the main page for
+    a specific dataset. This function requires that the UCI repository
     contain only a single file. An exception is made if all other files
     in the repository are named 'Index' or end in '.names'. By
     convention, these files are expected to contain information about
@@ -597,14 +599,18 @@ def fetchFile(source, update=False):
     ----------
     source : str
         Downloadable url or valid string to UCI database (see above).
-    update : bool
-        If True, will update the file stored locally with the data
+    overwrite : bool
+        If True, will overwrite the file stored locally with the data
         currently available from the source.
 
     Returns
     -------
     str
         The path to the available file.
+
+    See Also
+    --------
+    fetchFiles
 
     Examples
     --------
@@ -615,53 +621,58 @@ def fetchFile(source, update=False):
 
     Replacing the path to the root storage location with an ellipsis and
     using a Unix operating system, the ``titanic`` return looks like:
-    '.../nimbleData/openml-org/data/get_csv/16826755/phpMYEkMl'
+    '.../nimbleData/openml.org/data/get_csv/16826755/phpMYEkMl'
     Note how the directory structure mirrors the url.
 
     For the UCI database, two additional options are available. A string
     starting with 'uci:' followed by the name of a UCI dataset or the
     url to the main page of the dataset.
 
-    >>> wine = nimble.fetchFile('uci:wine') # doctest: +SKIP
+    >>> wine = nimble.fetchFile('uci::wine') # doctest: +SKIP
     >>> url = 'https://archive.ics.uci.edu/ml/datasets/Abalone'
     >>> abalone = nimble.fetchFile(url) # doctest: +SKIP
     """
-    return fileFetcher(source, update, allowMultiple=False)[0]
+    return fileFetcher(source, overwrite, allowMultiple=False)[0]
 
-def fetchFiles(source, update=False): # pylint: disable=line-too-long
+def fetchFiles(source, overwrite=False):
     """
     Get data files from the web or local storage.
 
-    Download data from the web and store at a specified location. Files
-    are stored in a directory named 'nimbleData' that is placed, by
-    default, in the home directory (pathlib.Path.home()). The location
-    can be changed in configuration.ini. Any subsequent calls for the
-    same source will identify that the data is locally available.
+    Downloads new data files from the web and stores them in a
+    "nimbleData" directory placed in a configurable location (see next
+    paragraph). Once stored, any subsequent calls to fetch the same
+    data will identify that the data is already available locally,
+    avoiding repeated downloads. For zip and tar files, extraction
+    will be attempted. If successful, the returned list paths will
+    include the extracted files, otherwise it will include the archive
+    file.
 
-    For zip and tar files, extraction will be attempted. If successful,
-    paths to the extracted files will be returned, otherwise the path to
-    the archive file is returned.
-
-    The paths within the nimbleData directory mirror each url structure.
-    So the exact url to the data source can be determine from the file's
-    location, except when the file was extracted from an archive.
+    The location to place the "nimbleData" directory is configurable
+    through nimble.settings by setting the "location" option in the
+    "fetch" section. By default, the location is the home directory
+    (pathlib.Path.home()). The file path within "nimbleData" matches the
+    the download url, except for files extracted from zip and tar files.
 
     Special support for the UCI repository is included. The ``source``
-    can be 'uci:<Name of Dataset>' or the url to the main page for a
+    can be 'uci::<Name of Dataset>' or the url to the main page for a
     specific dataset.
 
     Parameters
     ----------
     source : str
         Downloadable url or valid string to UCI database (see above).
-    update : bool
-        If True, will update any files stored locally with the data
+    overwrite : bool
+        If True, will overwrite any files stored locally with the data
         currently available from the source.
 
     Returns
     -------
     list
         The paths to the available files.
+
+    See Also
+    --------
+    fetchFile
 
     Examples
     --------
@@ -679,8 +690,8 @@ def fetchFiles(source, update=False): # pylint: disable=line-too-long
     starting with 'uci:' followed by the name of a UCI dataset or the
     url to the main page of the dataset.
 
-    >>> iris = nimble.fetchFiles('uci:Iris') # doctest: +SKIP
+    >>> iris = nimble.fetchFiles('uci::Iris') # doctest: +SKIP
     >>> url = 'https://archive.ics.uci.edu/ml/datasets/Wine+Quality'
     >>> wineQuality = fetchFiles(url) # doctest: +SKIP
     """
-    return fileFetcher(source, update)
+    return fileFetcher(source, overwrite)


### PR DESCRIPTION
Modified createDataFromFile and added helper functions to support the UCI shorthand in nimble.data. This also includes leveraging the functions for zip and tar files. For nimble.data, this is all handled in memory. This extends to all file inputs, local files, remote files, and open file objects. 

Changed fetch file functions `update` parameter to the more clear `overwrite` and modified UCI shorthand from `"uci:"` to `"uci::"`.

Modified documentation to more clearly explain how configuration is done through `nimble.settings` and added configurable values to Logging documentation and new Fetching Files documentation.

Removed function added to nimble/__init__.py for setting up fetch configuration and instead incorporated it into the `loadSettings` function.



