### PR TITLE
Helper to create list of constructors for tests

### DIFF
--- a/nimble/_utility.py
+++ b/nimble/_utility.py
@@ -156,7 +156,9 @@ class DeferredModuleImport(object):
     Defer import of third-party modules.
 
     Module must first be determined to accessible to nimble by calling
-    the ``nimbleAccessible`` method.
+    the ``nimbleAccessible`` method. For pickling, __getstate__ and
+    __setstate__ were defined due to issues loading trained learners
+    trained using SparseView objects.
     """
     def __init__(self, name):
         self.name = name
@@ -200,6 +202,12 @@ class DeferredModuleImport(object):
         ret = getattr(self.imported, name)
         setattr(self, name, ret)
         return ret
+
+    def __getstate__(self):
+        return self.__dict__.copy()
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
 
 ####################
 # Optional modules #

--- a/nimble/core/create.py
+++ b/nimble/core/create.py
@@ -557,9 +557,8 @@ def loadTrainedLearner(inputPath, useLog=None):
         raise InvalidArgumentValue(msg)
     with open(inputPath, 'rb') as file:
         ret = cloudpickle.load(file)
-    if not isinstance(ret,
-                      nimble.core.interfaces.TrainedLearner):
-        msg = 'File does not contain a nimble valid trainedLearner Object.'
+    if not isinstance(ret, nimble.core.interfaces.TrainedLearner):
+        msg = 'File does not contain a valid Nimble TrainedLearner object.'
         raise InvalidArgumentType(msg)
 
     handleLogging(useLog, 'load', "TrainedLearner",

--- a/nimble/core/data/dataframe.py
+++ b/nimble/core/data/dataframe.py
@@ -526,7 +526,9 @@ class DataFrame(Base):
         dtypes = tuple(map(lambda dtype: max(dtype, rowDtype), otherDtypes))
 
         if isinstance(other, nimble.core.data.Sparse):
-            values = self._asNumpyArray(numericRequired=True) * other._data
+            # scipy performs mat mul with * operator
+            array = self._asNumpyArray(numericRequired=True)
+            values = array * other._getSparseData()
         else:
             values = numpy.matmul(self._asNumpyArray(numericRequired=True),
                                   other.copy('numpyarray'))

--- a/nimble/core/data/matrix.py
+++ b/nimble/core/data/matrix.py
@@ -476,7 +476,7 @@ class Matrix(Base):
             return Matrix(numpy.matmul(self._data, other._data))
         if isinstance(other, nimble.core.data.Sparse):
             # '*' is matrix multiplication in scipy
-            return Matrix(self._data * other._data)
+            return Matrix(self._data * other._getSparseData())
         return Matrix(numpy.matmul(self._data, other.copy(to="numpyarray")))
 
     def _convertToNumericTypes_implementation(self, usableTypes):

--- a/tests/calculate/linalg_test.py
+++ b/tests/calculate/linalg_test.py
@@ -12,27 +12,25 @@ import nimble
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
 from nimble.calculate import inverse, pseudoInverse, leastSquaresSolution, solve
 
-
+from tests.helpers import getDataConstructors
 ###########
 # inverse #
 ###########
 
 def testInverseSquareObject():
     """
-        Test success of inverse for a square object and
-        test that input object is not modified.mm
+    Test success of inverse for a square object and
+    test that input object is not modified.
     """
     data = [[1, 1, 0], [1, 0, 1], [1, 1, 1]]
     pnames = ['p1', 'p2', 'p3']
     fnames = ['f1', 'f2', 'f3']
 
-    for dataType in nimble.core.data.available:
-        identityObj = nimble.identity(dataType, 3)
-        origObj = nimble.data(
-            dataType, data, pointNames=pnames, featureNames=fnames)
-        obj = nimble.data(dataType, data, pointNames=pnames,
-                          featureNames=fnames)
-        objNoNames = nimble.data(dataType, data)
+    for constructor in getDataConstructors():
+        identityObj = constructor(nimble.identity('Matrix', 3))
+        origObj = constructor(data, pointNames=pnames, featureNames=fnames)
+        obj = constructor(data, pointNames=pnames, featureNames=fnames)
+        objNoNames = constructor(data)
 
         objInv = inverse(obj)
 
@@ -46,8 +44,8 @@ def testInverseEmptyObject():
     """
     data = []
 
-    for dataType in nimble.core.data.available:
-        obj = nimble.data(dataType, data)
+    for constructor in getDataConstructors():
+        obj = constructor(data)
         objInv = inverse(obj)
         assert objInv == obj
 
@@ -58,8 +56,8 @@ def testInverseNonSquareObject():
     """
     data = [[1, 2, 3], [4, 5, 6]]
 
-    for dataType in nimble.core.data.available:
-        obj = nimble.data(dataType, data)
+    for constructor in getDataConstructors():
+        obj = constructor(data)
         try:
             inverse(obj)
             assert False # expected InvalidArgumentValue
@@ -73,8 +71,8 @@ def testNonInvertibleObject():
     """
     data = [[1, 1], [1, 1]]
 
-    for dataType in nimble.core.data.available:
-        obj = nimble.data(dataType, data)
+    for constructor in getDataConstructors():
+        obj = constructor(data)
 
         try:
             inverse(obj)
@@ -90,41 +88,38 @@ def testNonInvertibleObject():
 
 def testPseudoInverseObject():
     """
-        Test success of pseudoInverse for valid objects cases.
-        This includes, square objects, non-square objects and
-        singular objects.
+    Test success of pseudoInverse for valid objects cases.
+    This includes, square objects, non-square objects and
+    singular objects.
     """
-    def _testPseudoInverseCreateObjects(dataType):
+    def _testPseudoInverseCreateObjects(constructor):
 
         objsList = []
 
         data = [[1, 1, 0], [1, 0, 1], [1, 1, 1]]
         pnames = ['p1', 'p2', 'p3']
         fnames = ['f1', 'f2', 'f3']
-        obj = nimble.data(dataType, data, pointNames=pnames,
-                          featureNames=fnames)
+        obj = constructor(data, pointNames=pnames, featureNames=fnames)
         objsList.append(obj)
 
         data = [[1, 2, 3], [3, 4, 5]]
         pnames = ['p1', 'p2']
         fnames = ['f1', 'f2', 'f3']
-        obj = nimble.data(dataType, data, pointNames=pnames,
-                          featureNames=fnames)
+        obj = constructor(data, pointNames=pnames, featureNames=fnames)
         objsList.append(obj)
 
         data = [[1, 2], [3, 4], [5, 6]]
         pnames = ['p1', 'p2', 'p3']
         fnames = ['f1', 'f2']
-        obj = nimble.data(dataType, data, pointNames=pnames,
-                          featureNames=fnames)
+        obj = constructor(data, pointNames=pnames, featureNames=fnames)
         objsList.append(obj)
 
         data = [[1, 1], [1, 1]]
-        obj = nimble.data(dataType, data)
+        obj = constructor(data)
         objsList.append(obj)
 
         data = [[1, 2]]
-        obj = nimble.data(dataType, data)
+        obj = constructor(data)
         objsList.append(obj)
 
         return objsList
@@ -142,21 +137,21 @@ def testPseudoInverseObject():
         assert identityFromPinv.isApproximatelyEqual(identity)
         assert origObj == obj
 
-    for dataType in nimble.core.data.available:
+    for constructor in getDataConstructors():
         for method in ['least-squares', 'svd']:
-            objList = _testPseudoInverseCreateObjects(dataType)
+            objList = _testPseudoInverseCreateObjects(constructor)
             for obj in objList:
                 _pseudoInverseTestImplementation(obj, method)
 
 
 def testPseudoInverseEmptyObject():
     """
-        Test pseudoInverse for an empty object.
+    Test pseudoInverse for an empty object.
     """
     data = []
 
-    for dataType in nimble.core.data.available:
-        obj = nimble.data(dataType, data)
+    for constructor in getDataConstructors():
+        obj = constructor(data)
         objInv = pseudoInverse(obj)
         assert objInv == obj
 
@@ -167,7 +162,7 @@ def testPseudoInverseEmptyObject():
 
 def testSolveSuccess():
     """
-        Test success for solve
+    Test success for solve
     """
     _backendSolverSuccess(solve)
 
@@ -178,14 +173,14 @@ def testSolveSuccess():
 
 def testLeastSquareSolutionExact():
     """
-        Test success for leastSquareSolution exact case.
+    Test success for leastSquareSolution exact case.
     """
     _backendSolverSuccess(leastSquaresSolution)
 
 
 def testLeastSquareSolutionOverdetermined():
     """
-        Test success for leastSquareSolution overdetermined system.
+    Test success for leastSquareSolution overdetermined system.
     """
     aArray = numpy.array([[1, 2], [4, 5], [3, 4]])
     bArrays = [numpy.array([1, 2, 3]), numpy.array([[1], [2], [3]])]
@@ -196,7 +191,7 @@ def testLeastSquareSolutionOverdetermined():
 
 def testLeastSquareSolutionUnderdetermined():
     """
-        Test success for leastSquareSolution under-determined system.
+    Test success for leastSquareSolution under-determined system.
     """
     aArray = numpy.array([[1, 2, 3], [4, 5, 6]])
     bArrays = [numpy.array([1, 2]), numpy.array([[1], [2]])]
@@ -209,16 +204,17 @@ def _backendSolverSuccess(solverFunction):
     aArray = numpy.array([[1, 20], [-30, 4]])
     bArrays = [numpy.array([-30, 4]), numpy.array([[-30], [4]])]
 
-    for dataType in nimble.core.data.available:
-        for dataTypeB in nimble.core.data.available:
+    for constructor in getDataConstructors():
+        for constructorB in getDataConstructors():
             for bArray in bArrays:
-                A = nimble.data(dataType, aArray, featureNames=['f1', 'f2'])
-                b = nimble.data(dataTypeB, bArray)
+                A = constructor(aArray, featureNames=['f1', 'f2'])
+                b = constructorB(bArray)
                 sol = solverFunction(A, b)
                 aInv = inverse(A)
                 if len(b.features) > 1:
-                    b.transpose()
-                reference = (aInv @ b)
+                    reference = (aInv @ b.T)
+                else:
+                    reference = (aInv @ b)
                 reference.transpose()
                 # reference.points.setNames(['b'])
                 assert sol.isApproximatelyEqual(reference)
@@ -227,15 +223,13 @@ def _backendSolverSuccess(solverFunction):
                 assert sol.getTypeString() == A.getTypeString()
 
 def _backendNonSquareSolverSucces(aArray,  bArrays, featureNames):
-    for dataType in nimble.core.data.available:
-        for dataTypeB in nimble.core.data.available:
+    for constructor in getDataConstructors():
+        for constructorB in getDataConstructors():
             for bArray in bArrays:
-                aOrig = nimble.data(
-                    dataType, aArray, featureNames=featureNames)
-                A = nimble.data(dataType, aArray,
-                                featureNames=featureNames)
-                bOrig = nimble.data(dataTypeB, bArray)
-                b = nimble.data(dataTypeB, bArray)
+                aOrig = constructor(aArray, featureNames=featureNames)
+                A = constructor(aArray, featureNames=featureNames)
+                bOrig = constructorB(bArray)
+                b = constructorB(bArray)
                 sol = leastSquaresSolution(A, b)
 
                 assert A == aOrig
@@ -243,8 +237,9 @@ def _backendNonSquareSolverSucces(aArray,  bArrays, featureNames):
 
                 aPinv = pseudoInverse(A)
                 if len(b.features) > 1:
-                    b.transpose()
-                reference = (aPinv @ b)
+                    reference = (aPinv @ b.T)
+                else:
+                    reference = (aPinv @ b)
                 reference.transpose()
                 assert sol.isApproximatelyEqual(reference)
                 assert A.features.getNames() == sol.features.getNames()

--- a/tests/calculate/matrix_test.py
+++ b/tests/calculate/matrix_test.py
@@ -12,15 +12,16 @@ from nimble.calculate import elementwisePower
 from nimble.exceptions import InvalidArgumentType
 from tests.helpers import noLogEntryExpected
 from tests.helpers import CalledFunctionException, calledException
+from tests.helpers import getDataConstructors
 
 @patch('nimble.core.data.Base.__mul__', calledException)
 def test_elementwiseMultiply_callsObjElementsMultiply():
     left = [[1, 2, 3], [4, 5, 6]]
     right = [[6, 5, 4], [3, 2, 1]]
-    for leftRType in nimble.core.data.available:
-        leftObj = nimble.data(leftRType, left)
-        for rightRType in nimble.core.data.available:
-            rightObj = nimble.data(rightRType, right)
+    for lCon in getDataConstructors():
+        leftObj = lCon(left)
+        for rCon in getDataConstructors():
+            rightObj = rCon(right)
             try:
                 mult = elementwiseMultiply(leftObj, rightObj)
                 assert False # expected CalledFunctionException
@@ -31,12 +32,12 @@ def test_elementwiseMultiply():
     left = [[1, 2, 3], [4, 5, 6]]
     right = [[6, 5, 4], [3, 2, 1]]
     exp = [[6, 10, 12], [12, 10, 6]]
-    for leftRType in nimble.core.data.available:
-        leftObj = nimble.data(leftRType, left)
+    for lCon in getDataConstructors():
+        leftObj = lCon(left)
         origLeft = leftObj.copy()
-        expObj = nimble.data(leftRType, exp)
-        for rightRType in nimble.core.data.available:
-            rightObj = nimble.data(rightRType, right)
+        expObj = lCon(exp)
+        for rCon in getDataConstructors():
+            rightObj = rCon(right)
             origRight = rightObj.copy()
             mult = elementwiseMultiply(leftObj, rightObj)
             assert mult.isIdentical(expObj)
@@ -56,10 +57,10 @@ def test_elementwiseMultiply_logCount():
 def test_elementwisePower_callsObjElementsMultiply():
     left = [[1, 2, 3], [4, 5, 6]]
     right = [[6, 5, 4], [3, 2, 1]]
-    for leftRType in nimble.core.data.available:
-        leftObj = nimble.data(leftRType, left)
-        for rightRType in nimble.core.data.available:
-            rightObj = nimble.data(rightRType, right)
+    for lCon in getDataConstructors():
+        leftObj = lCon(left)
+        for rCon in getDataConstructors():
+            rightObj = rCon(right)
             try:
                 pow = elementwisePower(leftObj, rightObj)
                 assert False # expected CalledFunctionException
@@ -70,12 +71,12 @@ def test_elementwisePower():
     left = [[1, 2, 3], [4, 5, 6]]
     right = [[1, 2, 3], [3, 2, 1]]
     exp = [[1, 4, 27], [64, 25, 6]]
-    for leftRType in nimble.core.data.available:
-        leftObj = nimble.data(leftRType, left)
+    for lCon in getDataConstructors():
+        leftObj = lCon(left)
         origLeft = leftObj.copy()
-        expObj = nimble.data(leftRType, exp)
-        for rightRType in nimble.core.data.available:
-            rightObj = nimble.data(rightRType, right)
+        expObj = lCon(exp)
+        for rCon in getDataConstructors():
+            rightObj = rCon(right)
             origRight = rightObj.copy()
             pow = elementwisePower(leftObj, rightObj)
             assert pow.isIdentical(expObj)

--- a/tests/calculate/normalize_test.py
+++ b/tests/calculate/normalize_test.py
@@ -7,8 +7,7 @@ from nimble.calculate import range0to1Normalize
 from nimble.calculate import percentileNormalize
 from nimble.calculate.normalize import rangeNormalize
 from tests.helpers import noLogEntryExpected
-
-retTypes = nimble.core.data.available
+from tests.helpers import getDataConstructors
 
 @noLogEntryExpected
 def assertExpected(func, raw1, raw2, exp1, exp2):
@@ -17,12 +16,12 @@ def assertExpected(func, raw1, raw2, exp1, exp2):
         raw2 = numpy.array(raw2).reshape(shape)
         exp1 = numpy.array(exp1).reshape(shape)
         exp2 = numpy.array(exp2).reshape(shape)
-        for type1 in retTypes:
-            for type2 in retTypes:
-                data1 = nimble.data(type1, raw1, useLog=False)
-                expData1 = nimble.data(type1, exp1, useLog=False)
-                data2 = nimble.data(type2, raw2, useLog=False)
-                expData2 = nimble.data(type2, exp2, useLog=False)
+        for con1 in getDataConstructors():
+            for con2 in getDataConstructors():
+                data1 = con1(raw1, useLog=False)
+                expData1 = con1(exp1, useLog=False)
+                data2 = con2(raw2, useLog=False)
+                expData2 = con2(exp2, useLog=False)
 
                 out1 = func(data1)
                 assert out1 == expData1

--- a/tests/calculate/similarity_test.py
+++ b/tests/calculate/similarity_test.py
@@ -9,6 +9,7 @@ from nimble.calculate import rSquared
 from nimble.calculate import confusionMatrix
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
 from tests.helpers import noLogEntryExpected
+from tests.helpers import getDataConstructors
 
 ####################
 # cosineSimilarity #
@@ -178,9 +179,9 @@ def test_confusionMatrix_noLabels():
             [1], [2], [3], [4],
             [4], [3], [2], [1]]
 
-    for t in nimble.core.data.available:
-        knownObj = nimble.data(t, known, useLog=False)
-        predObj = nimble.data(t, pred, useLog=False)
+    for constructor in getDataConstructors():
+        knownObj = constructor(known, useLog=False)
+        predObj = constructor(pred, useLog=False)
 
         cm = confusionMatrix(knownObj, predObj)
 
@@ -191,7 +192,7 @@ def test_confusionMatrix_noLabels():
 
         featureNames = ['known_' + str(i) for i in range(1, 5)]
         pointNames = ['predicted_' + str(i) for i in range(1, 5)]
-        expObj = nimble.data(t, expData, pointNames, featureNames,
+        expObj = constructor(expData, pointNames, featureNames,
                              useLog=False)
 
         assert cm.isIdentical(expObj)
@@ -216,13 +217,13 @@ def test_confusionMatrix_noLabels_consistentOutput():
              [4], [3], [2], [1],
              [1], [2], [3], [4],]
 
-    for t in nimble.core.data.available:
-        knownObj1 = nimble.data(t, known1, useLog=False)
-        predObj1 = nimble.data(t, pred1, useLog=False)
+    for constructor in getDataConstructors():
+        knownObj1 = constructor(known1, useLog=False)
+        predObj1 = constructor(pred1, useLog=False)
         cm1 = confusionMatrix(knownObj1, predObj1)
 
-        knownObj2 = nimble.data(t, known2, useLog=False)
-        predObj2 = nimble.data(t, pred2, useLog=False)
+        knownObj2 = constructor(known2, useLog=False)
+        predObj2 = constructor(pred2, useLog=False)
         cm2 = confusionMatrix(knownObj2, predObj2)
 
         assert cm1 == cm2
@@ -238,9 +239,9 @@ def test_confusionMatrix_withLabelsDict():
             [1], [2], [3], [4],
             [4], [3], [2], [1]]
 
-    for t in nimble.core.data.available:
-        knownObj = nimble.data(t, known, useLog=False)
-        predObj = nimble.data(t, pred, useLog=False)
+    for constructor in getDataConstructors():
+        knownObj = constructor(known, useLog=False)
+        predObj = constructor(pred, useLog=False)
 
         labels = {1: 'one', 2: 'two', 3: 'three', 4: 'four'}
         cm = confusionMatrix(knownObj, predObj, labels=labels)
@@ -253,7 +254,7 @@ def test_confusionMatrix_withLabelsDict():
         sortedLabels = [labels[i] for i in range(1, 5)]
         featureNames = ['known_' + l for l in sortedLabels]
         pointNames = ['predicted_' + l for l in sortedLabels]
-        expObj = nimble.data(t, expData, pointNames, featureNames,
+        expObj = constructor(expData, pointNames, featureNames,
                              useLog=False)
 
         assert cm.isIdentical(expObj)
@@ -278,14 +279,14 @@ def test_confusionMatrix_withLabelsDict_consistentOutput():
              [4], [3], [2], [1],
              [1], [2], [3], [4],]
 
-    for t in nimble.core.data.available:
-        knownObj1 = nimble.data(t, known1, useLog=False)
-        predObj1 = nimble.data(t, pred1, useLog=False)
+    for constructor in getDataConstructors():
+        knownObj1 = constructor(known1, useLog=False)
+        predObj1 = constructor(pred1, useLog=False)
         labels1 = {1: 'one', 2: 'two', 3: 'three', 4: 'four'}
         cm1 = confusionMatrix(knownObj1, predObj1, labels=labels1)
 
-        knownObj2 = nimble.data(t, known2, useLog=False)
-        predObj2 = nimble.data(t, pred2, useLog=False)
+        knownObj2 = constructor(known2, useLog=False)
+        predObj2 = constructor(pred2, useLog=False)
         labels2 = {4: 'four', 3: 'three', 2: 'two', 1: 'one'}
         cm2 = confusionMatrix(knownObj2, predObj2, labels=labels2)
 
@@ -302,9 +303,9 @@ def test_confusionMatrix_withLabelsList():
             [3], [2], [1], [0],
             [0], [1], [2], [3]]
 
-    for t in nimble.core.data.available:
-        knownObj = nimble.data(t, known, useLog=False)
-        predObj = nimble.data(t, pred, useLog=False)
+    for constructor in getDataConstructors():
+        knownObj = constructor(known, useLog=False)
+        predObj = constructor(pred, useLog=False)
 
         labels = ['three', 'two', 'one', 'zero']
         cm = confusionMatrix(knownObj, predObj, labels=labels)
@@ -316,7 +317,7 @@ def test_confusionMatrix_withLabelsList():
 
         featureNames = ['known_' + l for l in labels]
         pointNames = ['predicted_' + l for l in labels]
-        expObj = nimble.data(t, expData, pointNames, featureNames,
+        expObj = constructor(expData, pointNames, featureNames,
                              useLog=False)
 
         assert cm.isIdentical(expObj)
@@ -334,9 +335,9 @@ def test_confusionMatrix_additionalLabelsProvided():
             [0], [1], [2], [4],
             [4], [2], [1], [0]]
 
-    for t in nimble.core.data.available:
-        knownObj = nimble.data(t, known, useLog=False)
-        predObj = nimble.data(t, pred, useLog=False)
+    for constructor in getDataConstructors():
+        knownObj = constructor(known, useLog=False)
+        predObj = constructor(pred, useLog=False)
 
         labelsList = ['zero', 'one', 'two', 'three', 'four']
         cm1 = confusionMatrix(knownObj, predObj, labels=labelsList)
@@ -352,7 +353,7 @@ def test_confusionMatrix_additionalLabelsProvided():
 
         featureNames = ['known_' + lbl for lbl in labelsList]
         pointNames = ['predicted_' + lbl for lbl in labelsList]
-        expObj = nimble.data(t, expData, pointNames, featureNames,
+        expObj = constructor(expData, pointNames, featureNames,
                              useLog=False)
 
         assert cm1 == expObj
@@ -369,9 +370,9 @@ def test_confusionMatrix_convertCountsToFractions():
             [3], [2], [1],
             [3], [2], [1]]
 
-    for t in nimble.core.data.available:
-        knownObj = nimble.data(t, known, useLog=False)
-        predObj = nimble.data(t, pred, useLog=False)
+    for constructor in getDataConstructors():
+        knownObj = constructor(known, useLog=False)
+        predObj = constructor(pred, useLog=False)
 
         cm = confusionMatrix(knownObj, predObj, convertCountsToFractions=True)
 
@@ -381,7 +382,7 @@ def test_confusionMatrix_convertCountsToFractions():
 
         featureNames = ['known_' + str(i) for i in range(1, 4)]
         pointNames = ['predicted_' + str(i) for i in range(1, 4)]
-        expObj = nimble.data(t, expData, pointNames, featureNames, useLog=False)
+        expObj = constructor(expData, pointNames, featureNames, useLog=False)
 
         assert cm.isIdentical(expObj)
 
@@ -396,9 +397,9 @@ def test_confusionMatrix_strings():
             ['dog'], ['cat'], ['fish'], ['bear'],
             ['cat'], ['dog'], ['bear'], ['fish']]
 
-    for t in nimble.core.data.available:
-        knownObj = nimble.data(t, known, useLog=False)
-        predObj = nimble.data(t, pred, useLog=False)
+    for constructor in getDataConstructors():
+        knownObj = constructor(known, useLog=False)
+        predObj = constructor(pred, useLog=False)
 
         cm = confusionMatrix(knownObj, predObj)
 
@@ -409,6 +410,6 @@ def test_confusionMatrix_strings():
 
         featureNames = ['known_' + lab for lab in ['bear', 'cat', 'dog', 'fish']]
         pointNames = ['predicted_' + lab for lab in ['bear', 'cat', 'dog', 'fish']]
-        expObj = nimble.data(t, expData, pointNames, featureNames, useLog=False)
+        expObj = constructor(expData, pointNames, featureNames, useLog=False)
 
         assert cm.isIdentical(expObj)

--- a/tests/calculate/statistic_test.py
+++ b/tests/calculate/statistic_test.py
@@ -24,6 +24,7 @@ from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
 from nimble.exceptions import InvalidArgumentValueCombination, PackageException
 from tests.helpers import generateRegressionData
 from tests.helpers import noLogEntryExpected
+from tests.helpers import getDataConstructors
 
 def testStDev():
     dataArr = np.array([[1], [1], [3], [4], [2], [6], [12], [0]])
@@ -45,22 +46,21 @@ def testQuartilesAPI():
     assert ret == (2, 4, 6)
 
 #the following tests will test both None/NaN ignoring and calculation correctness
-testDataTypes = nimble.core.data.available
 
 @noLogEntryExpected
 def testProportionMissing():
     raw = [[1, 2, np.nan], [None, 5, 6], [7, 0, 9]]
     func = nimble.calculate.statistic.proportionMissing
-    for dataType in testDataTypes:
-        objl = nimble.data(dataType, raw, useLog=False)
+    for constructor in getDataConstructors():
+        objl = constructor(raw, useLog=False)
 
         retlf = objl.features.calculate(func, useLog=False)
-        retlfCorrect = nimble.data(dataType, [1. / 3, 0, 1. / 3], useLog=False)
+        retlfCorrect = constructor([1. / 3, 0, 1. / 3], useLog=False)
         assert retlf.isIdentical(retlfCorrect)
         assert retlfCorrect.isIdentical(retlf)
 
         retlp = objl.points.calculate(func, useLog=False)
-        retlpCorrect = nimble.data(dataType, [[1. / 3], [1. / 3], [0]],
+        retlpCorrect = constructor([[1. / 3], [1. / 3], [0]],
                                    useLog=False)
         assert retlp.isIdentical(retlpCorrect)
         assert retlpCorrect.isIdentical(retlp)
@@ -69,16 +69,16 @@ def testProportionMissing():
 def testProportionZero():
     raw = [[1, 2, np.nan], [None, 5, 6], [7, 0, 9]]
     func = nimble.calculate.statistic.proportionZero
-    for dataType in testDataTypes:
-        objl = nimble.data(dataType, raw, useLog=False)
+    for constructor in getDataConstructors():
+        objl = constructor(raw, useLog=False)
 
         retlf = objl.features.calculate(func, useLog=False)
-        retlfCorrect = nimble.data(dataType, [0, 1. / 3, 0], useLog=False)
+        retlfCorrect = constructor([0, 1. / 3, 0], useLog=False)
         assert retlf.isIdentical(retlfCorrect)
         assert retlfCorrect.isIdentical(retlf)
 
         retlp = objl.points.calculate(func, useLog=False)
-        retlpCorrect = nimble.data(dataType, [[0], [0], [1. / 3]], useLog=False)
+        retlpCorrect = constructor([[0], [0], [1. / 3]], useLog=False)
         assert retlp.isIdentical(retlpCorrect)
         assert retlpCorrect.isIdentical(retlp)
 
@@ -86,16 +86,16 @@ def testProportionZero():
 def testMinimum():
     raw = [[1, 'a', np.nan], [None, 5, 6], [7, 0, 9]]
     func = nimble.calculate.statistic.minimum
-    for dataType in testDataTypes:
-        objl = nimble.data(dataType, raw, useLog=False)
+    for constructor in getDataConstructors():
+        objl = constructor(raw, useLog=False)
 
         retlf = objl.features.calculate(func, useLog=False)
-        retlfCorrect = nimble.data(dataType, [1, None, 6], useLog=False)
+        retlfCorrect = constructor([1, None, 6], useLog=False)
         assert retlf.isIdentical(retlfCorrect)
         assert retlfCorrect.isIdentical(retlf)
 
         retlp = objl.points.calculate(func, useLog=False)
-        retlpCorrect = nimble.data(dataType, [[None], [5], [0]], useLog=False)
+        retlpCorrect = constructor([[None], [5], [0]], useLog=False)
         assert retlp.isIdentical(retlpCorrect)
         assert retlpCorrect.isIdentical(retlp)
 
@@ -103,16 +103,16 @@ def testMinimum():
 def testMaximum():
     raw = [[1, 'a', np.nan], [None, 5, 6], [7, 0, 9]]
     func = nimble.calculate.statistic.maximum
-    for dataType in testDataTypes:
-        objl = nimble.data(dataType, raw, useLog=False)
+    for constructor in getDataConstructors():
+        objl = constructor(raw, useLog=False)
 
         retlf = objl.features.calculate(func, useLog=False)
-        retlfCorrect = nimble.data(dataType, [7, None, 9], useLog=False)
+        retlfCorrect = constructor([7, None, 9], useLog=False)
         assert retlf.isIdentical(retlfCorrect)
         assert retlfCorrect.isIdentical(retlf)
 
         retlp = objl.points.calculate(func, useLog=False)
-        retlpCorrect = nimble.data(dataType, [[None], [6], [9]], useLog=False)
+        retlpCorrect = constructor([[None], [6], [9]], useLog=False)
         assert retlp.isIdentical(retlpCorrect)
         assert retlpCorrect.isIdentical(retlp)
 
@@ -120,16 +120,16 @@ def testMaximum():
 def testMean():
     raw = [[1, 'a', np.nan], [None, 5, 6], [7, 0, 9]]
     func = nimble.calculate.statistic.mean
-    for dataType in testDataTypes:
-        objl = nimble.data(dataType, raw, useLog=False)
+    for constructor in getDataConstructors():
+        objl = constructor(raw, useLog=False)
 
         retlf = objl.features.calculate(func, useLog=False)
-        retlfCorrect = nimble.data(dataType, [4, None, 7.5], useLog=False)
+        retlfCorrect = constructor([4, None, 7.5], useLog=False)
         assert retlf.isIdentical(retlfCorrect)
         assert retlfCorrect.isIdentical(retlf)
 
         retlp = objl.points.calculate(func, useLog=False)
-        retlpCorrect = nimble.data(dataType, [[None], [5.5], [16. / 3]],
+        retlpCorrect = constructor([[None], [5.5], [16. / 3]],
                                    useLog=False)
         assert retlp.isIdentical(retlpCorrect)
         assert retlpCorrect.isIdentical(retlp)
@@ -138,16 +138,16 @@ def testMean():
 def testMedian():
     raw = [[1, 'a', np.nan], [None, 5, 6], [7, 0, 9]]
     func = nimble.calculate.statistic.median
-    for dataType in testDataTypes:
-        objl = nimble.data(dataType, raw, useLog=False)
+    for constructor in getDataConstructors():
+        objl = constructor(raw, useLog=False)
 
         retlf = objl.features.calculate(func, useLog=False)
-        retlfCorrect = nimble.data(dataType, [4, None, 7.5], useLog=False)
+        retlfCorrect = constructor([4, None, 7.5], useLog=False)
         assert retlf.isIdentical(retlfCorrect)
         assert retlfCorrect.isIdentical(retlf)
 
         retlp = objl.points.calculate(func, useLog=False)
-        retlpCorrect = nimble.data(dataType, [[None], [5.5], [7]], useLog=False)
+        retlpCorrect = constructor([[None], [5.5], [7]], useLog=False)
         assert retlp.isIdentical(retlpCorrect)
         assert retlpCorrect.isIdentical(retlp)
 
@@ -155,18 +155,18 @@ def testMedian():
 def testStandardDeviation():
     raw = [[1, 'a', np.nan], [None, 5, 6], [7, 0, 9]]
     func = nimble.calculate.statistic.standardDeviation
-    for dataType in testDataTypes:
-        objl = nimble.data(dataType, raw, useLog=False)
+    for constructor in getDataConstructors():
+        objl = constructor(raw, useLog=False)
 
         retlf = objl.features.calculate(func, useLog=False)
         retlfData = [4.242640687119285, None, 2.1213203435596424]
-        retlfCorrect = nimble.data(dataType, retlfData, useLog=False)
+        retlfCorrect = constructor(retlfData, useLog=False)
         assert retlf.isIdentical(retlfCorrect)
         assert retlfCorrect.isIdentical(retlf)
 
         retlp = objl.points.calculate(func, useLog=False)
         retlpData = [[None], [0.7071067811865476], [4.725815626252609]]
-        retlpCorrect = nimble.data(dataType, retlpData, useLog=False)
+        retlpCorrect = constructor(retlpData, useLog=False)
         assert retlp.isIdentical(retlpCorrect)
         assert retlpCorrect.isIdentical(retlp)
 
@@ -174,16 +174,16 @@ def testStandardDeviation():
 def testMedianAbsoluteDeviation():
     raw = [[1, 'a', np.nan], [None, 5, 6], [7, 0, 9], [3, 9, 15]]
     func = nimble.calculate.statistic.medianAbsoluteDeviation
-    for dataType in testDataTypes:
-        objl = nimble.data(dataType, raw, useLog=False)
+    for constructor in getDataConstructors():
+        objl = constructor(raw, useLog=False)
 
         retlf = objl.features.calculate(func, useLog=False)
-        retlfCorrect = nimble.data(dataType, [2, None, 3], useLog=False)
+        retlfCorrect = constructor([2, None, 3], useLog=False)
         assert retlf.isIdentical(retlfCorrect)
         assert retlfCorrect.isIdentical(retlf)
 
         retlp = objl.points.calculate(func, useLog=False)
-        retlpCorrect = nimble.data(dataType, [[None], [0.5], [2], [6]],
+        retlpCorrect = constructor([[None], [0.5], [2], [6]],
                                    useLog=False)
         assert retlp.isIdentical(retlpCorrect)
         assert retlpCorrect.isIdentical(retlp)
@@ -192,16 +192,16 @@ def testMedianAbsoluteDeviation():
 def testUniqueCount():
     raw = [[1, 'a', np.nan], [5, None, 6], [7.0, 0, 9]]
     func = nimble.calculate.statistic.uniqueCount
-    for dataType in ['List', 'DataFrame']:
-        objl = nimble.data(dataType, raw, useLog=False)
+    for constructor in getDataConstructors():
+        objl = constructor(raw, useLog=False)
 
         retlf = objl.features.calculate(func, useLog=False)
-        retlfCorrect = nimble.data(dataType, [3, 2, 2], useLog=False)
+        retlfCorrect = constructor([3, 2, 2], useLog=False)
         assert retlf.isIdentical(retlfCorrect)
         assert retlfCorrect.isIdentical(retlf)
 
         retlp = objl.points.calculate(func, useLog=False)
-        retlpCorrect = nimble.data(dataType, [[2], [2], [3]], useLog=False)
+        retlpCorrect = constructor([[2], [2], [3]], useLog=False)
         assert retlp.isIdentical(retlpCorrect)
         assert retlpCorrect.isIdentical(retlp)
 
@@ -209,16 +209,16 @@ def testUniqueCount():
 def testQuartiles():
     raw = [[1, 'a', np.nan], [None, 5, 6], [7, 0, 9], [2, 2, 3], [10, 10, 10]]
     func = nimble.calculate.statistic.quartiles
-    for dataType in testDataTypes:
-        objl = nimble.data(dataType, raw)
+    for constructor in getDataConstructors():
+        objl = constructor(raw)
 
         retlf = objl.features.calculate(func)
-        retlfCorrect = nimble.data(dataType, [[1.750, None, 5.250], [4.500, None, 7.500], [7.750, None, 9.250]])
+        retlfCorrect = constructor([[1.750, None, 5.250], [4.500, None, 7.500], [7.750, None, 9.250]])
         assert retlf.isIdentical(retlfCorrect)
         assert retlfCorrect.isIdentical(retlf)
 
         retlp = objl.points.calculate(func)
-        retlpCorrect = nimble.data(dataType, [[None, None, None], [5.250, 5.500, 5.750], [3.500, 7.000, 8.000],
+        retlpCorrect = constructor([[None, None, None], [5.250, 5.500, 5.750], [3.500, 7.000, 8.000],
                                              [2.000, 2.000, 2.500], [10.000, 10.000, 10.000]])
         assert retlp.isIdentical(retlpCorrect)
         assert retlpCorrect.isIdentical(retlp)
@@ -331,16 +331,16 @@ def test_residuals_matches_SKL():
 def test_count():
     raw = [[1, 'a', np.nan], [None, 5, 6], [7, 0, 9]]
     func = nimble.calculate.statistic.count
-    for dataType in testDataTypes:
-        objl = nimble.data(dataType, raw, useLog=False)
+    for constructor in getDataConstructors():
+        objl = constructor(raw, useLog=False)
 
         retlf = objl.features.calculate(func, useLog=False)
-        retlfCorrect = nimble.data(dataType, [2, 3, 2], useLog=False)
+        retlfCorrect = constructor([2, 3, 2], useLog=False)
         assert retlf.isIdentical(retlfCorrect)
         assert retlfCorrect.isIdentical(retlf)
 
         retlp = objl.points.calculate(func, useLog=False)
-        retlpCorrect = nimble.data(dataType, [[2], [2], [3]], useLog=False)
+        retlpCorrect = constructor([[2], [2], [3]], useLog=False)
         assert retlp.isIdentical(retlpCorrect)
         assert retlpCorrect.isIdentical(retlp)
 
@@ -348,15 +348,15 @@ def test_count():
 def test_sum():
     raw = [[1, 0, np.nan], [None, 5, 6], [7, 0, 9]]
     func = nimble.calculate.statistic.sum
-    for dataType in testDataTypes:
-        objl = nimble.data(dataType, raw, useLog=False)
+    for constructor in getDataConstructors():
+        objl = constructor(raw, useLog=False)
 
         retlf = objl.features.calculate(func, useLog=False)
-        retlfCorrect = nimble.data(dataType, [8, 5, 15], useLog=False)
+        retlfCorrect = constructor([8, 5, 15], useLog=False)
         assert retlf.isIdentical(retlfCorrect)
         assert retlfCorrect.isIdentical(retlf)
 
         retlp = objl.points.calculate(func, useLog=False)
-        retlpCorrect = nimble.data(dataType, [[1], [11], [16]], useLog=False)
+        retlpCorrect = constructor([[1], [11], [16]], useLog=False)
         assert retlp.isIdentical(retlpCorrect)
         assert retlpCorrect.isIdentical(retlp)

--- a/tests/customLearners/knn_imputation_test.py
+++ b/tests/customLearners/knn_imputation_test.py
@@ -12,6 +12,7 @@ from nimble.exceptions import InvalidArgumentValue
 from nimble.learners import KNNImputation
 
 from tests.helpers import assertNoNamesGenerated
+from tests.helpers import getDataConstructors
 
 @raises(InvalidArgumentValue)
 def test_KNNImputation_exception_invalidMode():
@@ -25,9 +26,9 @@ def test_KNNImputation_classification():
     pNames = ['p0', 'p1', 'p2', 'p3', 'p4']
     data = [[1, None, None], [1, 3, 6], [2, 1, 6], [1, 3, 7], [None, 3, None]]
     expData = [[1, 3, 6], [1, 3, 6], [2, 1, 6], [1, 3, 7], [1, 3, 6]]
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data, pointNames=pNames, featureNames=fNames, useLog=False)
-        expTest = nimble.data(t, expData, pointNames=pNames, featureNames=fNames, useLog=False)
+    for constructor in getDataConstructors():
+        toTest = constructor(data, pointNames=pNames, featureNames=fNames, useLog=False)
+        expTest = constructor(expData, pointNames=pNames, featureNames=fNames, useLog=False)
         learner = KNNImputation()
         learner.train(toTest, k=3, mode='classification')
         ret = learner.apply(toTest)
@@ -39,9 +40,9 @@ def test_KNNImputation_regression():
     pNames = ['p0', 'p1', 'p2', 'p3', 'p4']
     data = [[1, None, None], [1, 3, 9], [2, 1, 6], [3, 2, 3], [None, 3, None]]
     expData = [[1, 2, 6], [1, 3, 9], [2, 1, 6], [3, 2, 3], [2, 3, 6]]
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data, pointNames=pNames, featureNames=fNames, useLog=False)
-        expTest = nimble.data(t, expData, pointNames=pNames, featureNames=fNames, useLog=False)
+    for constructor in getDataConstructors():
+        toTest = constructor(data, pointNames=pNames, featureNames=fNames, useLog=False)
+        expTest = constructor(expData, pointNames=pNames, featureNames=fNames, useLog=False)
         learner = KNNImputation()
         learner.train(toTest, k=3, mode='regression')
         ret = learner.apply(toTest)
@@ -59,9 +60,9 @@ def test_KNNImputation_regression_exception_NoSKL():
 def test_KNNImputation_lazyNameGeneration():
     data = [[1, None, None], [1, 3, 6], [2, 1, 6], [1, 3, 7], [None, 3, None]]
     expData = [[1, 3, 6], [1, 3, 6], [2, 1, 6], [1, 3, 7], [1, 3, 6]]
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data)
-        expTest = nimble.data(t, expData)
+    for constructor in getDataConstructors():
+        toTest = constructor(data)
+        expTest = constructor(expData)
         learner = KNNImputation()
         learner.train(toTest, mode='classification', k=3)
         ret = learner.apply(toTest)
@@ -71,12 +72,16 @@ def test_KNNImputation_lazyNameGeneration():
 
 def test_KNNImputation_NamePath_preservation():
     data = [[None, None, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1]]
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data)
+    for constructor in getDataConstructors():
+        toTest = constructor(data)
 
         toTest._name = "TestName"
-        toTest._absPath = os.path.abspath("TestAbsPath")
-        toTest._relPath = "testRelPath"
+        if isinstance(toTest, nimble.core.data.BaseView):
+            toTest._source._absPath = os.path.abspath('TestAbsPath')
+            toTest._source._relPath = 'testRelPath'
+        else:
+            toTest._absPath = os.path.abspath("TestAbsPath")
+            toTest._relPath = "testRelPath"
 
         learner = KNNImputation()
         learner.train(toTest, mode='classification', k=3)

--- a/tests/data/high_level_backend.py
+++ b/tests/data/high_level_backend.py
@@ -47,6 +47,7 @@ from tests.helpers import logCountAssertionFactory
 from tests.helpers import noLogEntryExpected, oneLogEntryExpected
 from tests.helpers import assertNoNamesGenerated
 from tests.helpers import CalledFunctionException, calledException
+from tests.helpers import getDataConstructors
 
 
 preserveName = "PreserveTestName"
@@ -1344,8 +1345,8 @@ class HighLevelDataSafe(DataTestObject):
 
             toTest = self.constructor(data)
 
-            for retType in nimble.core.data.available:
-                currObj = nimble.data(retType, data, useLog=False)
+            for constructor in getDataConstructors():
+                currObj = constructor(data, useLog=False)
                 assert toTest.isApproximatelyEqual(currObj)
                 assert toTest.hashCode() == currObj.hashCode()
                 assertNoNamesGenerated(toTest)

--- a/tests/data/numerical_backend.py
+++ b/tests/data/numerical_backend.py
@@ -20,6 +20,7 @@ import numpy
 import os
 import os.path
 from unittest.mock import patch
+from functools import partial
 
 from nose.tools import *
 
@@ -34,7 +35,7 @@ from .baseObject import DataTestObject
 from tests.helpers import logCountAssertionFactory, noLogEntryExpected
 from tests.helpers import assertNoNamesGenerated
 from tests.helpers import CalledFunctionException, calledException
-
+from tests.helpers import getDataConstructors
 
 preserveName = "PreserveTestName"
 preserveAPath = os.path.join(os.getcwd(), "correct", "looking", "path")
@@ -814,10 +815,9 @@ def back_autoVsNumpyScalar(constructor, opName, nimbleinplace, sparsity):
 
 def back_autoVsNumpyObjCalleeDiffTypes(constructor, opName, nimbleinplace, sparsity):
     """ Test operation on handmade data with different types of data objects"""
-    makers = [getattr(nimble.core.data, retType) for retType in nimble.core.data.available]
+    makers = [partial(con, useLog=False) for con in getDataConstructors()]
 
-    for i in range(len(makers)):
-        maker = makers[i]
+    for maker in makers:
         numPts = pythonRandom.randint(1, 10)
         # use square for matmul so shapes are compatible, otherwise randomize
         if 'matmul' in opName:
@@ -1714,7 +1714,7 @@ class NumericalDataSafe(DataTestObject):
         assert expObj == getattr(lhsObj, logicOp)(rhsObj)
 
     @noLogEntryExpected
-    def back_logical_diffObjectTypes(self, logicOp):
+    def back_logical_allObjectTypes(self, logicOp):
         lhs = [[True, True], [True, False]]
         rhs = [[False, True], [False, False]]
 
@@ -1722,8 +1722,8 @@ class NumericalDataSafe(DataTestObject):
 
         exp = self.getLogicalExpectedOutput(logicOp)
         expObj = self.constructor(exp)
-        for rType in [t for t in nimble.core.data.available if t != lhsObj.getTypeString()]:
-            rhsObj = nimble.data(rType, rhs, useLog=False)
+        for constructor in getDataConstructors():
+            rhsObj = constructor(rhs, useLog=False)
 
             assert expObj == getattr(lhsObj, logicOp)(rhsObj)
 
@@ -1737,7 +1737,7 @@ class NumericalDataSafe(DataTestObject):
         self.back_logical_allCombinations(logicOp, inputType='bool')
         self.back_logical_allCombinations(logicOp, inputType='int')
         self.back_logical_allCombinations(logicOp, inputType='float')
-        self.back_logical_diffObjectTypes(logicOp)
+        self.back_logical_allObjectTypes(logicOp)
 
     ###########
     # __and__ #

--- a/tests/data/stretch_backend.py
+++ b/tests/data/stretch_backend.py
@@ -14,6 +14,7 @@ from nimble.random import pythonRandom
 from .baseObject import DataTestObject
 from tests.helpers import assertNoNamesGenerated
 from tests.helpers import noLogEntryExpected
+from tests.helpers import getDataConstructors
 
 class StretchDataSafe(DataTestObject):
 
@@ -691,18 +692,17 @@ class StretchDataSafe(DataTestObject):
         assert ret2.isIdentical(exp)
 
     @noLogEntryExpected
-    def test_stretch_differentObjectTypes(self):
+    def test_stretch_allObjectTypes(self):
         matrixObj = self.constructor([[1, 2, 3], [4, 5, 6]])
         pointVect = self.constructor([9, 8, 7])
         featureVect = self.constructor([[8], [9]])
-        otherTypes = [t for t in nimble.core.data.available if t != matrixObj.getTypeString()]
-        for oType in otherTypes:
+        for constructor in getDataConstructors():
             possibleOps = [operator.add, operator.sub, operator.mul, operator.truediv,
                            operator.floordiv, operator.mod, operator.pow]
             randOp = possibleOps[pythonRandom.randint(0, 6)]
-            matDiff = matrixObj.copy(oType)
-            pvDiff = pointVect.copy(oType)
-            fvDiff = featureVect.copy(oType)
+            matDiff = constructor(matrixObj.copy(), useLog=False)
+            pvDiff = constructor(pointVect.copy(), useLog=False)
+            fvDiff = constructor(featureVect.copy(), useLog=False)
 
             out1 = randOp(matrixObj, pvDiff.stretch)
             assert out1.getTypeString() == matrixObj.getTypeString()
@@ -720,7 +720,7 @@ class StretchDataSafe(DataTestObject):
             assert out5.getTypeString() == pointVect.getTypeString()
 
             out6 = randOp(featureVect.stretch, pvDiff.stretch)
-            assert out5.getTypeString() == pointVect.getTypeString()
+            assert out6.getTypeString() == pointVect.getTypeString()
 
     @noLogEntryExpected
     def back_stretchSetNames(self, obj1, obj2, expPts, expFts):

--- a/tests/data/structure_backend.py
+++ b/tests/data/structure_backend.py
@@ -49,6 +49,7 @@ from tests.helpers import logCountAssertionFactory
 from tests.helpers import noLogEntryExpected, oneLogEntryExpected
 from tests.helpers import assertNoNamesGenerated, assertExpectedException
 from tests.helpers import CalledFunctionException, calledException
+from tests.helpers import getDataConstructors
 
 preserveName = "PreserveTestName"
 preserveAPath = os.path.join(os.getcwd(), "correct", "looking", "path")
@@ -3007,21 +3008,18 @@ class StructureModifying(StructureShared):
     def backend_insert_allPossibleNimbleDataType(self, axis):
         data = [[1, 2, 3], [4, 5, 6], [7, 8, 9]]
 
-        currType = self.constructor([]).getTypeString()
-        availableTypes = nimble.core.data.available
-        otherTypes = [retType for retType in availableTypes if retType != currType]
         inserted = []
-        for other in otherTypes:
+        for constructor in getDataConstructors():
             toTest = self.constructor(data)
             if axis == 'point':
                 insertData = [[-1, -2, -3]]
-                otherTest = nimble.data(other, insertData)
+                otherTest = constructor(insertData)
                 exp = self.constructor([[1, 2, 3], [4, 5, 6], [7, 8, 9], [-1, -2, -3]])
                 toTest.points.insert(len(toTest.points), otherTest)
                 inserted.append(toTest)
             else:
                 insertData = [[-1], [-2], [-3]]
-                otherTest = nimble.data(other, insertData)
+                otherTest = constructor(insertData)
                 exp = self.constructor([[1, 2, 3, -1], [4, 5, 6, -2], [7, 8, 9, -3]])
                 toTest.features.insert(len(toTest.features), otherTest)
                 inserted.append(toTest)
@@ -8227,9 +8225,9 @@ class StructureModifying(StructureShared):
         fill = [[0, 0], [0, 0]]
         exp = [[0, 0, 13], [0, 0, 23], [31, 32, 33]]
         exp = self.constructor(exp)
-        for t in nimble.core.data.available:
+        for constructor in getDataConstructors():
             toTest = self.constructor(raw)
-            arg = nimble.data(t, fill)
+            arg = constructor(fill)
             toTest.replaceRectangle(arg, 0, 0, 1, 1)
             assert toTest == exp
 

--- a/tests/fill/test_fill.py
+++ b/tests/fill/test_fill.py
@@ -3,6 +3,7 @@ from nimble import fill
 from nimble import match
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
 from tests.helpers import noLogEntryExpected
+from tests.helpers import getDataConstructors
 
 
 @noLogEntryExpected
@@ -11,9 +12,9 @@ def test_constant_noMatches():
     match = lambda x: False
     constant = 100
     expected = [1, 2, 2, 9]
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data, useLog=False)
-        exp = nimble.data(t, expected, useLog=False)
+    for constructor in getDataConstructors():
+        toTest = constructor(data, useLog=False)
+        exp = constructor(expected, useLog=False)
         assert fill.constant(toTest, match, constant) == exp
 
 @noLogEntryExpected
@@ -22,9 +23,9 @@ def test_constant_number_ignoreMatches():
     match = lambda x: x == 2
     constant = 100
     expected = [1, 100, 100, 9]
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data, useLog=False)
-        exp = nimble.data(t, expected, useLog=False)
+    for constructor in getDataConstructors():
+        toTest = constructor(data, useLog=False)
+        exp = constructor(expected, useLog=False)
         assert fill.constant(toTest, match, constant) == exp
 
 @noLogEntryExpected
@@ -33,9 +34,9 @@ def test_constant_string_ignoreMatches():
     match = lambda x: x == 2
     constant = ""
     expected = [1, "", "", 9]
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data, useLog=False)
-        exp = nimble.data(t, expected, useLog=False)
+    for constructor in getDataConstructors():
+        toTest = constructor(data, useLog=False)
+        exp = constructor(expected, useLog=False)
         assert fill.constant(toTest, match, constant) == exp
 
 @noLogEntryExpected
@@ -44,25 +45,25 @@ def test_constant_allMatches():
     match = lambda x: x in [1, 2, 9]
     constant = 100
     expected = [100, 100, 100, 100]
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data, useLog=False)
-        exp = nimble.data(t, expected, useLog=False)
+    for constructor in getDataConstructors():
+        toTest = constructor(data, useLog=False)
+        exp = constructor(expected, useLog=False)
         assert fill.constant(toTest, match, constant) == exp
 
 @noLogEntryExpected
 def backend_fill(func, data, match, expected=None):
     "backend for fill functions that do not require additional arguments"
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data, useLog=False)
-        exp = nimble.data(t, expected, useLog=False)
+    for constructor in getDataConstructors():
+        toTest = constructor(data, useLog=False)
+        exp = constructor(expected, useLog=False)
         assert func(toTest, match) == exp
 
 @noLogEntryExpected
 def backend_fill_exception(func, data, match, exceptionType):
     "backend for fill functions when testing exception raising"
-    for t in nimble.core.data.available:
+    for constructor in getDataConstructors():
         try:
-            toTest = nimble.data(t, data, useLog=False)
+            toTest = constructor(data, useLog=False)
             func(toTest, match)
             assert False  # Expected an exception
         except exceptionType as et:
@@ -198,9 +199,9 @@ def test_interpolate_withArguments():
     arguments['fp'] = [5, 13, 21]
     match = lambda x: x == "na"
     expected = [1, 7, 9, 5]
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data, useLog=False)
-        exp = nimble.data(t, expected, useLog=False)
+    for constructor in getDataConstructors():
+        toTest = constructor(data, useLog=False)
+        exp = constructor(expected, useLog=False)
         assert fill.interpolate(toTest, match, **arguments) == exp
 
 @noLogEntryExpected
@@ -212,9 +213,9 @@ def test_interpolate_xKwargIncluded_exception():
     arguments['fp'] = [5, 13, 21]
     arguments['x'] = [1]  # disallowed argument
     match = lambda x: x == "na"
-    for t in nimble.core.data.available:
+    for constructor in getDataConstructors():
         try:
-            toTest = nimble.data(t, data, useLog=False)
+            toTest = constructor(data, useLog=False)
             ret = fill.interpolate(toTest, match, **arguments)
             assert False  # expected TypeError
         except TypeError:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -5,7 +5,7 @@ Custom assertion types can be helpful if the assertion can be added to
 existing tests which are also testing other functionality.
 """
 import tempfile
-from functools import wraps
+from functools import wraps, partial
 import os
 import copy
 
@@ -156,3 +156,29 @@ def assertExpectedException(exception, func, *args, messageIncludes=None,
     except exception as e:
         if messageIncludes is not None:
             assert messageIncludes in str(e)
+
+def _getViewFunc(returnType):
+    """
+    Return function creating a view of the given returnType.
+    Helper for dataConstructors.
+    """
+    def getView(*args, **kwargs):
+        obj = nimble.data(returnType, *args, **kwargs)
+        return obj.view()
+    # mirror attributes of functools.partial
+    getView.func = nimble.data
+    getView.args = [returnType]
+    getView.kwargs = {}
+    return getView
+
+def getDataConstructors(includeViews=True):
+    """
+    Create data object constructors for tests iterating through each
+    concrete data type. By default includes constructors for views.
+    """
+    constructors = []
+    for returnType in nimble.core.data.available:
+        constructors.append(partial(nimble.data, returnType))
+        if includeViews:
+            constructors.append(_getViewFunc(returnType))
+    return constructors

--- a/tests/logger/data_set_analyzier_tests.py
+++ b/tests/logger/data_set_analyzier_tests.py
@@ -5,6 +5,7 @@ from nose.tools import assert_almost_equal, assert_equal
 import nimble
 from nimble._utility import scipy
 from nimble.core.logger.data_set_analyzer import *
+from tests.helpers import getDataConstructors
 
 
 def testProduceInfoTable_denseData():
@@ -14,8 +15,8 @@ def testProduceInfoTable_denseData():
     """
     data1 = np.array([[1, 2, 3, 1], [3, 3, 1, 5], [1, 1, 5, 2]])
     names1 = ['var1', 'var2', 'var3', 'var4']
-    for retType in nimble.core.data.available:
-        trainObj = nimble.data(retType, source=data1, featureNames=names1)
+    for constructor in getDataConstructors():
+        trainObj = constructor(source=data1, featureNames=names1)
         funcs = featurewiseFunctionGenerator()
         rawTable = produceFeaturewiseInfoTable(trainObj, funcs)
         funcNames = rawTable[0]
@@ -67,8 +68,8 @@ def testProduceInfoTable_sparseData():
 
     raw = scipy.sparse.coo_matrix((vals, (row, col)))
 
-    for retType in nimble.core.data.available:
-        testObj = nimble.data(retType, source=raw)
+    for constructor in getDataConstructors():
+        testObj = constructor(source=raw)
         funcs = featurewiseFunctionGenerator()
         rawTable = produceFeaturewiseInfoTable(testObj, funcs)
         print(rawTable)

--- a/tests/logger/testLoggingCount.py
+++ b/tests/logger/testLoggingCount.py
@@ -27,6 +27,7 @@ from nimble.core.data import Features
 from nimble.core.interfaces.universal_interface import UniversalInterface
 from nimble.core.interfaces.universal_interface import TrainedLearner
 from tests.helpers import noLogEntryExpected, oneLogEntryExpected
+from tests.helpers import getDataConstructors
 
 ALL_USER_FACING = []
 modules = [nimble, calculate, exceptions, fill, match, random]
@@ -225,8 +226,8 @@ def test_Init_logCount():
 
 @noLogEntryExpected
 def test_copy_logCount():
-    for rType in nimble.core.data.available:
-        obj = nimble.data(rType, [[1,2,3],[4,5,6]], useLog=False)
+    for constructor in getDataConstructors():
+        obj = constructor([[1,2,3],[4,5,6]], useLog=False)
         copy = obj.copy()
 
 def test_featureReport_logCount():
@@ -245,21 +246,21 @@ def test_groupByFeature_logCount():
     @oneLogEntryExpected
     def wrapped(obj):
         return obj.groupByFeature(0)
-    for rType in nimble.core.data.available:
-        obj = nimble.data(rType, [[1,2,3],[1,4,5],[2,2,3],[2,4,5]],
+    for constructor in getDataConstructors():
+        obj = constructor([[1,2,3],[1,4,5],[2,2,3],[2,4,5]],
                           useLog=False)
         grouped = wrapped(obj)
 
 @noLogEntryExpected
 def test_getTypeString_logCount():
-    for rType in nimble.core.data.available:
-        obj = nimble.data(rType, [[1,2,3],[4,5,6]], useLog=False)
+    for constructor in getDataConstructors():
+        obj = constructor([[1,2,3],[4,5,6]], useLog=False)
         ts = obj.getTypeString()
 
 @noLogEntryExpected
 def test_hashCode_logCount():
-    for rType in nimble.core.data.available:
-        obj = nimble.data(rType, [[1,2,3],[4,5,6]], useLog=False)
+    for constructor in getDataConstructors():
+        obj = constructor([[1,2,3],[4,5,6]], useLog=False)
         hash = obj.hashCode()
 
 @noLogEntryExpected
@@ -276,8 +277,8 @@ def test_toString_logCount():
 
 @noLogEntryExpected
 def test_validate_logCount():
-    for rType in nimble.core.data.available:
-        obj = nimble.data(rType, [[1,2,3],[4,5,6]], useLog=False)
+    for constructor in getDataConstructors():
+        obj = constructor([[1,2,3],[4,5,6]], useLog=False)
         isDefault = obj.validate()
 
 ############################
@@ -288,8 +289,8 @@ def test_points_permute_logCount():
     @oneLogEntryExpected
     def wrapped(obj):
         return obj.points.permute()
-    for rType in nimble.core.data.available:
-        obj = nimble.data(rType, [[1,2,3],[1,4,5],[2,2,3],[2,4,5]],
+    for constructor in getDataConstructors(includeViews=False):
+        obj = constructor([[1,2,3],[1,4,5],[2,2,3],[2,4,5]],
                           useLog=False)
         grouped = wrapped(obj)
 
@@ -297,8 +298,8 @@ def test_features_permute_logCount():
     @oneLogEntryExpected
     def wrapped(obj):
         return obj.features.permute()
-    for rType in nimble.core.data.available:
-        obj = nimble.data(rType, [[1,2,3],[1,4,5],[2,2,3],[2,4,5]],
+    for constructor in getDataConstructors(includeViews=False):
+        obj = constructor([[1,2,3],[1,4,5],[2,2,3],[2,4,5]],
                              useLog=False)
         grouped = wrapped(obj)
 
@@ -348,8 +349,8 @@ def captureOutput(toCall):
         backupOut = sys.stdout
         sys.stdout = tmpFile
         try:
-            for rType in nimble.core.data.available:
-                obj = nimble.data(rType, [[1,2,3],[4,5,6]], useLog=False)
+            for constructor in getDataConstructors():
+                obj = constructor([[1,2,3],[4,5,6]], useLog=False)
                 ret = toCall(obj)
         finally:
             sys.stdout = backupOut

--- a/tests/logger/testLoggingFlags.py
+++ b/tests/logger/testLoggingFlags.py
@@ -13,6 +13,10 @@ import nimble
 from nimble.calculate import fractionIncorrect
 from tests.helpers import configSafetyWrapper
 from tests.helpers import generateClassificationData
+from tests.helpers import getDataConstructors
+
+constructors = getDataConstructors()
+nonViewConstructors = getDataConstructors(includeViews=False)
 
 learnerName = 'nimble.KNNClassifier'
 
@@ -66,17 +70,19 @@ def test_random_data():
         back_load(nimble.random.data, rType, 5, 5, 0.99)
 
 def test_loadData():
-    for rType in nimble.core.data.available:
-        obj = nimble.data(rType, [[1, 2, 3], [4, 5, 6]], useLog=False)
+    for constructor in constructors:
+        obj = constructor([[1, 2, 3], [4, 5, 6]], useLog=False)
         with tempfile.NamedTemporaryFile(suffix='.nimd') as tmpFile:
             obj.save(tmpFile.name)
             back_load(nimble.loadData, tmpFile.name)
 
 def test_loadTrainedLearner():
-    for rType in nimble.core.data.available:
-        train = nimble.data(rType, [[0, 0, 1], [0, 1, 0], [1, 0, 0]], useLog=False)
-        test = nimble.data(rType, [[3], [2], [1]], useLog=False)
-        tl = nimble.train('nimble.KNNClassifier', train, test)
+    # Weird failure for SparseView (something to do with __getstate__ attribute
+    # lookup for scipy by cloudpickle?)
+    for constructor in constructors:
+        trainX = constructor([[0, 0, 1], [0, 1, 0], [1, 0, 0]], useLog=False)
+        trainY = constructor([[3], [2], [1]], useLog=False)
+        tl = nimble.train('nimble.KNNClassifier', trainX, trainY)
         with tempfile.NamedTemporaryFile(suffix='.nimm') as tmpFile:
             tl.save(tmpFile.name)
             back_load(nimble.loadTrainedLearner, tmpFile.name)
@@ -300,14 +306,14 @@ def test_Deep_trainAndTestOnTrainingData_CVError():
     wrapped.__name__ = 'trainAndTestOnTrainingData'
     backendDeep(wrapped, runAndCheck)
 
-def prepAndCheck(toCall, rType, useLog):
+def prepAndCheck(toCall, constructor, useLog):
     data = [["a", 1, 1], ["a", 1, 1], ["a", 1, 1], ["a", 1, 1], ["a", 1, 1], ["a", 1, 1],
             ["b", 2, 2], ["b", 2, 2], ["b", 2, 2], ["b", 2, 2], ["b", 2, 2], ["b", 2, 2],
             ["c", 3, 3], ["c", 3, 3], ["c", 3, 3], ["c", 3, 3], ["c", 3, 3], ["c", 3, 3]]
     pNames = ['p' + str(i) for i in range(18)]
     fNames = ['f0', 'f1', 'f2']
     # nimble.data not logged
-    dataObj = nimble.data(rType, data, pointNames=pNames,
+    dataObj = constructor(data, pointNames=pNames,
                           featureNames=fNames, useLog=False)
 
     logger = nimble.core.logger.active
@@ -328,57 +334,57 @@ def test_replaceFeatureWithBinaryFeatures():
     def wrapped(obj, useLog):
         return obj.replaceFeatureWithBinaryFeatures(0, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_transformFeatureToIntegers():
     def wrapped(obj, useLog):
         return obj.transformFeatureToIntegers(0, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_trainAndTestSets():
     def wrapped(obj, useLog):
         return obj.trainAndTestSets(testFraction=0.5, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in constructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_groupByFeature():
     def wrapped(obj, useLog):
         return obj.groupByFeature(by=0, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in constructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_transpose():
     def wrapped(obj, useLog):
         obj.transpose(useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_replaceRectangle():
     def wrapped(obj, useLog):
         obj.replaceRectangle(1, 2, 0, 4, 0, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_featureReport():
     def wrapped(obj, useLog):
         obj[:, 1].featureReport(useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in constructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_summaryReport():
     def wrapped(obj, useLog):
         obj.summaryReport(useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in constructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 @configSafetyWrapper
 def flattenUnflattenBackend(toCall, validator, **kwargs):
@@ -411,16 +417,18 @@ def test_flattenUnflatten_pointAxis():
         obj.flatten(useLog=useLog)
         obj.unflatten((18, 3), useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        flattenUnflattenBackend(wrapped_Flatten_UnFlatten, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        flattenUnflattenBackend(wrapped_Flatten_UnFlatten, prepAndCheck,
+                                constructor=constructor)
 
 def test_flattenUnflatten_featureAxis():
     def wrapped_Flatten_UnFlatten(obj, useLog):
         obj.flatten(order='feature', useLog=useLog)
         obj.unflatten((18, 3), order='feature', useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        flattenUnflattenBackend(wrapped_Flatten_UnFlatten, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        flattenUnflattenBackend(wrapped_Flatten_UnFlatten, prepAndCheck,
+                                constructor=constructor)
 
 def test_merge():
     mData = [[1, 4], [2, 5], [3, 6]]
@@ -431,30 +439,30 @@ def test_merge():
     def wrapped(obj, useLog):
         obj.merge(mergeObj, point='intersection', feature='union', useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_transformElements():
     def wrapped(obj, useLog):
         ret = obj.transformElements(lambda elm: elm, features=0, useLog=useLog)
         return ret
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_calculateOnElements():
     def wrapped(obj, useLog):
         return obj.calculateOnElements(lambda x: len(x), features=0, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in constructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_matchingElements():
     def wrapped(obj, useLog):
         return obj.matchingElements(lambda x: True, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in constructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 ###################
 # Points/Features #
@@ -480,151 +488,150 @@ def test_point_mapReduce():
     def wrapped(obj, useLog):
         return obj.points.mapReduce(simpleMapper, simpleReducer, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in constructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_mapReduce():
     def wrapped(obj, useLog):
         # transpose data to make use of same mapper and reducer
-        obj.transpose(useLog=False)
-        return obj.features.mapReduce(simpleMapper, simpleReducer, useLog=useLog)
+        return obj.T.features.mapReduce(simpleMapper, simpleReducer, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in constructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_points_calculate():
     def wrapped(obj, useLog):
         return obj.points.calculate(lambda x: len(x), useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in constructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_calculate():
     def wrapped(obj, useLog):
         return obj.features.calculate(lambda x: len(x), features=0, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in constructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_points_permute():
     def wrapped(obj, useLog):
         return obj.points.permute(useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_permute():
     def wrapped(obj, useLog):
         return obj.features.permute(useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_normalize():
     def wrapped(obj, useLog):
         return obj.features.normalize(lambda x: x, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_points_sort():
     def wrapped(obj, useLog):
         return obj.points.sort(by="f0", useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_sort():
     def wrapped(obj, useLog):
         return obj.features.sort(by=nimble.match.allNumeric, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_points_extract():
     def wrapped(obj, useLog):
         return obj.points.extract(toExtract=0, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_extract():
     def wrapped(obj, useLog):
         return obj.features.extract(toExtract=0, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_points_delete():
     def wrapped(obj, useLog):
         return obj.points.delete(toDelete=0, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_delete():
     def wrapped(obj, useLog):
         return obj.features.delete(toDelete=0, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_points_retain():
     def wrapped(obj, useLog):
         return obj.points.retain(toRetain=0, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_retain():
     def wrapped(obj, useLog):
         return obj.features.retain(toRetain=0, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_points_copy():
     def wrapped(obj, useLog):
         return obj.points.copy(toCopy=0, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in constructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_copy():
     def wrapped(obj, useLog):
         return obj.features.copy(toCopy=0, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in constructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_points_fillMatching():
     def wrapped(obj, useLog):
         return obj.points.fillMatching(fillWith=11, matchingElements=1, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_fillMatching():
     def wrapped(obj, useLog):
         return obj.features.fillMatching(fillWith=11, matchingElements=1, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 
 def test_points_transform():
     def wrapped(obj, useLog):
         return obj.points.transform(lambda pt: [val for val in pt], useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_transform():
     def wrapped(obj, useLog):
         return obj.features.transform(lambda ft: [val for val in ft], features=0, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_points_insert():
     def wrapped(obj, useLog):
@@ -632,8 +639,8 @@ def test_points_insert():
         toInsert = nimble.data("Matrix", insertData, useLog=False)
         return obj.points.insert(0, toInsert, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_insert():
     def wrapped(obj, useLog):
@@ -641,8 +648,8 @@ def test_features_insert():
         toInsert = nimble.data("Matrix", insertData, useLog=False)
         return obj.features.insert(0, toInsert, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_points_append():
 
@@ -651,8 +658,8 @@ def test_points_append():
         toAppend = nimble.data("Matrix", appendData, useLog=False)
         return obj.points.append(toAppend, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_append():
     def wrapped(obj, useLog):
@@ -660,8 +667,8 @@ def test_features_append():
         toAppend = nimble.data("Matrix", appendData, useLog=False)
         return obj.features.append(toAppend, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_splitByParsing():
     def customParser(val):
@@ -674,16 +681,16 @@ def test_features_splitByParsing():
     def wrapped(obj, useLog):
         return obj.features.splitByParsing(1, customParser, ['str', 'int'], useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_points_splitByCollapsingFeatures():
     def wrapped(obj, useLog):
         return obj.points.splitByCollapsingFeatures(['f0', 'f1', 'f2'],
                                                     'featureNames', 'values',
                                                     useLog = useLog)
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_points_combineByExpandingFeatures():
     def wrapped(obj, useLog):
@@ -696,35 +703,35 @@ def test_points_combineByExpandingFeatures():
         newObj = nimble.data('Matrix', newData, featureNames=fNames, useLog=False)
         return newObj.points.combineByExpandingFeatures('dist', 'time', useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_points_setName():
     def wrapped(obj, useLog):
         return obj.points.setName(0, 'newPointName', useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_setName():
     def wrapped(obj, useLog):
         return obj.features.setName(0, 'newFeatureName', useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_points_setNames():
     def wrapped(obj, useLog):
         newNames = ['new_pt' + str(i) for i in range(18)]
         return obj.points.setNames(newNames, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)
 
 def test_features_setNames():
     def wrapped(obj, useLog):
         newNames = ['new_ft' + str(i) for i in range(3)]
         return obj.features.setNames(newNames, useLog=useLog)
 
-    for rType in nimble.core.data.available:
-        backend(wrapped, prepAndCheck, rType=rType)
+    for constructor in nonViewConstructors:
+        backend(wrapped, prepAndCheck, constructor=constructor)

--- a/tests/logger/testLoggingIO.py
+++ b/tests/logger/testLoggingIO.py
@@ -25,6 +25,7 @@ from nimble.exceptions import InvalidArgumentValueCombination
 from nimble.exceptions import InvalidArgumentType
 from tests.helpers import generateClassificationData
 from tests.helpers import configSafetyWrapper
+from tests.helpers import getDataConstructors
 
 #####################
 # Helpers for tests #
@@ -804,8 +805,9 @@ def testLambdaStringConversionCommas():
     data = [["a", 1, 1], ["a", 1, 1], ["a", 1, 1], ["a", 1, 1], ["a", 1, 1], ["a", 1, 1],
             ["b", 2, 2], ["b", 2, 2], ["b", 2, 2], ["b", 2, 2], ["b", 2, 2], ["b", 2, 2],
             ["c", 3, 3], ["c", 3, 3], ["c", 3, 3], ["c", 3, 3], ["c", 3, 3], ["c", 3, 3]]
-    for retType in nimble.core.data.available:
-        dataObj = nimble.data(retType, data, useLog=False)
+    for constructor in getDataConstructors():
+        retType = constructor.args[0]
+        dataObj = constructor(data, useLog=False)
         calculated1 = dataObj.points.calculate(lambda x: [x[0], x[2]], points=0)
         checkLogContents('points.calculate', retType, {'function': "lambda x: [x[0], x[2]]",
                                                         'points': 0})

--- a/tests/match/test_match.py
+++ b/tests/match/test_match.py
@@ -3,6 +3,7 @@ import numpy
 import nimble
 from nimble import match
 from tests.helpers import noLogEntryExpected
+from tests.helpers import getDataConstructors
 
 @noLogEntryExpected
 def backend_match_value(toMatch, true, false):
@@ -68,8 +69,8 @@ def test_match_infinity():
 def backend_match_anyAll(anyOrAll, func, data):
     """backend for match functions accepting 1D and 2D data and testing for any or all"""
     data = numpy.array(data, dtype=numpy.object_)
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data, useLog=False)
+    for constructor in getDataConstructors():
+        toTest = constructor(data, useLog=False)
         # test whole matrix
         if anyOrAll == 'any':
             assert func(toTest)
@@ -91,7 +92,7 @@ def backend_match_anyAll(anyOrAll, func, data):
             else:
                 assert func(feature)
         # test by point
-        toTest.transpose(useLog=False)
+        toTest = toTest.T
         for i, point in enumerate(toTest.points):
             # index 0 never contains any matching values
             if i == 0:

--- a/tests/testCrossValidate.py
+++ b/tests/testCrossValidate.py
@@ -6,6 +6,7 @@ the backend helpers they rely on.
 import math
 import sys
 from unittest import mock
+import functools
 
 import numpy
 import nose
@@ -29,13 +30,17 @@ from nimble.core.learn import KFoldCrossValidator
 from tests.helpers import configSafetyWrapper
 from tests.helpers import logCountAssertionFactory
 from tests.helpers import generateClassificationData
+from tests.helpers import getDataConstructors
 
 
-def _randomLabeledDataSet(dataType='Matrix', numPoints=50, numFeatures=5, numLabels=3):
+def _randomLabeledDataSet(numPoints=50, numFeatures=5, numLabels=3,
+                          constructor=None):
     """returns a tuple of two data objects of type dataType
     the first object in the tuple contains the feature information ('X' in nimble language)
     the second object in the tuple contains the labels for each feature ('Y' in nimble language)
     """
+    if constructor is None:
+        constructor = functools.partial(nimble.data, 'Matrix')
     if numLabels is None:
         labelsRaw = [[pythonRandom.random()] for _x in range(numPoints)]
     else:  # labels data set
@@ -43,7 +48,8 @@ def _randomLabeledDataSet(dataType='Matrix', numPoints=50, numFeatures=5, numLab
 
     rawFeatures = [[pythonRandom.random() for _x in range(numFeatures)] for _y in range(numPoints)]
 
-    return (nimble.data(dataType, rawFeatures, useLog=False), nimble.data(dataType, labelsRaw, useLog=False))
+    return (constructor(rawFeatures, useLog=False),
+            constructor(labelsRaw, useLog=False))
 
 
 def test_crossValidate_XY_unchanged():
@@ -69,8 +75,9 @@ def test_crossValidate_callable():
     numLabels = 3
     numPoints = 10
 
-    for dType in nimble.core.data.available:
-        X, Y = _randomLabeledDataSet(numPoints=numPoints, numLabels=numLabels, dataType=dType)
+    for constructor in getDataConstructors():
+        X, Y = _randomLabeledDataSet(numPoints=numPoints, numLabels=numLabels,
+                                     constructor=constructor)
 
         classifierAlgos = ['nimble.KNNClassifier']
         for curAlgo in classifierAlgos:
@@ -78,7 +85,8 @@ def test_crossValidate_callable():
             assert isinstance(crossValidator.bestResult, float)
 
             #With regression dataset (no repeated labels)
-            X, Y = _randomLabeledDataSet(numPoints=numPoints, numLabels=None, dataType=dType)
+            X, Y = _randomLabeledDataSet(numPoints=numPoints, numLabels=None,
+                                         constructor=constructor)
             classifierAlgos = ['nimble.RidgeRegression']
             for curAlgo in classifierAlgos:
                 crossValidator = crossValidate(curAlgo, X, Y, meanAbsoluteError, {}, folds=3)

--- a/tests/testFillMatching.py
+++ b/tests/testFillMatching.py
@@ -13,12 +13,16 @@ from nimble.exceptions import ImproperObjectAction, InvalidArgumentValue
 
 from tests.helpers import logCountAssertionFactory
 from tests.helpers import assertNoNamesGenerated
+from tests.helpers import getDataConstructors
+
+# fillMatching is inplace
+constructors = getDataConstructors(includeViews=False)
 
 def test_fillMatching_exception_nansUnmatched():
     raw = [[1, 1, 1, 0], [1, 1, 1, None], [2, 2, 2, 0], [2, 2, 2, 3],
            [2, 2, 2, 4], [2, 2, 2, 4]]
-    for t in nimble.core.data.available:
-        data = nimble.data(t, raw)
+    for constructor in constructors:
+        data = constructor(raw)
         try:
             nimble.fillMatching('nimble.KNNImputation', 1, data, mode='classification')
             assert False # expected ImproperObjectAction
@@ -28,8 +32,8 @@ def test_fillMatching_exception_nansUnmatched():
 def test_fillMatching_trainXUnaffectedByFailure():
     raw = [[2, 2, 2, 4], [2, 2, 2, 4], [2, 2, 2, 0], [2, 2, 2, 3],
            [2, 2, 2, 4], [2, 2, 2, 4]]
-    for t in nimble.core.data.available:
-        data = nimble.data(t, raw)
+    for constructor in constructors:
+        data = constructor(raw)
         dataCopy = data.copy()
         # trying to fill 2 will fail because the training data will be empty
         try:
@@ -40,9 +44,9 @@ def test_fillMatching_trainXUnaffectedByFailure():
 
 @logCountAssertionFactory(len(nimble.core.data.available) * 2)
 def backend_fillMatching(matchingElements, raw, expRaw):
-    for t in nimble.core.data.available:
-        data = nimble.data(t, raw, useLog=False)
-        exp = nimble.data(t, expRaw, useLog=False)
+    for constructor in constructors:
+        data = constructor(raw, useLog=False)
+        exp = constructor(expRaw, useLog=False)
         for value in ['nimble.KNNImputation', KNNImputation]:
             nimble.fillMatching(value, matchingElements, data,
                                 mode='classification', k=1)
@@ -96,9 +100,9 @@ def test_fillMatching_pointsLimited():
     pNames = ['p0', 'p1', 'p2', 'p3', 'p4']
     data = [[1, None, None], [1, 3, 6], [2, 1, 6], [1, 3, 7], [None, 3, None]]
     expData = [[1, None, None], [1, 3, 6], [2, 1, 6], [1, 3, 7], [1, 3, 6]]
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data, pointNames=pNames, featureNames=fNames)
-        expTest = nimble.data(t, expData, pointNames=pNames, featureNames=fNames)
+    for constructor in constructors:
+        toTest = constructor(data, pointNames=pNames, featureNames=fNames)
+        expTest = constructor(expData, pointNames=pNames, featureNames=fNames)
         nimble.fillMatching('nimble.KNNImputation', match.missing, toTest,
                             points=[2, 3, 4], mode='classification', k=3)
         assert toTest == expTest
@@ -118,9 +122,9 @@ def test_fillMatching_featuresLimited():
     pNames = ['p0', 'p1', 'p2', 'p3', 'p4']
     data = [[1, None, None], [1, 3, 6], [2, 1, 6], [1, 3, 7], [None, 3, None]]
     expData = [[1, 3, None], [1, 3, 6], [2, 1, 6], [1, 3, 7], [1, 3, None]]
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data, pointNames=pNames, featureNames=fNames)
-        expTest = nimble.data(t, expData, pointNames=pNames, featureNames=fNames)
+    for constructor in constructors:
+        toTest = constructor(data, pointNames=pNames, featureNames=fNames)
+        expTest = constructor(expData, pointNames=pNames, featureNames=fNames)
         nimble.fillMatching('nimble.KNNImputation', match.missing, toTest,
                             features=[1,0], mode='classification', k=3)
         assert toTest == expTest
@@ -130,9 +134,9 @@ def test_fillMatching_pointsFeaturesLimited():
     pNames = ['p0', 'p1', 'p2', 'p3', 'p4']
     data = [[1, None, None], [1, 3, 6], [2, 1, 6], [1, 3, 7], [None, 3, None]]
     expData = [[1, None, 6], [1, 3, 6], [2, 1, 6], [1, 3, 7], [None, 3, None]]
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data, pointNames=pNames, featureNames=fNames)
-        expTest = nimble.data(t, expData, pointNames=pNames, featureNames=fNames)
+    for constructor in constructors:
+        toTest = constructor(data, pointNames=pNames, featureNames=fNames)
+        expTest = constructor(expData, pointNames=pNames, featureNames=fNames)
         nimble.fillMatching('nimble.KNNImputation', match.missing, toTest,
                             points=0, features=2, mode='classification', k=3)
         assert toTest == expTest
@@ -140,9 +144,9 @@ def test_fillMatching_pointsFeaturesLimited():
 def test_fillMatching_lazyNameGeneration():
     data = [[1, 'na', 'x'], [1, 3, 6], [2, 1, 6], [1, 3, 7], ['na', 3, 'x']]
     expData = [[1, 3, 6], [1, 3, 6], [2, 1, 6], [1, 3, 7], [1, 3, 6]]
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data)
-        expTest = nimble.data(t, expData)
+    for constructor in constructors:
+        toTest = constructor(data)
+        expTest = constructor(expData)
         nimble.fillMatching('nimble.KNNImputation', match.nonNumeric, toTest,
                             k=3, mode='classification')
 
@@ -151,8 +155,8 @@ def test_fillMatching_lazyNameGeneration():
 
 def test_fillMatching_NamePath_preservation():
     data = [[None, None, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1], [1, 1, 1]]
-    for t in nimble.core.data.available:
-        toTest = nimble.data(t, data)
+    for constructor in constructors:
+        toTest = constructor(data)
 
         toTest._name = "TestName"
         toTest._absPath = os.path.abspath("TestAbsPath")

--- a/tests/testGeneratedData.py
+++ b/tests/testGeneratedData.py
@@ -14,7 +14,6 @@ from nimble.exceptions import InvalidArgumentValue
 from nimble.exceptions import InvalidArgumentValueCombination
 from tests.helpers import noLogEntryExpected
 
-
 returnTypes = copy.copy(nimble.core.data.available)
 
 #######################

--- a/tests/testRandom.py
+++ b/tests/testRandom.py
@@ -120,7 +120,7 @@ def testSparsityReturnedPlausible():
         points (zeros and non zeros) is within 1 percent of the 1 - sparsity.
     -These tests are run for all combinations of the paramaters:
         supportedFundamentalTypes = ['int', 'float']
-        returnTypes = ['Matrix','Sparse','List']
+        returnTypes = ['Matrix', 'Sparse', 'List', 'DataFrame']
         sparsities = [0.0, 0.5, .99]
     """
     supportedFundamentalTypes = ['int', 'float']


### PR DESCRIPTION
The use of constructors, as opposed to `nimble.core.data.available` strings, supports construction of each concrete type and their View. Every case of `nimble.core.data.available` was replaced in tests, except when testing `nimble.data`, `nimble.random.data`, or `Base.copy` since the string inputs `nimble.core.data.available` are the only allowed inputs.

The `getDataConstructors` function is in tests/helpers.py and returns a list of object constructors for testing. By default it includes constructors for the Views, but setting `includeViews` to `False` prevents that for testing functions and methods that make inplace modifications. 

A couple of bugs were identified. 
1) Matrix multiplication for `Matrix `and `DataFrame` have sparse-optimized implementations, but these failed when the other object was `SparseView` because `data` attribute of the `coo_matrix` is set to `None` so `other._data` was replaced with `other._getSparseData()` to work for views as well.  
2) `SparseView` caused an issue when loading a TrainedLearner. Specifically, when `trainY` is a `SparseView` for our `KNNClassifier`, the unpickling process removes the attributes of our ` DeferredModuleImport` for `scipy` causing an infinite loop because `DeferredModuleImport.__getattr__` relies on these attributes. This could be addressed by modifying `KNNClassifier`, but since this is a custom learner and user custom learners could suffer from the same issue, I think it is better to address it on the pickling side. The default pickling behavior (that occurs when [`__getstate__` ](https://docs.python.org/3/library/pickle.html#object.__getstate__) and/or [`__setstate__`](https://docs.python.org/3/library/pickle.html#object.__setstate__) are not defined) appears to work for all other object types, but adding a definition for `__setstate__` in the object prevents failure in all cases. For completeness, `__getstate__` was also added so it is also not reliant on the default behavior.
