### PR TITLE
switch to import numpy as np

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -31,7 +31,7 @@ os.environ['PYTHONPATH'] = NimbleParentDirPath
 
 # -- General configuration ------------------------------------------------
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '2.2'
+needs_sphinx = '3.3'
 
 def process_docstring(app, what, name, obj, options, lines):
     """

--- a/nimble/_utility.py
+++ b/nimble/_utility.py
@@ -12,7 +12,7 @@ import numbers
 import datetime
 from types import ModuleType
 
-import numpy
+import numpy as np
 
 # nimble.exceptions may be imported
 from nimble.exceptions import InvalidArgumentValue, ImproperObjectAction
@@ -123,21 +123,21 @@ def allowedNumpyDType(dtype):
     Check if a dtype is one allowed for nimble data.
     """
     return (dtype in [int, float, bool, object]
-            or numpy.issubdtype(dtype, numpy.number)
-            or numpy.issubdtype(dtype, numpy.datetime64))
+            or np.issubdtype(dtype, np.number)
+            or np.issubdtype(dtype, np.datetime64))
 
 def numpy2DArray(obj, dtype=None, copy=True, order='K', subok=False):
     """
-    Mirror numpy.array() but require the data be two-dimensional.
+    Mirror np.array() but require the data be two-dimensional.
     """
-    ret = numpy.array(obj, dtype=dtype, copy=copy, order=order, subok=subok,
-                      ndmin=2)
+    ret = np.array(obj, dtype=dtype, copy=copy, order=order, subok=subok,
+                   ndmin=2)
     if len(ret.shape) > 2:
         raise InvalidArgumentValue('obj cannot be more than two-dimensional')
 
     if not allowedNumpyDType(ret.dtype):
-        ret = numpy.array(obj, dtype=numpy.object_, copy=copy, order=order,
-                          subok=subok, ndmin=2)
+        ret = np.array(obj, dtype=np.object_, copy=copy, order=order,
+                       subok=subok, ndmin=2)
 
     return ret
 
@@ -145,10 +145,10 @@ def is2DArray(arr):
     """
     Determine if a numpy ndarray object is two-dimensional.
 
-    Since numpy.matrix inherits from numpy.ndarray, they will always
+    Since np.matrix inherits from np.ndarray, they will always
     return True.
     """
-    return isinstance(arr, numpy.ndarray) and len(arr.shape) == 2
+    return isinstance(arr, np.ndarray) and len(arr.shape) == 2
 
 
 class DeferredModuleImport(object):
@@ -240,9 +240,9 @@ def sparseMatrixToArray(sparseMatrix):
                 and not scipy.sparse.isspmatrix_coo(sparseMatrix)):
             sparseMatrix = sparseMatrix.tocoo()
         retDType = sparseMatrix.dtype
-        if isinstance(retDType, numpy.flexible):
+        if isinstance(retDType, np.flexible):
             retDType = object
-        ret = numpy.zeros(sparseMatrix.shape, dtype=retDType)
+        ret = np.zeros(sparseMatrix.shape, dtype=retDType)
         nonzero = (sparseMatrix.row, sparseMatrix.col)
         for (i, j), v in zip(zip(*nonzero), sparseMatrix.data):
             ret[i, j] = v
@@ -253,9 +253,9 @@ def dtypeConvert(obj):
     Most learners need numeric dtypes so attempt to convert from
     object dtype if possible, otherwise return object as-is.
     """
-    if hasattr(obj, 'dtype') and obj.dtype == numpy.object_:
+    if hasattr(obj, 'dtype') and obj.dtype == np.object_:
         try:
-            obj = obj.astype(numpy.float)
+            obj = obj.astype(np.float)
         except ValueError:
             pass
     return obj
@@ -264,7 +264,7 @@ def isDatetime(x):
     """
     Determine if a value is a datetime object.
     """
-    datetimeTypes = [datetime.datetime, numpy.datetime64]
+    datetimeTypes = [datetime.datetime, np.datetime64]
     if pd.nimbleAccessible():
         datetimeTypes.append(pd.Timestamp)
     return isinstance(x, tuple(datetimeTypes))
@@ -273,7 +273,7 @@ def isAllowedSingleElement(x):
     """
     Determine if an element is an allowed single element.
     """
-    if isinstance(x, (numbers.Number, str, numpy.bool_)):
+    if isinstance(x, (numbers.Number, str, np.bool_)):
         return True
 
     if isDatetime(x):
@@ -346,7 +346,7 @@ def removeDuplicatesNative(cooObj):
 
     if not duplicates and not zeroInData:
         if not allowedNumpyDType(cooObj.data.dtype):
-            cooObj.data = cooObj.data.astype(numpy.object_)
+            cooObj.data = cooObj.data.astype(np.object_)
         return cooObj
 
     rows = []
@@ -360,12 +360,12 @@ def removeDuplicatesNative(cooObj):
             cols.append(j)
             data.append(value)
 
-    dataNP = numpy.array(data)
+    dataNP = np.array(data)
     # if there are mixed strings and numeric values numpy will automatically
     # turn everything into strings. This will check to see if that has
     # happened and use the object dtype instead.
-    if len(dataNP) > 0 and isinstance(dataNP[0], numpy.flexible):
-        dataNP = numpy.array(data, dtype='O')
+    if len(dataNP) > 0 and isinstance(dataNP[0], np.flexible):
+        dataNP = np.array(data, dtype='O')
     cooNew = scipy.sparse.coo_matrix((dataNP, (rows, cols)),
                                      shape=cooObj.shape)
 

--- a/nimble/calculate/confidence.py
+++ b/nimble/calculate/confidence.py
@@ -1,7 +1,7 @@
 """
 Confidence Intervals for error metrics.
 """
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import PackageException
@@ -20,7 +20,7 @@ def _confidenceIntervalHelper(mean, standardDeviation, sampleSize,
 
     halfConfidence = 1 - ((1 - confidence) / 2.0)
     boundaryOnNormalScale = scipy.stats.t.ppf(halfConfidence, sampleSize - 1)
-    sqrtN = numpy.sqrt(sampleSize)
+    sqrtN = np.sqrt(sampleSize)
 
     low = mean - (boundaryOnNormalScale * (standardDeviation / sqrtN))
     high = mean + (boundaryOnNormalScale * (standardDeviation / sqrtN))
@@ -43,7 +43,7 @@ def rootMeanSquareErrorConfidenceInterval(known, predicted, confidence=0.95):
     standardDeviation = nimble.calculate.standardDeviation(errors)
 
     return _confidenceIntervalHelper(mean, standardDeviation, numSamples,
-                                     confidence, numpy.sqrt)
+                                     confidence, np.sqrt)
 
 
 def meanAbsoluteErrorConfidenceInterval(known, predicted, confidence=0.95):
@@ -75,8 +75,8 @@ def fractionIncorrectConfidenceInterval(known, predicted, confidence=0.95):
     rawPredicted = predicted.copy(to='numpyarray')
     errors = rawKnown[:] != rawPredicted[:]
     numSamples = len(errors)
-    fracIncorrect = numpy.mean(errors)
-    standardDeviation = numpy.sqrt((fracIncorrect) * (1 - fracIncorrect))
+    fracIncorrect = np.mean(errors)
+    standardDeviation = np.sqrt((fracIncorrect) * (1 - fracIncorrect))
 
     return _confidenceIntervalHelper(fracIncorrect, standardDeviation,
                                      numSamples, confidence)

--- a/nimble/calculate/linalg.py
+++ b/nimble/calculate/linalg.py
@@ -4,7 +4,7 @@ Linear algebra functions that can be used with nimble base objects.
 
 import re
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
@@ -295,7 +295,7 @@ def _backendSolvers(aObj, bObj, solverFunction):
     elif aObj.getTypeString() == 'Sparse':
         aCopy = aObj.copy()
         aData = dtypeConvert(aCopy._data)
-        bData = dtypeConvert(numpy.asarray(bObj._data))
+        bData = dtypeConvert(np.asarray(bObj._data))
         if solverFunction.__name__ == 'solve':
             solution = scipy.sparse.linalg.spsolve(aData, bData)
         else:

--- a/nimble/calculate/loss.py
+++ b/nimble/calculate/loss.py
@@ -7,7 +7,7 @@ level of correctness in the predicted values.
 
 from math import sqrt
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.core.data import Base
@@ -185,8 +185,8 @@ def varianceFractionRemaining(knownValues, predictedValues):
     rawDiff = diffObject.copy(to="numpy array")
     rawKnowns = knownValues.copy(to="numpy array")
     assert rawDiff.shape[1] == 1
-    avgSqDif = numpy.dot(rawDiff.T, rawDiff)[0, 0] / float(len(rawDiff))
-    return avgSqDif / float(numpy.var(rawKnowns))
+    avgSqDif = np.dot(rawDiff.T, rawDiff)[0, 0] / float(len(rawDiff))
+    return avgSqDif / float(np.var(rawKnowns))
 
 
 varianceFractionRemaining.optimal = 'min'

--- a/nimble/calculate/normalize.py
+++ b/nimble/calculate/normalize.py
@@ -3,7 +3,7 @@ Normalize
 """
 import functools
 
-import numpy
+import numpy as np
 
 import nimble
 
@@ -200,18 +200,18 @@ def percentileNormalize(values1, values2=None):
     percentiles = arr1.copy()
 
     # index locations of sorted values
-    argsort = numpy.argsort(arr1)
-    anyNan = any(map(numpy.isnan, arr1))
+    argsort = np.argsort(arr1)
+    anyNan = any(map(np.isnan, arr1))
     if anyNan: # ignore index for nan
         epsilon = 1 / (len(arr1) - 2)
     else:
         epsilon = 1 / (len(arr1) - 1)
     for i, idx in enumerate(argsort):
-        if not numpy.isnan(percentiles[idx]):
+        if not np.isnan(percentiles[idx]):
             percentiles[idx] = i * epsilon
 
     # adjust percentiles for duplicate values
-    for v in numpy.unique(arr1):
+    for v in np.unique(arr1):
         sameVal = arr1 == v
         samePercs = percentiles[sameVal]
         if len(samePercs) > 1:
@@ -230,12 +230,12 @@ def percentileNormalize(values1, values2=None):
 
     sortedArr1 = arr1[argsort]
     sortedPercs = percentiles[argsort]
-    minimum = numpy.nanmin(sortedArr1)
-    maximum = numpy.nanmax(sortedArr1)
+    minimum = np.nanmin(sortedArr1)
+    maximum = np.nanmax(sortedArr1)
 
     interpVal = functools.partial(_interpPercentile, minimum, maximum,
                                   sortedArr1, sortedPercs)
-    interpVector = numpy.vectorize(interpVal)
+    interpVector = np.vectorize(interpVal)
     values2Percentiles = values2.copy()
     if len(values2.points) == 1:
         values2Percentiles.points.transform(interpVector, useLog=False)
@@ -245,7 +245,7 @@ def percentileNormalize(values1, values2=None):
     return values1Percentiles, values2Percentiles
 
 def _interpPercentile(minimum, maximum, sortedValues, sortedPercentiles, val):
-    if numpy.isnan(val):
+    if np.isnan(val):
         return val
     if val == minimum == maximum:
         return 0.5 # all values were equal
@@ -253,7 +253,7 @@ def _interpPercentile(minimum, maximum, sortedValues, sortedPercentiles, val):
         return 0.0
     if val >= maximum:
         return 1.0
-    idx = numpy.searchsorted(sortedValues, val) # binary search
+    idx = np.searchsorted(sortedValues, val) # binary search
     leftVal, rightVal = sortedValues[idx - 1:idx + 1]
     leftPerc, rightPerc = sortedPercentiles[idx - 1:idx + 1]
     if val == rightVal:

--- a/nimble/calculate/similarity.py
+++ b/nimble/calculate/similarity.py
@@ -2,7 +2,7 @@
 Similarity calculations.
 """
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
@@ -23,8 +23,8 @@ def cosineSimilarity(knownValues, predictedValues):
     known = knownValues.copy(to="numpy array").flatten()
     predicted = predictedValues.copy(to="numpy array").flatten()
 
-    numerator = (numpy.dot(known, predicted))
-    denominator = (numpy.linalg.norm(known) * numpy.linalg.norm(predicted))
+    numerator = (np.dot(known, predicted))
+    denominator = (np.linalg.norm(known) * np.linalg.norm(predicted))
 
     return numerator / denominator
 
@@ -266,7 +266,7 @@ def _validateIndex(idx, numLabels, sourceArg):
 
 def _confusionMatrixWithLabelsList(knownValues, predictedValues, labels):
     numLabels = len(labels)
-    toFill = numpy.zeros((numLabels, numLabels), dtype=int)
+    toFill = np.zeros((numLabels, numLabels), dtype=int)
     validLabels = set() # to prevent repeated validation of same label
     for kVal, pVal in zip(knownValues, predictedValues):
         kVal = _mapInt(kVal)
@@ -289,7 +289,7 @@ def _validateKey(key, labels, sourceArg):
 def _confusionMatrixWithLabelsDict(knownValues, predictedValues, labels):
     sortedLabels = sorted(labels)
     numLabels = len(labels)
-    toFill = numpy.zeros((numLabels, numLabels), dtype=int)
+    toFill = np.zeros((numLabels, numLabels), dtype=int)
     labelsIdx = {}
     for kVal, pVal in zip(knownValues, predictedValues):
         # trigger KeyError if label not present
@@ -319,7 +319,7 @@ def _confusionMatrixNoLabels(knownValues, predictedValues):
     knownLabels = sorted(list(map(_mapInt, knownLabels)))
     labelsIdx = {}
     length = len(knownLabels)
-    toFill = numpy.zeros((length, length), dtype=int)
+    toFill = np.zeros((length, length), dtype=int)
 
     for (kVal, pVal), count in confusionDict.items():
         if kVal not in labelsIdx:

--- a/nimble/calculate/statistic.py
+++ b/nimble/calculate/statistic.py
@@ -5,7 +5,7 @@ Statistics calculations.
 import collections
 import functools
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble import match
@@ -14,7 +14,7 @@ from nimble.exceptions import InvalidArgumentValueCombination, PackageException
 from nimble._utility import scipy
 from nimble._utility import dtypeConvert
 
-numericalTypes = (int, float, numpy.number)
+numericalTypes = (int, float, np.number)
 
 # alias for python sum since we define our own sum function here
 _sum = sum
@@ -28,7 +28,7 @@ def numericRequired(func):
         try:
             return func(*args, **kwargs)
         except (TypeError, ValueError):
-            nan = numpy.nan
+            nan = np.nan
             if func.__name__ == 'quartiles':
                 return (nan, nan, nan)
             return nan
@@ -135,12 +135,12 @@ def _minmax(values, minmax):
     else:
         toProcess = values.copy('numpyarray')
     if minmax == 'min':
-        ret = numpy.nanmin(toProcess)
+        ret = np.nanmin(toProcess)
     else:
-        ret = numpy.nanmax(toProcess)
+        ret = np.nanmax(toProcess)
 
     if isinstance(ret, str):
-        return numpy.nan
+        return np.nan
 
     return ret
 
@@ -150,7 +150,7 @@ def _meanSparseBackend(nonZeroVals, lenData, numNan):
     is needed for standard deviation calculations so this helper avoids
     repeated attempts to determine the number of nan values in the data.
     """
-    dataSum = numpy.nansum(nonZeroVals)
+    dataSum = np.nansum(nonZeroVals)
     return dataSum / (lenData - numNan)
 
 @numericRequired
@@ -178,11 +178,11 @@ def mean(values):
     2.0
     """
     if values.getTypeString() == 'Sparse':
-        nonZero = values._data.data.astype(numpy.float)
-        numNan = numpy.sum(numpy.isnan(nonZero))
+        nonZero = values._data.data.astype(np.float)
+        numNan = np.sum(np.isnan(nonZero))
         return _meanSparseBackend(nonZero, len(values), numNan)
-    arr = values.copy('numpyarray', outputAs1D=True).astype(numpy.float)
-    return numpy.nanmean(arr)
+    arr = values.copy('numpyarray', outputAs1D=True).astype(np.float)
+    return np.nanmean(arr)
 
 @numericRequired
 def median(values):
@@ -208,8 +208,8 @@ def median(values):
     >>> median(vector)
     2.0
     """
-    arr = values.copy('numpyarray', outputAs1D=True).astype(numpy.float)
-    return numpy.nanmedian(arr, overwrite_input=True)
+    arr = values.copy('numpyarray', outputAs1D=True).astype(np.float)
+    return np.nanmedian(arr, overwrite_input=True)
 
 def mode(values):
     """
@@ -272,22 +272,22 @@ def standardDeviation(values, sample=True):
     1.707825127659933
     """
     if values.getTypeString() == 'Sparse':
-        nonZero = values._data.data.astype(numpy.float)
-        numNan = numpy.sum(numpy.isnan(nonZero))
+        nonZero = values._data.data.astype(np.float)
+        numNan = np.sum(np.isnan(nonZero))
         meanRet = _meanSparseBackend(nonZero, len(values), numNan)
 
-        dataSumSquared = numpy.nansum((nonZero - meanRet) ** 2)
+        dataSumSquared = np.nansum((nonZero - meanRet) ** 2)
         zeroSumSquared = meanRet ** 2 * (len(values) - values._data.nnz)
         divisor = len(values) - numNan
         if sample:
             divisor -= 1
         var = (dataSumSquared + zeroSumSquared) / divisor
-        return numpy.sqrt(var)
+        return np.sqrt(var)
 
-    arr = values.copy('numpyarray', outputAs1D=True).astype(numpy.float)
+    arr = values.copy('numpyarray', outputAs1D=True).astype(np.float)
     if sample:
-        return numpy.nanstd(arr, ddof=1)
-    return numpy.nanstd(arr)
+        return np.nanstd(arr, ddof=1)
+    return np.nanstd(arr)
 
 @numericRequired
 def medianAbsoluteDeviation(values):
@@ -309,8 +309,8 @@ def medianAbsoluteDeviation(values):
     >>> medianAbsoluteDeviation(vector)
     1.5
     """
-    arr = values.copy('numpy array', outputAs1D=True).astype(numpy.float)
-    mad = numpy.nanmedian(numpy.abs(arr - numpy.nanmedian(arr)))
+    arr = values.copy('numpy array', outputAs1D=True).astype(np.float)
+    mad = np.nanmedian(np.abs(arr - np.nanmedian(arr)))
     return mad
 
 def uniqueCount(values):
@@ -354,7 +354,7 @@ def quartiles(values):
     """
     # copy as horizontal array to use for intermediate calculations
     values = dtypeConvert(values.copy(to="numpyarray", outputAs1D=True))
-    ret = numpy.nanpercentile(values, (25, 50, 75), overwrite_input=True)
+    ret = np.nanpercentile(values, (25, 50, 75), overwrite_input=True)
     return tuple(ret)
 
 def nonMissing(elem):
@@ -420,7 +420,7 @@ def residuals(toPredict, controlVars):
     workingTP = dtypeConvert(toPredict.copy(to="numpy array"))
 
     x, _, _, _ = scipy.linalg.lstsq(workingCV, workingTP)
-    pred = numpy.matmul(workingCV, x)
+    pred = np.matmul(workingCV, x)
     ret = toPredict - pred
     return ret
 

--- a/nimble/calculate/utility.py
+++ b/nimble/calculate/utility.py
@@ -5,7 +5,7 @@ functions.
 
 import math
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentValue
@@ -227,12 +227,12 @@ def _runTrialGivenParameters(toCheck, knowns, predictionType):
 
 
 def _generateAllZeros(length):
-    return nimble.data("List", numpy.zeros([length, 1], dtype=int),
+    return nimble.data("List", np.zeros([length, 1], dtype=int),
                        useLog=False)
 
 
 def _generateAllOnes(length):
-    return nimble.data("List", numpy.ones([length, 1], dtype=int),
+    return nimble.data("List", np.ones([length, 1], dtype=int),
                        useLog=False)
 
 
@@ -240,7 +240,7 @@ def _generateMixedRandom(length):
     while True:
         correct = numpyRandom.randint(2, size=[length, 1])
         # we don't want all zeros or all ones
-        if numpy.any(correct) and not numpy.all(correct):
+        if np.any(correct) and not np.all(correct):
             break
     correct = nimble.data(returnType="List", source=correct, useLog=False)
     return correct

--- a/nimble/core/_learnHelpers.py
+++ b/nimble/core/_learnHelpers.py
@@ -8,7 +8,7 @@ functions are contained in learn.py without the distraction of helpers.
 import itertools
 from functools import wraps
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentValue, InvalidArgumentType
@@ -194,7 +194,7 @@ class FoldIterator(object):
             #		indices = range(0, len(copiedList[0].points)
             #                              - len(self.foldList[self.index])))
             #		pythonRandom.shuffle(indices)
-        indices = numpy.arange(0, (len(copiedList[0].points)
+        indices = np.arange(0, (len(copiedList[0].points)
                                    - len(self.foldList[self.index])))
         numpyRandom.shuffle(indices)
 
@@ -382,10 +382,10 @@ def generateClusteredPoints(numClusters, numPointsPerCluster,
             pointsList.append(curFeatureVector)
             clusterNoiselessLabelList.append([float(curCluster)])
 
-    pointsArray = numpy.array(pointsList, dtype=numpy.float)
-    labelsArray = numpy.array(labelsList, dtype=numpy.float)
-    clusterNoiselessLabelArray = numpy.array(clusterNoiselessLabelList,
-                                             dtype=numpy.float)
+    pointsArray = np.array(pointsList, dtype=np.float)
+    labelsArray = np.array(labelsList, dtype=np.float)
+    clusterNoiselessLabelArray = np.array(clusterNoiselessLabelList,
+                                          dtype=np.float)
     # todo verify that your list of lists is valid initializer for all
     # datatypes, not just matrix
     # then convert
@@ -438,9 +438,9 @@ def sumAbsoluteDifference(dataOne, dataTwo):
 
     differences = numpyOne - numpyTwo
 
-    absoluteDifferences = numpy.abs(differences)
+    absoluteDifferences = np.abs(differences)
 
-    sumAbsoluteDifferences = numpy.sum(absoluteDifferences)
+    sumAbsoluteDifferences = np.sum(absoluteDifferences)
 
     return sumAbsoluteDifferences
 
@@ -708,7 +708,7 @@ def _validTrainData(trainX, trainY):
         raise InvalidArgumentType(msg)
 
     if trainY is not None:
-        if not isinstance(trainY, (Base, str, int, numpy.int64)):
+        if not isinstance(trainY, (Base, str, int, np.int64)):
             msg = "trainY may only be an object derived from Base, or an "
             msg += "ID of the feature containing labels in testX"
             raise InvalidArgumentType(msg)

--- a/nimble/core/create.py
+++ b/nimble/core/create.py
@@ -3,7 +3,7 @@ Module the user-facing data creation functions for the top level
 nimble import.
 """
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
@@ -16,14 +16,14 @@ from nimble.core._createHelpers import initDataObject
 from nimble.core._createHelpers import createDataFromFile
 from nimble.core._createHelpers import createConstantHelper
 from nimble.core._createHelpers import fileFetcher
+from nimble.core._createHelpers import DEFAULT_MISSING
 
 
 def data(returnType, source, pointNames='automatic', featureNames='automatic',
          name=None, convertToType=None, keepPoints='all', keepFeatures='all',
-         treatAsMissing=(float('nan'), numpy.nan, None, '', 'None', 'nan',
-                         'NULL', 'NA'),
-         replaceMissingWith=numpy.nan, ignoreNonNumericalFeatures=False,
-         inputSeparator='automatic', copyData=True, useLog=None):
+         treatAsMissing=DEFAULT_MISSING, replaceMissingWith=np.nan,
+         ignoreNonNumericalFeatures=False, inputSeparator='automatic',
+         copyData=True, useLog=None):
     """
     Function to instantiate one of the Nimble data container types.
 
@@ -132,12 +132,12 @@ def data(returnType, source, pointNames='automatic', featureNames='automatic',
     treatAsMissing : list
         Values that will be treated as missing values in the data. These
         values will be replaced with value from ``replaceMissingWith``
-        By default this list is [float('nan'), numpy.nan, None, '',
+        By default this list is [float('nan'), np.nan, None, '',
         'None', 'nan']. Set to None or [] to disable replacing missing
         values.
     replaceMissingWith
         A single value with which to replace any value in
-        ``treatAsMissing``. By default this value is numpy.nan.
+        ``treatAsMissing``. By default this value is np.nan.
     ignoreNonNumericalFeatures : bool
         **This only applies when ``source`` is a file.**
         Indicate whether features containing non-numeric data should not
@@ -339,7 +339,7 @@ def ones(returnType, numPoints, numFeatures, pointNames='automatic',
         name="ones DataFrame"
         )
     """
-    return createConstantHelper(numpy.ones, returnType, numPoints, numFeatures,
+    return createConstantHelper(np.ones, returnType, numPoints, numFeatures,
                                 pointNames, featureNames, name)
 
 
@@ -413,8 +413,8 @@ def zeros(returnType, numPoints, numFeatures, pointNames='automatic',
         name="Sparse all-zeros"
         )
     """
-    return createConstantHelper(numpy.zeros, returnType, numPoints,
-                                numFeatures, pointNames, featureNames, name)
+    return createConstantHelper(np.zeros, returnType, numPoints, numFeatures,
+                                pointNames, featureNames, name)
 
 
 def identity(returnType, size, pointNames='automatic',
@@ -501,7 +501,7 @@ def identity(returnType, size, pointNames='automatic',
         return nimble.data(returnType, rawCoo, pointNames=pointNames,
                            featureNames=featureNames, name=name, useLog=False)
 
-    raw = numpy.identity(size)
+    raw = np.identity(size)
     return nimble.data(returnType, raw, pointNames=pointNames,
                        featureNames=featureNames, name=name, useLog=False)
 

--- a/nimble/core/data/axis.py
+++ b/nimble/core/data/axis.py
@@ -18,7 +18,7 @@ from operator import itemgetter
 import functools
 import re
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble import fill
@@ -149,7 +149,7 @@ class Axis(ABC):
             msg = "There are no valid " + self._axis + " identifiers; "
             msg += "this object has 0 " + self._axis + "s"
             raise IndexError(msg)
-        if isinstance(identifier, (int, numpy.integer)):
+        if isinstance(identifier, (int, np.integer)):
             if identifier < 0:
                 identifier = num + identifier
             if identifier < 0 or identifier >= num:
@@ -159,7 +159,7 @@ class Axis(ABC):
                 raise IndexError(msg)
         elif isinstance(identifier, str):
             identifier = self._getIndexByName(identifier)
-        elif allowFloats and isinstance(identifier, (float, numpy.float)):
+        elif allowFloats and isinstance(identifier, (float, np.float)):
             if identifier % 1: # x!=int(x)
                 idVal = str(identifier)
                 msg = "A float valued key of value x is only accepted if x == "
@@ -193,7 +193,7 @@ class Axis(ABC):
             return False
 
     def _getitem(self, key):
-        singleKey = isinstance(key, (int, float, str, numpy.integer))
+        singleKey = isinstance(key, (int, float, str, np.integer))
         if singleKey:
             key = [self._getIndex(key, allowFloats=True)]
         else:
@@ -547,7 +547,7 @@ class Axis(ABC):
 
         if targetCount == 0:
             ret = nimble.data(self._base.getTypeString(),
-                              numpy.empty(shape=(0, 0)), useLog=False)
+                              np.empty(shape=(0, 0)), useLog=False)
         else:
             mapResults = {}
             # apply the mapper to each point in the data
@@ -588,9 +588,9 @@ class Axis(ABC):
         # use our fill.constant function with the fillWith value
         if not callable(fillWith):
             value = fillWith
-            # for consistency use numpy.nan for None and nans
+            # for consistency use np.nan for None and nans
             if value is None or value != value:
-                value = numpy.nan
+                value = np.nan
             fillFunc = fill.constant
             kwarguments['constantValue'] = value
             removeKwargs.append('constantValue')
@@ -632,7 +632,7 @@ class Axis(ABC):
 
 
     def _repeat(self, totalCopies, copyVectorByVector):
-        if not isinstance(totalCopies, (int, numpy.int)) or totalCopies < 1:
+        if not isinstance(totalCopies, (int, np.int)) or totalCopies < 1:
             raise InvalidArgumentType("totalCopies must be a positive integer")
         if totalCopies == 1:
             return self._base.copy()
@@ -982,7 +982,7 @@ class Axis(ABC):
         # at this point, the input must be a dict
         #check input before performing any action
         for name in assignments.keys():
-            if not None and not isinstance(name, str):
+            if not isinstance(name, str):
                 raise InvalidArgumentValue("Names must be strings")
             if not isinstance(assignments[name], int):
                 raise InvalidArgumentValue("Indices must be integers")
@@ -1039,7 +1039,7 @@ class Axis(ABC):
                 stop -= 1
             return list(range(start, stop, step))
 
-        numBool = sum(isinstance(val, (bool, numpy.bool_)) for val in key)
+        numBool = sum(isinstance(val, (bool, np.bool_)) for val in key)
         # contains all boolean values
         if numBool == length:
             return [i for i, v in enumerate(key) if v]
@@ -1410,10 +1410,10 @@ class Axis(ABC):
             if any(x[:len(DEFAULT_PREFIX)] == DEFAULT_PREFIX for x in rnames):
                 raise ImproperObjectAction(msg)
 
-            ldiff = numpy.setdiff1d(lnames, rnames, assume_unique=True)
+            ldiff = np.setdiff1d(lnames, rnames, assume_unique=True)
             # names are not the same.
             if len(ldiff) != 0:
-                rdiff = numpy.setdiff1d(rnames, lnames, assume_unique=True)
+                rdiff = np.setdiff1d(rnames, lnames, assume_unique=True)
                 msgBase += "Yet, the following names were unmatched (caller "
                 msgBase += "names on the left, callee names on the right):\n"
                 msg = copy.copy(msgBase)

--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -14,7 +14,7 @@ import os.path
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble import match
@@ -222,7 +222,7 @@ class Base(ABC):
     @property
     def _featureCount(self):
         if len(self._shape) > 2:
-            return int(numpy.prod(self._shape[1:]))
+            return int(np.prod(self._shape[1:]))
         return self._shape[1]
 
     @_featureCount.setter
@@ -956,7 +956,7 @@ class Base(ABC):
             optType = self.getTypeString()
         # Use vectorized for functions with oneArg
         if calculator.oneArg:
-            vectorized = numpy.vectorize(calculator)
+            vectorized = np.vectorize(calculator)
             values = self._calculate_implementation(
                 vectorized, points, features, preserveZeros)
 
@@ -966,9 +966,9 @@ class Base(ABC):
             if not features:
                 features = list(range(len(self.features)))
             # if unable to vectorize, iterate over each point
-            values = numpy.empty([len(points), len(features)])
+            values = np.empty([len(points), len(features)])
             if allowBoolOutput:
-                values = values.astype(numpy.bool_)
+                values = values.astype(np.bool_)
             pIdx = 0
             for i in points:
                 fIdx = 0
@@ -976,8 +976,8 @@ class Base(ABC):
                     value = self[i, j]
                     currRet = calculator(value, i, j)
                     if (match.nonNumeric(currRet) and currRet is not None
-                            and values.dtype != numpy.object_):
-                        values = values.astype(numpy.object_)
+                            and values.dtype != np.object_):
+                        values = values.astype(np.object_)
                     values[pIdx, fIdx] = currRet
                     fIdx += 1
                 pIdx += 1
@@ -992,13 +992,13 @@ class Base(ABC):
     def _calculate_genericVectorized(self, function, points, features):
         # need points/features as arrays for indexing
         if points:
-            points = numpy.array(points)
+            points = np.array(points)
         else:
-            points = numpy.array(range(len(self.points)))
+            points = np.array(range(len(self.points)))
         if features:
-            features = numpy.array(features)
+            features = np.array(features)
         else:
-            features = numpy.array(range(len(self.features)))
+            features = np.array(range(len(self.features)))
         toCalculate = self.copy(to='numpyarray')
         # array with only desired points and features
         toCalculate = toCalculate[points[:, None], features]
@@ -1007,7 +1007,7 @@ class Base(ABC):
         except Exception: # pylint: disable=broad-except
             # change output type of vectorized function to object to handle
             # nonnumeric data
-            function.otypes = [numpy.object_]
+            function.otypes = [np.object_]
             return function(toCalculate)
 
     @limitedTo2D
@@ -1059,7 +1059,7 @@ class Base(ABC):
 
         ret = self.calculateOnElements(condition, outputType='Matrix',
                                        useLog=False)
-        return int(numpy.sum(ret._data))
+        return int(np.sum(ret._data))
 
     @limitedTo2D
     def countUniqueElements(self, points=None, features=None):
@@ -1169,7 +1169,7 @@ class Base(ABC):
             return point[by]
 
         def findKey2(point, by):#if by is a list of string or a list of int
-            return tuple([point[i] for i in by])
+            return tuple(point[i] for i in by)
 
         #if by is a list, then use findKey2; o.w. use findKey1
         if isinstance(by, (str, numbers.Number)):
@@ -1833,12 +1833,12 @@ class Base(ABC):
 
         #process x
         singleX = False
-        if isinstance(x, (int, float, str, numpy.integer)):
+        if isinstance(x, (int, float, str, np.integer)):
             x = self.points._getIndex(x, allowFloats=True)
             singleX = True
         #process y
         singleY = False
-        if isinstance(y, (int, float, str, numpy.integer)):
+        if isinstance(y, (int, float, str, np.integer)):
             y = self.features._getIndex(y, allowFloats=True)
             singleY = True
         #if it is the simplest data retrieval such as X[1,2],
@@ -2656,11 +2656,11 @@ class Base(ABC):
             #do rolling average
             xToPlot, yToPlot = list(zip(*sorted(zip(xToPlot, yToPlot),
                                                 key=lambda x: x[0])))
-            convShape = (numpy.ones(sampleSizeForAverage)
+            convShape = (np.ones(sampleSizeForAverage)
                          / float(sampleSizeForAverage))
             startIdx = sampleSizeForAverage-1
-            xToPlot = numpy.convolve(xToPlot, convShape)[startIdx:-startIdx]
-            yToPlot = numpy.convolve(yToPlot, convShape)[startIdx:-startIdx]
+            xToPlot = np.convolve(xToPlot, convShape)[startIdx:-startIdx]
+            yToPlot = np.convolve(yToPlot, convShape)[startIdx:-startIdx]
 
             tmpStr = ' (%s sample average)' % sampleSizeForAverage
             xlabel += tmpStr
@@ -2680,8 +2680,8 @@ class Base(ABC):
         plotAxisLimits(ax)
 
         if trend is not None and trend.lower() == 'linear':
-            meanX = numpy.mean(xToPlot)
-            meanY = numpy.mean(yToPlot)
+            meanX = np.mean(xToPlot)
+            meanY = np.mean(yToPlot)
             errorX = meanX - xToPlot
             sumSquareErrorX = sum((errorX) ** 2)
             sumErrorXY = sum(errorX * (meanY - yToPlot))
@@ -3140,7 +3140,7 @@ class Base(ABC):
     def _copy_outputAs1D(self, to):
         if to == 'numpyarray':
             if self._pointCount == 0 or self._featureCount == 0:
-                return numpy.array([])
+                return np.array([])
             return self._copy_implementation('numpyarray').flatten()
 
         if self._pointCount == 0 or self._featureCount == 0:
@@ -3151,9 +3151,9 @@ class Base(ABC):
     def _copy_pythonList(self, rowsArePoints):
         ret = self._copy_implementation('pythonlist')
         if len(self._shape) > 2:
-            ret = numpy.reshape(ret, self._shape).tolist()
+            ret = np.reshape(ret, self._shape).tolist()
         if not rowsArePoints:
-            ret = numpy.transpose(ret).tolist()
+            ret = np.transpose(ret).tolist()
         return ret
 
     def _copy_nestedPythonTypes(self, to, rowsArePoints):
@@ -3559,7 +3559,7 @@ class Base(ABC):
         if len(dataDimensions) < 2:
             msg = "dataDimensions must contain a minimum of 2 values"
             raise InvalidArgumentValue(msg)
-        if self.shape[0] * self.shape[1] != numpy.prod(dataDimensions):
+        if self.shape[0] * self.shape[1] != np.prod(dataDimensions):
             msg = "The product of the dimensions must be equal to the number "
             msg += "of values in this object"
             raise InvalidArgumentValue(msg)
@@ -3569,7 +3569,7 @@ class Base(ABC):
                 msg = "order='feature' is not allowed when unflattening to "
                 msg += 'more than two dimensions'
                 raise ImproperObjectAction(msg)
-            shape2D = (dataDimensions[0], numpy.prod(dataDimensions[1:]))
+            shape2D = (dataDimensions[0], np.prod(dataDimensions[1:]))
         else:
             shape2D = dataDimensions
 
@@ -3623,13 +3623,13 @@ class Base(ABC):
             * 'union' - Return all points/features from the caller and
               callee. If ``onFeature`` is None, unnamed points/features
               will be assumed to be unique. Any missing data from the
-              caller and callee will be filled with numpy.NaN.
+              caller and callee will be filled with np.NaN.
             * 'intersection': Return only points/features shared between
               the caller  and callee. If ``onFeature`` is None,
               point / feature names are required.
             * 'left': Return only the points/features from the caller.
               Any missing data from the callee will be filled with
-              numpy.NaN.
+              np.NaN.
         onFeature : identifier, None
             The name or index of the feature present in both objects to
             merge on.  If None, the merge will be based on point names.
@@ -4216,7 +4216,7 @@ class Base(ABC):
         provided the object can be inverted using
         nimble.calculate.inverse.
         """
-        if not isinstance(power, (int, numpy.int)):
+        if not isinstance(power, (int, np.int)):
             msg = 'power must be an integer'
             raise InvalidArgumentType(msg)
         if not len(self.points) == len(self.features):
@@ -4676,7 +4676,7 @@ class Base(ABC):
                 # inplace operations will modify the data even if op fails
                 # use not inplace operation, setting to inplace occurs after
                 useOp = opName[:2] + opName[3:]
-            with numpy.errstate(divide='raise', invalid='raise'):
+            with np.errstate(divide='raise', invalid='raise'):
                 ret = obj._binaryOperations_implementation(useOp, other)
         except (TypeError, ValueError, FloatingPointError) as error:
             obj._diagnoseFailureAndRaiseException(opName, other, error)

--- a/nimble/core/data/dataframe.py
+++ b/nimble/core/data/dataframe.py
@@ -4,7 +4,7 @@ Class extending Base, using a pandas DataFrame to store data.
 
 import itertools
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
@@ -167,7 +167,7 @@ class DataFrame(Base):
             comment += ','.join(self.points.getNames())
         if includeFeatureNames:
             comment += '\n#' + ','.join(self.features.getNames())
-        scipy.io.mmwrite(outPath, self._data.astype(numpy.float),
+        scipy.io.mmwrite(outPath, self._data.astype(np.float),
                          comment=comment)
 
     def _referenceDataFrom_implementation(self, other):
@@ -202,11 +202,11 @@ class DataFrame(Base):
         needsReshape = len(self._shape) > 2
         if to in ['pythonlist', 'numpyarray']:
             # convert pandas Timestamp type if necessary
-            timestamp = [d.type == numpy.datetime64 for d in self._data.dtypes]
+            timestamp = [d.type == np.datetime64 for d in self._data.dtypes]
             arr = self._asNumpyArray()
             if any(timestamp):
                 attr = 'to_pydatetime' if to == 'pythonlist' else 'to_numpy'
-                convTimestamp = numpy.vectorize(lambda v: getattr(v, attr)())
+                convTimestamp = np.vectorize(lambda v: getattr(v, attr)())
                 arr[:, timestamp] = convTimestamp(arr[:, timestamp])
 
             if needsReshape:
@@ -218,7 +218,7 @@ class DataFrame(Base):
             return arr.copy()
 
         if needsReshape:
-            data = numpy.empty(self._shape[:2], dtype=numpy.object_)
+            data = np.empty(self._shape[:2], dtype=np.object_)
             for i in range(self.shape[0]):
                 data[i] = self.points[i].copy('pythonlist')
         elif to == 'pandasdataframe':
@@ -226,7 +226,7 @@ class DataFrame(Base):
         else:
             data = self._data
         if to == 'numpymatrix':
-            return numpy.matrix(data)
+            return np.matrix(data)
         if 'scipy' in to:
             if not scipy.nimbleAccessible():
                 msg = "scipy is not available"
@@ -259,12 +259,12 @@ class DataFrame(Base):
         if isinstance(replaceWith, DataFrame):
             replaceDtypes = replaceWith._data.dtypes
         else:
-            replaceDtypes = (numpy.dtype(type(replaceWith)),) * len(ftRange)
+            replaceDtypes = (np.dtype(type(replaceWith)),) * len(ftRange)
         for i, rdt in zip(ftRange, replaceDtypes):
             dtypes.iloc[i] = max(dtypes.iloc[i], rdt)
         if not isinstance(replaceWith, Base):
-            values = replaceWith * numpy.ones((pointEnd - pointStart + 1,
-                                               featureEnd - featureStart + 1))
+            values = replaceWith * np.ones((pointEnd - pointStart + 1,
+                                            featureEnd - featureStart + 1))
         else:
             #convert values to be array or matrix, instead of pandas DataFrame
             values = replaceWith._asNumpyArray()
@@ -280,9 +280,9 @@ class DataFrame(Base):
         numElements = len(self.points) * len(self.features)
         dtypes = self._data.dtypes
         if order == 'point':
-            newDtypes = tuple(numpy.tile(dtypes, len(self.points)))
+            newDtypes = tuple(np.tile(dtypes, len(self.points)))
         else:
-            newDtypes = tuple(numpy.repeat(dtypes, len(self.points)))
+            newDtypes = tuple(np.repeat(dtypes, len(self.points)))
         order = convertToNumpyOrder(order)
         array = self._asNumpyArray()
         values = array.reshape((1, numElements), order=order)
@@ -299,7 +299,7 @@ class DataFrame(Base):
             jumps = range(reshape[1])
             newDtypes = tuple(max(dtypes[i::reshape[1]]) for i in jumps)
         else:
-            jumps = range(0, numpy.prod(reshape), reshape[0])
+            jumps = range(0, np.prod(reshape), reshape[0])
             newDtypes = tuple(max(dtypes[i:i+reshape[1]]) for i in jumps)
         order = convertToNumpyOrder(order)
         array = self._asNumpyArray()
@@ -369,8 +369,8 @@ class DataFrame(Base):
                 right = right + numColsL
             matches = self._data.iloc[:, left] == self._data.iloc[:, right]
 
-            nansL = numpy.array([x != x for x in self._data.iloc[:, left]])
-            nansR = numpy.array([x != x for x in self._data.iloc[:, right]])
+            nansL = np.array([x != x for x in self._data.iloc[:, left]])
+            nansR = np.array([x != x for x in self._data.iloc[:, right]])
             acceptableValues = matches + nansL + nansR
             if not all(acceptableValues):
                 msg = "The objects contain different values for the same "
@@ -390,7 +390,7 @@ class DataFrame(Base):
         self._pointCount = len(self._data.index)
 
     def _replaceFeatureWithBinaryFeatures_implementation(self, uniqueIdx):
-        toFill = numpy.zeros((len(self.points), len(uniqueIdx)))
+        toFill = np.zeros((len(self.points), len(uniqueIdx)))
         for ptIdx, val in self._data.iterrows():
             ftIdx = uniqueIdx[val[0]]
             toFill[ptIdx, ftIdx] = 1
@@ -441,7 +441,7 @@ class DataFrame(Base):
         """
         Create an object of one less dimension.
         """
-        reshape = (self._shape[1], int(numpy.prod(self._shape[2:])))
+        reshape = (self._shape[1], int(np.prod(self._shape[2:])))
         data = self._asNumpyArray()[pointIndex].reshape(reshape)
         return DataFrame(data, shape=self._shape[1:], reuseData=True)
 
@@ -475,9 +475,9 @@ class DataFrame(Base):
                 if len(otherDtypes) == 1:
                     otherDtypes = (otherDtypes[0],) * len(self.features)
         else:
-            dtype = numpy.dtype(type(other))
-            if dtype > numpy.dtype(float):
-                dtype = numpy.object_
+            dtype = np.dtype(type(other))
+            if dtype > np.dtype(float):
+                dtype = np.object_
             otherDtypes = tuple(dtype for _ in initialDtypes)
 
         dtypes = []
@@ -487,8 +487,8 @@ class DataFrame(Base):
         alwaysFloat = 'truediv' in opName
         for dtype1, dtype2 in zip(initialDtypes, otherDtypes):
             useType = max(dtype1, dtype2)
-            if alwaysFloat and useType < numpy.dtype(float):
-                dtypes.append(numpy.dtype(float))
+            if alwaysFloat and useType < np.dtype(float):
+                dtypes.append(np.dtype(float))
             else:
                 dtypes.append(useType)
 
@@ -530,8 +530,8 @@ class DataFrame(Base):
             array = self._asNumpyArray(numericRequired=True)
             values = array * other._getSparseData()
         else:
-            values = numpy.matmul(self._asNumpyArray(numericRequired=True),
-                                  other.copy('numpyarray'))
+            values = np.matmul(self._asNumpyArray(numericRequired=True),
+                               other.copy('numpyarray'))
         ret = DataFrame(values)
         ret._setDtypes(dtypes)
 
@@ -565,19 +565,19 @@ class DataFrame(Base):
         floats if the dtypes are not already all the same numeric dtype.
         """
         dtypes = self._data.dtypes
-        allowedDtypes = set((numpy.dtype(bool), numpy.dtype(int),
-                            numpy.dtype(float)))
+        allowedDtypes = set((np.dtype(bool), np.dtype(int),
+                            np.dtype(float)))
         if not numericRequired:
-            allowedDtypes.add(numpy.dtype(numpy.object_))
+            allowedDtypes.add(np.dtype(np.object_))
 
         if len(dtypes) > 0:
-            floatDtype = numpy.dtype(float)
+            floatDtype = np.dtype(float)
             if all(d in allowedDtypes and d <= floatDtype for d in dtypes):
                 return self._data.values
         if numericRequired:
             return self._data.values.astype(float)
 
-        return self._data.astype(numpy.object_).values
+        return self._data.astype(np.object_).values
 
 
 class DataFrameView(BaseView, DataFrame):

--- a/nimble/core/data/dataframeAxis.py
+++ b/nimble/core/data/dataframeAxis.py
@@ -5,7 +5,7 @@ operations on a nimble DataFrame object.
 
 from abc import ABCMeta, abstractmethod
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble._utility import pd
@@ -94,7 +94,7 @@ class DataFrameAxis(Axis, metaclass=ABCMeta):
         uniqueData, uniqueIndices = denseAxisUniqueArray(self._base,
                                                          self._axis)
         uniqueData = pd.DataFrame(uniqueData)
-        if numpy.array_equal(self._base._asNumpyArray(), uniqueData):
+        if np.array_equal(self._base._asNumpyArray(), uniqueData):
             return self._base.copy()
         axisNames, offAxisNames = uniqueNameGetter(self._base, self._axis,
                                                    uniqueIndices)
@@ -111,9 +111,9 @@ class DataFrameAxis(Axis, metaclass=ABCMeta):
         if self._isPoint:
             for i, series in self._base._data.iteritems():
                 if copyVectorByVector:
-                    repeated[i] = numpy.repeat(series, totalCopies)
+                    repeated[i] = np.repeat(series, totalCopies)
                 else:
-                    repeated[i] = numpy.tile(series, totalCopies)
+                    repeated[i] = np.tile(series, totalCopies)
             ret = pd.DataFrame(repeated).reset_index(drop=True)
         else:
             for i, series in self._base._data.iteritems():
@@ -189,7 +189,7 @@ class DataFramePoints(DataFrameAxis, Points):
         collapseData = self._base._asNumpyArray()[:, collapseIndices]
         retainData = self._base._asNumpyArray()[:, retainIndices]
 
-        collapseDtypes = (numpy.dtype(object), max(self._base._data.dtypes))
+        collapseDtypes = (np.dtype(object), max(self._base._data.dtypes))
         dtypes = []
         for i in range(len(self._base.features)):
             if i in retainIndices:

--- a/nimble/core/data/features.py
+++ b/nimble/core/data/features.py
@@ -12,7 +12,7 @@ wrapping of function calls for the logger takes place in here.
 
 from abc import ABC, abstractmethod
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.core.logger import handleLogging
@@ -1578,7 +1578,7 @@ class Features(ABC):
             )
 
         Fill using nimble's match and fill modules; limit to first
-        feature. Note: None is converted to numpy.nan in nimble.
+        feature. Note: None is converted to np.nan in nimble.
 
         >>> from nimble import match
         >>> from nimble import fill
@@ -1838,7 +1838,7 @@ class Features(ABC):
             featureNames={'category':0, 'id':1, 'quantity':2}
             )
         """
-        if not (isinstance(rule, (int, numpy.integer, str))
+        if not (isinstance(rule, (int, np.integer, str))
                 or hasattr(rule, '__iter__')
                 or hasattr(rule, '__call__')):
             msg = "rule must be an integer, string, iterable of integers "
@@ -1850,7 +1850,7 @@ class Features(ABC):
         for i, value in enumerate(self._base[:, feature]):
             if isinstance(rule, str):
                 splitList.append(value.split(rule))
-            elif isinstance(rule, (int, numpy.number)):
+            elif isinstance(rule, (int, np.number)):
                 splitList.append([value[:rule], value[rule:]])
             elif hasattr(rule, '__iter__'):
                 split = []
@@ -1864,7 +1864,7 @@ class Features(ABC):
                         # item in next iteration
                         startIdx = (value[startIdx:].index(item) +
                                     len(value[:startIdx]) + 1)
-                    elif isinstance(item, (int, numpy.integer)):
+                    elif isinstance(item, (int, np.integer)):
                         split.append(value[startIdx:item])
                         startIdx = item
                     else:

--- a/nimble/core/data/list.py
+++ b/nimble/core/data/list.py
@@ -5,7 +5,7 @@ Class extending Base, using a list of lists to store data.
 import copy
 import itertools
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
@@ -107,7 +107,7 @@ class List(Base):
             #case6: data is a ListPassThrough associated with empty list
             data = []
 
-        self._numFeatures = int(numpy.prod(shape[1:]))
+        self._numFeatures = int(np.prod(shape[1:]))
         self._data = data
 
         kwds['featureNames'] = featureNames
@@ -254,7 +254,7 @@ class List(Base):
         isEmpty = False
         if len(self.points) == 0 or len(self.features) == 0:
             isEmpty = True
-            emptyData = numpy.empty(shape=self.shape)
+            emptyData = np.empty(shape=self.shape)
 
         if to == 'pythonlist':
             return [pt.copy() for pt in self._data]
@@ -282,7 +282,7 @@ class List(Base):
                 return ret.reshape(self._shape)
             return ret
         if needsReshape:
-            data = numpy.empty(self._shape[:2], dtype=numpy.object_)
+            data = np.empty(self._shape[:2], dtype=np.object_)
             for i in range(self.shape[0]):
                 data[i] = self.points[i].copy('pythonlist')
             if isEmpty:
@@ -291,8 +291,8 @@ class List(Base):
             data = _convertList(numpy2DArray, self._data)
         if to == 'numpymatrix':
             if isEmpty:
-                return numpy.matrix(emptyData)
-            return numpy.matrix(data)
+                return np.matrix(emptyData)
+            return np.matrix(data)
         if 'scipy' in to:
             if not scipy.nimbleAccessible():
                 msg = "scipy is not available"
@@ -347,7 +347,7 @@ class List(Base):
     def _unflatten_implementation(self, reshape, order):
         result = []
         numPoints = reshape[0]
-        numFeatures = numpy.prod(reshape[1:])
+        numFeatures = np.prod(reshape[1:])
         data = self.copy('pythonlist', outputAs1D=True)
         if order == 'point':
             for i in range(numPoints):
@@ -491,7 +491,7 @@ class List(Base):
                     merged.append(pt)
                 matched.append(target)
             elif point in ['union', 'left']:
-                ptR = [numpy.nan] * (len(right[0]) - len(matchingFtIdx[1]))
+                ptR = [np.nan] * (len(right[0]) - len(matchingFtIdx[1]))
                 pt = ptL + ptR
                 merged.append(pt)
 
@@ -499,7 +499,7 @@ class List(Base):
             for row in right:
                 target = row[onIdxR]
                 if target not in matched:
-                    pt = [numpy.nan] * (len(left[0]) + unmatchedFtCountR)
+                    pt = [np.nan] * (len(left[0]) + unmatchedFtCountR)
                     for i, j in zip(matchingFtIdx[0], matchingFtIdx[1]):
                         pt[i] = row[j]
                     pt[len(left[0]):] = [row[i] for i in range(len(right[0]))
@@ -517,7 +517,7 @@ class List(Base):
         self._data = merged
 
     def _replaceFeatureWithBinaryFeatures_implementation(self, uniqueIdx):
-        toFill = numpy.zeros((len(self.points), len(uniqueIdx)))
+        toFill = np.zeros((len(self.points), len(uniqueIdx)))
         for ptIdx, val in enumerate(self._data):
             ftIdx = uniqueIdx[val[0]]
             toFill[ptIdx, ftIdx] = 1
@@ -557,7 +557,7 @@ class List(Base):
         """
         Create an object of one less dimension
         """
-        reshape = (self._shape[1], int(numpy.prod(self._shape[2:])))
+        reshape = (self._shape[1], int(np.prod(self._shape[2:])))
         data = []
         point = self._data[pointIndex]
         for i in range(reshape[0]):
@@ -635,7 +635,7 @@ class List(Base):
             self._data = [list(map(convertType, pt)) for pt in self._data]
 
     def _iterateElements_implementation(self, order, only):
-        array = numpy.array(self._data, dtype=numpy.object_)
+        array = np.array(self._data, dtype=np.object_)
         return NimbleElementIterator(array, order, only)
 
 
@@ -656,7 +656,7 @@ class ListView(BaseView, List):
         # for copy
         if ((len(self.points) == 0 or len(self.features) == 0)
                 and to != 'List'):
-            emptyStandin = numpy.empty(self._shape)
+            emptyStandin = np.empty(self._shape)
             intermediate = nimble.data('Matrix', emptyStandin, useLog=False)
             return intermediate.copy(to=to)
 
@@ -746,7 +746,7 @@ class ListPassThrough(object):
         return self.pRange
 
     def __array__(self, dtype=None):
-        tmpArray = numpy.array(self.source._data, dtype=dtype)
+        tmpArray = np.array(self.source._data, dtype=dtype)
         return tmpArray[self.pStart:self.pEnd, self.fStart:self.fEnd]
 
 ###########

--- a/nimble/core/data/listAxis.py
+++ b/nimble/core/data/listAxis.py
@@ -6,7 +6,7 @@ operations on a nimble List object.
 import copy
 from abc import ABCMeta, abstractmethod
 
-import numpy
+import numpy as np
 
 import nimble
 from .axis import Axis
@@ -62,7 +62,7 @@ class ListAxis(Axis, metaclass=ABCMeta):
             if self._base._data == []:
                 # create empty matrix with correct shape
                 shape = (len(self._base.points), len(targetList))
-                satisfying = numpy.empty(shape, dtype=numpy.object_)
+                satisfying = np.empty(shape, dtype=np.object_)
             else:
                 satisfying = [[self._base._data[pt][ft] for ft in targetList]
                               for pt in range(len(self._base.points))]
@@ -207,7 +207,7 @@ class ListPoints(ListAxis, Points):
             retainData.append(retainFeatures)
 
         tmpData = fillArrayWithCollapsedFeatures(
-            featuresToCollapse, retainData, numpy.array(collapseData),
+            featuresToCollapse, retainData, np.array(collapseData),
             currNumPoints, currFtNames, numRetPoints, numRetFeatures)
 
         self._base._data = tmpData.tolist()
@@ -287,8 +287,8 @@ class ListFeatures(ListAxis, Features):
 
     def _splitByParsing_implementation(self, featureIndex, splitList,
                                        numRetFeatures, numResultingFts):
-        tmpData = numpy.empty(shape=(len(self._base.points), numRetFeatures),
-                              dtype=numpy.object_)
+        tmpData = np.empty(shape=(len(self._base.points), numRetFeatures),
+                           dtype=np.object_)
 
         tmpData[:, :featureIndex] = [ft[:featureIndex] for ft
                                      in self._base._data]

--- a/nimble/core/data/matrix.py
+++ b/nimble/core/data/matrix.py
@@ -4,7 +4,7 @@ Class extending Base, using a numpy dense matrix to store data.
 
 import itertools
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
@@ -47,7 +47,7 @@ class Matrix(Base):
             msg += "or python list."
             raise InvalidArgumentType(msg)
 
-        if isinstance(data, numpy.matrix):
+        if isinstance(data, np.matrix):
             data = numpy2DArray(data)
         elif isinstance(data, list):
             data = numpyArrayFromList(data)
@@ -121,18 +121,17 @@ class Matrix(Base):
         with open(outPath, 'w') as outFile:
             if includeFeatureNames:
                 self._writeFeatureNamesToCSV(outFile, includePointNames)
-            if not numpy.issubdtype(self._data.dtype, numpy.number):
-                vectorizeCommas = numpy.vectorize(csvCommaFormat,
-                                                  otypes=[object])
+            if not np.issubdtype(self._data.dtype, np.number):
+                vectorizeCommas = np.vectorize(csvCommaFormat, otypes=[object])
                 viewData = vectorizeCommas(self._data).view()
             else:
                 viewData = self._data.view()
             if includePointNames:
                 pnames = list(map(csvCommaFormat, self.points.getNames()))
                 pnames = numpy2DArray(pnames).transpose()
-                viewData = numpy.concatenate((pnames, viewData), 1)
+                viewData = np.concatenate((pnames, viewData), 1)
 
-            numpy.savetxt(outFile, viewData, delimiter=',', fmt='%s')
+            np.savetxt(outFile, viewData, delimiter=',', fmt='%s')
 
     def _writeFileMTX_implementation(self, outPath, includePointNames,
                                      includeFeatureNames):
@@ -159,7 +158,7 @@ class Matrix(Base):
         else:
             header += '#\n'
 
-        scipy.io.mmwrite(target=outPath, a=self._data.astype(numpy.float),
+        scipy.io.mmwrite(target=outPath, a=self._data.astype(np.float),
                          comment=header)
 
     def _referenceDataFrom_implementation(self, other):
@@ -183,13 +182,13 @@ class Matrix(Base):
                 return self._data.reshape(self._shape)
             return self._data.copy()
         if needsReshape:
-            data = numpy.empty(self._shape[:2], dtype=numpy.object_)
+            data = np.empty(self._shape[:2], dtype=np.object_)
             for i in range(self.shape[0]):
                 data[i] = self.points[i].copy('pythonlist')
         else:
             data = self._data
         if to == 'numpymatrix':
-            return numpy.matrix(data)
+            return np.matrix(data)
         if 'scipy' in to:
             if not scipy.nimbleAccessible():
                 msg = "scipy is not available"
@@ -197,7 +196,7 @@ class Matrix(Base):
             if to == 'scipycoo':
                 return scipy.sparse.coo_matrix(data)
             try:
-                ret = data.astype(numpy.float)
+                ret = data.astype(np.float)
             except ValueError as e:
                 msg = 'Can only create scipy {0} matrix from numeric data'
                 raise ValueError(msg.format(to[-3:])) from e
@@ -216,8 +215,8 @@ class Matrix(Base):
     def _replaceRectangle_implementation(self, replaceWith, pointStart,
                                          featureStart, pointEnd, featureEnd):
         if not isinstance(replaceWith, Base):
-            values = replaceWith * numpy.ones((pointEnd - pointStart + 1,
-                                               featureEnd - featureStart + 1))
+            values = replaceWith * np.ones((pointEnd - pointStart + 1,
+                                            featureEnd - featureStart + 1))
         else:
             values = replaceWith._data
 
@@ -237,8 +236,8 @@ class Matrix(Base):
 
     def _merge_implementation(self, other, point, feature, onFeature,
                               matchingFtIdx):
-        self._data = numpy.array(self._data, dtype=numpy.object_)
-        otherArr = numpy.array(other._data, dtype=numpy.object_)
+        self._data = np.array(self._data, dtype=np.object_)
+        otherArr = np.array(other._data, dtype=np.object_)
         if onFeature is not None:
             if feature in ["intersection", "left"]:
                 onFeatureIdx = self.features.getIndex(onFeature)
@@ -261,49 +260,48 @@ class Matrix(Base):
             onIdxL = 0
             onIdxR = 0
             if not self.points._anyDefaultNames():
-                ptsL = numpy.array(self.points.getNames(), dtype=numpy.object_)
+                ptsL = np.array(self.points.getNames(), dtype=np.object_)
                 ptsL = ptsL.reshape(-1, 1)
             elif self._pointNamesCreated():
                 # differentiate default names between objects;
                 # note still start with DEFAULT_PREFIX
                 namesL = [n + '_l' if isDefaultName(n) else n
                           for n in self.points.getNames()]
-                ptsL = numpy.array(namesL, dtype=numpy.object_)
+                ptsL = np.array(namesL, dtype=np.object_)
                 ptsL = ptsL.reshape(-1, 1)
             else:
                 defNames = [DEFAULT_PREFIX + '_l' for _
                             in range(len(self.points))]
-                ptsL = numpy.array(defNames, dtype=numpy.object_)
+                ptsL = np.array(defNames, dtype=np.object_)
                 ptsL = ptsL.reshape(-1, 1)
             if not other.points._anyDefaultNames():
-                ptsR = numpy.array(other.points.getNames(),
-                                   dtype=numpy.object_)
+                ptsR = np.array(other.points.getNames(), dtype=np.object_)
                 ptsR = ptsR.reshape(-1, 1)
             elif other._pointNamesCreated():
                 # differentiate default names between objects;
                 # note still start with DEFAULT_PREFIX
                 namesR = [n + '_r' if isDefaultName(n) else n
                           for n in other.points.getNames()]
-                ptsR = numpy.array(namesR, dtype=numpy.object_)
+                ptsR = np.array(namesR, dtype=np.object_)
                 ptsR = ptsR.reshape(-1, 1)
             else:
                 defNames = [DEFAULT_PREFIX + '_r' for _
                             in range(len(other.points))]
-                ptsR = numpy.array(defNames, dtype=numpy.object_)
+                ptsR = np.array(defNames, dtype=np.object_)
                 ptsR = ptsR.reshape(-1, 1)
             if feature == "intersection":
                 concatL = (ptsL, self._data[:, matchingFtIdx[0]])
-                self._data = numpy.concatenate(concatL, axis=1)
+                self._data = np.concatenate(concatL, axis=1)
                 concatR = (ptsR, otherArr[:, matchingFtIdx[1]])
-                right = numpy.concatenate(concatR, axis=1)
+                right = np.concatenate(concatR, axis=1)
                 # matching indices were sorted when slicing above
                 # this also accounts for prepended column
                 matchingFtIdx[0] = list(range(self._data.shape[1]))
                 matchingFtIdx[1] = matchingFtIdx[0]
             elif feature == "left":
-                self._data = numpy.concatenate((ptsL, self._data), axis=1)
+                self._data = np.concatenate((ptsL, self._data), axis=1)
                 concatR = (ptsR, otherArr[:, matchingFtIdx[1]])
-                right = numpy.concatenate(concatR, axis=1)
+                right = np.concatenate(concatR, axis=1)
                 # account for new column in matchingFtIdx
                 matchingFtIdx[0] = list(map(lambda x: x + 1, matchingFtIdx[0]))
                 matchingFtIdx[0].insert(0, 0)
@@ -311,8 +309,8 @@ class Matrix(Base):
                 # this also accounts for prepended column
                 matchingFtIdx[1] = list(range(right.shape[1]))
             else:
-                self._data = numpy.concatenate((ptsL, self._data), axis=1)
-                right = numpy.concatenate((ptsR, otherArr), axis=1)
+                self._data = np.concatenate((ptsL, self._data), axis=1)
+                right = np.concatenate((ptsR, otherArr), axis=1)
                 # account for new column in matchingFtIdx
                 matchingFtIdx[0] = list(map(lambda x: x + 1, matchingFtIdx[0]))
                 matchingFtIdx[0].insert(0, 0)
@@ -335,9 +333,9 @@ class Matrix(Base):
                 for ptR in matchesR:
                     # check for conflicts between matching features
                     matches = ptL[matchingFtIdx[0]] == ptR[matchingFtIdx[1]]
-                    nansL = numpy.array([x != x for x
+                    nansL = np.array([x != x for x
                                          in ptL[matchingFtIdx[0]]])
-                    nansR = numpy.array([x != x for x
+                    nansR = np.array([x != x for x
                                          in ptR[matchingFtIdx[1]]])
                     acceptableValues = matches + nansL + nansR
                     if not all(acceptableValues):
@@ -351,14 +349,14 @@ class Matrix(Base):
                             if value != value:
                                 fill = ptR[matchingFtIdx[1]][i]
                                 ptL[matchingFtIdx[0]][i] = fill
-                    ptR = numpy.delete(ptR, matchingFtIdx[1])
-                    pt = numpy.concatenate((ptL, ptR)).flatten()
+                    ptR = np.delete(ptR, matchingFtIdx[1])
+                    pt = np.concatenate((ptL, ptR)).flatten()
                     merged.append(pt)
                 matched.append(target)
             elif point in ['union', 'left']:
                 ptL = ptL.reshape(1, -1)
-                ptR = numpy.ones((1, unmatchedPtCountR)) * numpy.nan
-                pt = numpy.append(ptL, ptR)
+                ptR = np.ones((1, unmatchedPtCountR)) * np.nan
+                pt = np.append(ptL, ptR)
                 merged.append(pt)
 
         if point == 'union':
@@ -367,9 +365,9 @@ class Matrix(Base):
             for row in right:
                 target = row[onIdxR]
                 if target not in matched:
-                    ones = numpy.ones((left.shape[1] + unmatchedPtCountR,),
-                                      dtype=numpy.object_)
-                    pt = ones * numpy.nan
+                    ones = np.ones((left.shape[1] + unmatchedPtCountR,),
+                                   dtype=np.object_)
+                    pt = ones * np.nan
                     pt[matchingFtIdx[0]] = row[matchingFtIdx[1]]
                     pt[left.shape[1]:] = row[notMatchingR]
                     merged.append(pt)
@@ -378,19 +376,19 @@ class Matrix(Base):
         self._featureCount = left.shape[1] + unmatchedPtCountR
         self._pointCount = len(merged)
         if len(merged) == 0 and onFeature is None:
-            merged = numpy.empty((0, left.shape[1] + unmatchedPtCountR - 1))
+            merged = np.empty((0, left.shape[1] + unmatchedPtCountR - 1))
             self._featureCount -= 1
         elif len(merged) == 0:
-            merged = numpy.empty((0, left.shape[1] + unmatchedPtCountR))
+            merged = np.empty((0, left.shape[1] + unmatchedPtCountR))
         elif onFeature is None:
             # remove point names feature
             merged = [row[1:] for row in merged]
             self._featureCount -= 1
 
-        self._data = numpy2DArray(merged, dtype=numpy.object_)
+        self._data = numpy2DArray(merged, dtype=np.object_)
 
     def _replaceFeatureWithBinaryFeatures_implementation(self, uniqueIdx):
-        toFill = numpy.zeros((len(self.points), len(uniqueIdx)))
+        toFill = np.zeros((len(self.points), len(uniqueIdx)))
         for ptIdx, val in enumerate(self._data):
             ftIdx = uniqueIdx[val.item()]
             toFill[ptIdx, ftIdx] = 1
@@ -428,12 +426,12 @@ class Matrix(Base):
         """
         Create an object of one less dimension
         """
-        reshape = (self._shape[1], int(numpy.prod(self._shape[2:])))
+        reshape = (self._shape[1], int(np.prod(self._shape[2:])))
         data = self._data[pointIndex].reshape(reshape)
         return Matrix(data, shape=self._shape[1:], reuseData=True)
 
     def _validate_implementation(self, level):
-        shape = numpy.shape(self._data)
+        shape = np.shape(self._data)
         assert shape[0] == len(self.points)
         assert shape[1] == len(self.features)
 
@@ -473,11 +471,11 @@ class Matrix(Base):
         according to efficiency constraints.
         """
         if isinstance(other, Matrix):
-            return Matrix(numpy.matmul(self._data, other._data))
+            return Matrix(np.matmul(self._data, other._data))
         if isinstance(other, nimble.core.data.Sparse):
             # '*' is matrix multiplication in scipy
             return Matrix(self._data * other._getSparseData())
-        return Matrix(numpy.matmul(self._data, other.copy(to="numpyarray")))
+        return Matrix(np.matmul(self._data, other.copy(to="numpyarray")))
 
     def _convertToNumericTypes_implementation(self, usableTypes):
         if self._data.dtype not in usableTypes:
@@ -487,7 +485,7 @@ class Matrix(Base):
         return NimbleElementIterator(self._data, order, only)
 
     def _isBooleanData(self):
-        return self._data.dtype in [bool, numpy.bool_]
+        return self._data.dtype in [bool, np.bool_]
 
 class MatrixView(BaseView, Matrix):
     """

--- a/nimble/core/data/matrixAxis.py
+++ b/nimble/core/data/matrixAxis.py
@@ -5,7 +5,7 @@ operations on a nimble Matrix object.
 
 from abc import ABCMeta, abstractmethod
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble._utility import numpy2DArray
@@ -55,8 +55,7 @@ class MatrixAxis(Axis, metaclass=ABCMeta):
             ret = self._base._data[:, targetList]
 
         if structure != 'copy':
-            self._base._data = numpy.delete(self._base._data,
-                                            targetList, axisVal)
+            self._base._data = np.delete(self._base._data, targetList, axisVal)
 
         return nimble.core.data.Matrix(ret, pointNames=pointNames,
                                        featureNames=featureNames,
@@ -77,7 +76,7 @@ class MatrixAxis(Axis, metaclass=ABCMeta):
     def _unique_implementation(self):
         uniqueData, uniqueIndices = denseAxisUniqueArray(self._base,
                                                          self._axis)
-        if numpy.array_equal(self._base._data, uniqueData):
+        if np.array_equal(self._base._data, uniqueData):
             return self._base.copy()
 
         axisNames, offAxisNames = uniqueNameGetter(self._base, self._axis,
@@ -99,9 +98,9 @@ class MatrixAxis(Axis, metaclass=ABCMeta):
             ptDim = 1
             ftDim = totalCopies
         if copyVectorByVector:
-            repeated = numpy.repeat(self._base._data, totalCopies, axis)
+            repeated = np.repeat(self._base._data, totalCopies, axis)
         else:
-            repeated = numpy.tile(self._base._data, (ptDim, ftDim))
+            repeated = np.tile(self._base._data, (ptDim, ftDim))
         return repeated
 
     ###########
@@ -114,11 +113,11 @@ class MatrixAxis(Axis, metaclass=ABCMeta):
         current values with the transformed values.
         """
         baseDtype = self._base._data.dtype
-        if baseDtype != numpy.object_ and retDtype == numpy.object_:
-            self._base._data = self._base._data.astype(numpy.object_)
-        elif baseDtype == numpy.int and retDtype == numpy.float:
-            self._base._data = self._base._data.astype(numpy.float)
-        elif baseDtype == numpy.bool_ and retDtype != numpy.bool_:
+        if baseDtype != np.object_ and retDtype == np.object_:
+            self._base._data = self._base._data.astype(np.object_)
+        elif baseDtype == np.int and retDtype == np.float:
+            self._base._data = self._base._data.astype(np.float)
+        elif baseDtype == np.bool_ and retDtype != np.bool_:
             self._base._data = self._base._data.astype(retDtype)
 
     ####################
@@ -156,7 +155,7 @@ class MatrixPoints(MatrixAxis, Points):
         """
         startData = self._base._data[:insertBefore, :]
         endData = self._base._data[insertBefore:, :]
-        self._base._data = numpy.concatenate(
+        self._base._data = np.concatenate(
             (startData, toInsert._data, endData), 0)
 
     def _transform_implementation(self, function, limitTo):
@@ -164,12 +163,12 @@ class MatrixPoints(MatrixAxis, Points):
             if limitTo is not None and i not in limitTo:
                 continue
             currRet = function(pt)
-            retArray = numpy.array(currRet, dtype=function.convertType)
+            retArray = np.array(currRet, dtype=function.convertType)
             self._convertBaseDtype(retArray.dtype)
             self._base._data[i, :] = retArray
         # if transformations applied to all data and function.convertType is
         # not object we can convert base with object dtype to a numeric dtype.
-        if (self._base._data.dtype == numpy.object_ and limitTo is None
+        if (self._base._data.dtype == np.object_ and limitTo is None
                 and function.convertType is not object):
             self._base._data = self._base._data.astype(function.convertType)
 
@@ -231,7 +230,7 @@ class MatrixFeatures(MatrixAxis, Features):
         """
         startData = self._base._data[:, :insertBefore]
         endData = self._base._data[:, insertBefore:]
-        self._base._data = numpy.concatenate(
+        self._base._data = np.concatenate(
             (startData, toInsert._data, endData), 1)
 
     def _transform_implementation(self, function, limitTo):
@@ -239,12 +238,12 @@ class MatrixFeatures(MatrixAxis, Features):
             if limitTo is not None and j not in limitTo:
                 continue
             currRet = function(f)
-            retArray = numpy.array(currRet, dtype=function.convertType)
+            retArray = np.array(currRet, dtype=function.convertType)
             self._convertBaseDtype(retArray.dtype)
             self._base._data[:, j] = retArray
         # if transformations applied to all data and function.convertType is
         # not object we can convert base object dtype to a numeric dtype.
-        if (self._base._data.dtype == numpy.object_ and limitTo is None
+        if (self._base._data.dtype == np.object_ and limitTo is None
                 and function.convertType is not object):
             self._base._data = self._base._data.astype(function.convertType)
 
@@ -254,8 +253,8 @@ class MatrixFeatures(MatrixAxis, Features):
 
     def _splitByParsing_implementation(self, featureIndex, splitList,
                                        numRetFeatures, numResultingFts):
-        tmpData = numpy.empty(shape=(len(self._base.points), numRetFeatures),
-                              dtype=numpy.object_)
+        tmpData = np.empty(shape=(len(self._base.points), numRetFeatures),
+                           dtype=np.object_)
 
         tmpData[:, :featureIndex] = self._base._data[:, :featureIndex]
         for i in range(numResultingFts):

--- a/nimble/core/data/points.py
+++ b/nimble/core/data/points.py
@@ -1530,7 +1530,7 @@ class Points(ABC):
             )
 
         Fill using nimble's match and fill modules; limit to last point.
-        Note: None is converted to numpy.nan in nimble.
+        Note: None is converted to np.nan in nimble.
 
         >>> from nimble import match
         >>> from nimble import fill
@@ -1700,7 +1700,7 @@ class Points(ABC):
         ``featureWithFeatureNames`` and ``featuresWithValues`` in each
         point will become the values for the expanded features for the
         combined points. If a combined point lacks a featureName/value
-        pair for any given feature(s), numpy.nan will be assigned as the
+        pair for any given feature(s), np.nan will be assigned as the
         value(s) at that feature(s). The resulting featureNames depends
         on the number of features with values. For a single feature with
         values, the new feature names are the unique values in

--- a/nimble/core/data/sparse.py
+++ b/nimble/core/data/sparse.py
@@ -5,7 +5,7 @@ coo_matrix.
 
 import warnings
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
@@ -63,15 +63,15 @@ class Sparse(Base):
         elif scipy.sparse.isspmatrix(data):
             # data is a spmatrix in other format instead of coo
             self._data = data.tocoo()
-        else: # data is numpy.array or python list
+        else: # data is np.array or python list
             if isinstance(data, list):
                 data = numpyArrayFromList(data)
-            # Sparse will convert None to 0 so we need to use numpy.nan instead
+            # Sparse will convert None to 0 so we need to use np.nan instead
             # pylint: disable=singleton-comparison
             if data[data == None].size:
-                if data.dtype not in [float, numpy.floating, object]:
+                if data.dtype not in [float, np.floating, object]:
                     data = data.astype(float)
-                data[data == None] = numpy.nan
+                data[data == None] = np.nan
 
             self._data = scipy.sparse.coo_matrix(data)
 
@@ -193,7 +193,7 @@ class Sparse(Base):
             try:
                 data = function(data)
             except Exception: # pylint: disable=broad-except
-                function.otypes = [numpy.object_]
+                function.otypes = [np.object_]
                 data = function(data)
             shape = self._data.shape
             values = scipy.sparse.coo_matrix((data, (row, col)), shape=shape)
@@ -326,7 +326,7 @@ class Sparse(Base):
         else:
             header += '#\n'
 
-        scipy.io.mmwrite(target=outPath, a=self._data.astype(numpy.float),
+        scipy.io.mmwrite(target=outPath, a=self._data.astype(np.float),
                          comment=header)
 
     def _referenceDataFrom_implementation(self, other):
@@ -357,7 +357,7 @@ class Sparse(Base):
                 return ret.reshape(self._shape)
             return ret
         if needsReshape:
-            data = numpy.empty(self._shape[:2], dtype=numpy.object_)
+            data = np.empty(self._shape[:2], dtype=np.object_)
             for i in range(self.shape[0]):
                 data[i] = self.points[i].copy('pythonlist')
         elif 'scipy' in to:
@@ -365,14 +365,14 @@ class Sparse(Base):
         else:
             data = sparseMatrixToArray(self._data)
         if to == 'numpymatrix':
-            return numpy.matrix(data)
+            return np.matrix(data)
         if 'scipy' in to:
             if to == 'scipycoo':
                 if needsReshape:
                     return scipy.sparse.coo_matrix(data)
                 return data.copy()
             try:
-                ret = data.astype(numpy.float)
+                ret = data.astype(np.float)
             except ValueError as e:
                 msg = 'Can only create scipy {0} matrix from numeric data'
                 raise ValueError(msg.format(to[-3:])) from e
@@ -528,14 +528,14 @@ class Sparse(Base):
         else:
             copyIndex = len(self._data.data)
 
-        newData = numpy.empty(copyIndex + len(toAddData),
-                              dtype=self._data.data.dtype)
+        newData = np.empty(copyIndex + len(toAddData),
+                           dtype=self._data.data.dtype)
         newData[:copyIndex] = self._data.data[:copyIndex]
         newData[copyIndex:] = toAddData
-        newRow = numpy.empty(copyIndex + len(toAddRow))
+        newRow = np.empty(copyIndex + len(toAddRow))
         newRow[:copyIndex] = self._data.row[:copyIndex]
         newRow[copyIndex:] = toAddRow
-        newCol = numpy.empty(copyIndex + len(toAddCol))
+        newCol = np.empty(copyIndex + len(toAddCol))
         newCol[:copyIndex] = self._data.col[:copyIndex]
         newCol[copyIndex:] = toAddCol
         shape = (len(self.points), len(self.features))
@@ -610,46 +610,45 @@ class Sparse(Base):
         else:
             onIdxL = 0
             onIdxR = 0
-            leftData = self._data.data.astype(numpy.object_)
+            leftData = self._data.data.astype(np.object_)
             if not self.points._anyDefaultNames():
-                leftData = numpy.append([self.points.getNames()], leftData)
+                leftData = np.append([self.points.getNames()], leftData)
             elif self._pointNamesCreated():
                 # differentiate default names between objects;
                 # note still start with DEFAULT_PREFIX
                 leftNames = [n + '_l' if isDefaultName(n) else n
                              for n in self.points.getNames()]
-                leftData = numpy.append([leftNames], leftData)
+                leftData = np.append([leftNames], leftData)
             else:
                 leftNames = [DEFAULT_PREFIX + str(i) for i
                              in range(len(self.points))]
-                leftData = numpy.append(leftNames, leftData)
-            leftRow = numpy.append(list(range(len(self.points))),
-                                   self._data.row)
-            leftCol = numpy.append([0 for _ in range(len(self.points))],
-                                   self._data.col + 1)
-            rightData = other._data.data.copy().astype(numpy.object_)
+                leftData = np.append(leftNames, leftData)
+            leftRow = np.append(list(range(len(self.points))), self._data.row)
+            leftCol = np.append([0 for _ in range(len(self.points))],
+                                self._data.col + 1)
+            rightData = other._data.data.copy().astype(np.object_)
             if not other.points._anyDefaultNames():
-                rightData = numpy.append([other.points.getNames()], rightData)
+                rightData = np.append([other.points.getNames()], rightData)
             elif other._pointNamesCreated():
                 # differentiate default names between objects;
                 # note still start with DEFAULT_PREFIX
                 rightNames = [n + '_r' if isDefaultName(n) else n
                               for n in other.points.getNames()]
-                rightData = numpy.append([rightNames], rightData)
+                rightData = np.append([rightNames], rightData)
             else:
                 rtRange = range(self.shape[0], self.shape[0] + other.shape[0])
                 rightNames = [DEFAULT_PREFIX + str(i) for i in rtRange]
-                rightData = numpy.append(rightNames, rightData)
-            rightRow = numpy.append(list(range(len(other.points))),
-                                    other._data.row.copy())
-            rightCol = numpy.append([0 for i in range(len(other.points))],
-                                    other._data.col.copy() + 1)
+                rightData = np.append(rightNames, rightData)
+            rightRow = np.append(list(range(len(other.points))),
+                                 other._data.row.copy())
+            rightCol = np.append([0 for i in range(len(other.points))],
+                                 other._data.col.copy() + 1)
             matchingFtIdx[0] = list(map(lambda x: x + 1, matchingFtIdx[0]))
             matchingFtIdx[0].insert(0, 0)
             matchingFtIdx[1] = list(map(lambda x: x + 1, matchingFtIdx[1]))
             matchingFtIdx[1].insert(0, 0)
 
-        mergedData = numpy.empty((0, 0), dtype=numpy.object_)
+        mergedData = np.empty((0, 0), dtype=np.object_)
         mergedRow = []
         mergedCol = []
         matched = []
@@ -657,7 +656,7 @@ class Sparse(Base):
         numPts = 0
 
         for ptIdxL, target in enumerate(leftData[leftCol == onIdxL]):
-            rowIdxR = numpy.where(rightData[rightCol == onIdxR] == target)[0]
+            rowIdxR = np.where(rightData[rightCol == onIdxR] == target)[0]
             if len(rowIdxR) > 0:
                 for ptIdxR in rowIdxR:
                     ptL = leftData[leftRow == ptIdxL]
@@ -680,7 +679,7 @@ class Sparse(Base):
                                 ptL[matchingFtIdx[0]][i] = fill
                     ptR = ptR[[i for i in range(len(ptR))
                                if i not in matchingFtIdx[1]]]
-                    pt = numpy.append(ptL, ptR)
+                    pt = np.append(ptL, ptR)
                     if feature == "intersection":
                         pt = pt[matchingFtIdx[0]]
                         leftFtCount = len(matchingFtIdx[0])
@@ -691,7 +690,7 @@ class Sparse(Base):
                     if onFeature is None:
                         pt = pt[1:]
                     matched.append(target)
-                    mergedData = numpy.append(mergedData, pt)
+                    mergedData = np.append(mergedData, pt)
                     mergedRow.extend([nextPt] * len(pt))
                     mergedCol.extend(list(range(len(pt))))
                     nextPt += 1
@@ -700,11 +699,11 @@ class Sparse(Base):
                 ptL = leftData[leftRow == ptIdxL]
                 if onFeature is not None:
                     numNaN = len(other.features) - len(matchingFtIdx[1])
-                    ptR = [numpy.nan] * numNaN
+                    ptR = [np.nan] * numNaN
                 else:
                     numNaN = len(other.features) - len(matchingFtIdx[1]) + 1
-                    ptR = [numpy.nan] * numNaN
-                pt = numpy.append(ptL, ptR)
+                    ptR = [np.nan] * numNaN
+                pt = np.append(ptL, ptR)
                 if feature == "intersection":
                     pt = pt[matchingFtIdx[0]]
                 elif onFeature is not None and feature == "left":
@@ -713,7 +712,7 @@ class Sparse(Base):
                     pt = pt[:len(self.features) + 1]
                 if onFeature is None:
                     pt = pt[1:]
-                mergedData = numpy.append(mergedData, pt)
+                mergedData = np.append(mergedData, pt)
                 mergedRow.extend([nextPt] * len(pt))
                 mergedCol.extend(list(range(len(pt))))
                 nextPt += 1
@@ -723,18 +722,18 @@ class Sparse(Base):
             for ptIdxR, target in enumerate(rightData[rightCol == onIdxR]):
                 if target not in matched:
                     if onFeature is not None:
-                        nanList = [numpy.nan] * len(self.features)
-                        ptL = numpy.array(nanList, dtype=numpy.object_)
+                        nanList = [np.nan] * len(self.features)
+                        ptL = np.array(nanList, dtype=np.object_)
                     else:
-                        nanList = [numpy.nan] * (len(self.features) + 1)
-                        ptL = numpy.array(nanList, dtype=numpy.object_)
+                        nanList = [np.nan] * (len(self.features) + 1)
+                        ptL = np.array(nanList, dtype=np.object_)
                     fill = rightData[(rightRow == ptIdxR)][matchingFtIdx[1]]
                     ptL[matchingFtIdx[0]] = fill
                     # only unmatched points from right
-                    notMatchedR = numpy.in1d(rightCol, matchingFtIdx[1],
-                                             invert=True)
+                    notMatchedR = np.in1d(rightCol, matchingFtIdx[1],
+                                          invert=True)
                     ptR = rightData[(rightRow == ptIdxR) & (notMatchedR)]
-                    pt = numpy.append(ptL, ptR)
+                    pt = np.append(ptL, ptR)
                     if feature == "intersection":
                         pt = pt[matchingFtIdx[0]]
                     elif onFeature is not None and feature == "left":
@@ -744,7 +743,7 @@ class Sparse(Base):
                     if onFeature is None:
                         # remove pointNames column added
                         pt = pt[1:]
-                    mergedData = numpy.append(mergedData, pt)
+                    mergedData = np.append(mergedData, pt)
                     mergedRow.extend([nextPt] * len(pt))
                     mergedCol.extend(list(range(len(pt))))
                     nextPt += 1
@@ -803,13 +802,13 @@ class Sparse(Base):
         #binary search
         start, end = self._sorted['indices'][axisVal:axisVal + 2]
         if start == end: # axisVal is not in self._data.row
-            if numpy.issubdtype(self._data.dtype, numpy.bool_):
+            if np.issubdtype(self._data.dtype, np.bool_):
                 return False
             return 0
-        k = numpy.searchsorted(offAxis[start:end], offAxisVal) + start
+        k = np.searchsorted(offAxis[start:end], offAxisVal) + start
         if k < end and offAxis[k] == offAxisVal:
             return self._data.data[k]
-        if numpy.issubdtype(self._data.dtype, numpy.bool_):
+        if np.issubdtype(self._data.dtype, np.bool_):
             return False
         return 0
 
@@ -860,8 +859,8 @@ class Sparse(Base):
             if not allOtherAxis:
                 secondaryLimited = sortedSecondary[start:end]
                 targetSecondary = [secondaryStart, secondaryEnd]
-                innerStart, innerEnd = numpy.searchsorted(secondaryLimited,
-                                                          targetSecondary)
+                innerStart, innerEnd = np.searchsorted(secondaryLimited,
+                                                       targetSecondary)
                 outerStart = start
                 start = start + innerStart
                 end = outerStart + innerEnd
@@ -870,18 +869,18 @@ class Sparse(Base):
                 if dropDimension:
                     firstIdx = 1
                     pshape = self._shape[firstIdx]
-                    fshape = int(numpy.prod(self._shape[firstIdx + 1:]))
+                    fshape = int(np.prod(self._shape[firstIdx + 1:]))
                     kwds['pointStart'] = 0
                     kwds['pointEnd'] = self._shape[1]
                     kwds['featureStart'] = 0
-                    kwds['featureEnd'] = int(numpy.prod(self._shape[2:]))
+                    kwds['featureEnd'] = int(np.prod(self._shape[2:]))
                 else:
                     firstIdx = 0
                 primary = sortedSecondary[start:end] // fshape
                 secondary = sortedSecondary[start:end] % fshape
                 kwds['shape'] = [pshape] + self._shape[firstIdx + 1:]
             else:
-                primary = numpy.zeros((end - start,), dtype=int)
+                primary = np.zeros((end - start,), dtype=int)
                 secondary = sortedSecondary[start:end] - secondaryStart
 
             if singlePoint:
@@ -932,7 +931,7 @@ class Sparse(Base):
                 noZerosInData = all(i != 0 for i in self._data.data)
             assert noZerosInData
 
-            assert self._data.dtype.type is not numpy.string_
+            assert self._data.dtype.type is not np.string_
 
             sortedAxis = self._sorted['axis']
             sortedIndices = self._sorted['indices']
@@ -1117,13 +1116,13 @@ class Sparse(Base):
         trueDiv = opSplit[0] + 'truediv__'
         # ret is self for inplace operation
         ret = self._binaryOperations_implementation(trueDiv, other)
-        ret._data.data = numpy.floor(ret._data.data)
+        ret._data.data = np.floor(ret._data.data)
         ret._data.eliminate_zeros()
         return ret
 
     def _genericMod_implementation(self, opName, other):
         """
-        Uses numpy.mod on the nonzero values in the coo matrix.
+        Uses np.mod on the nonzero values in the coo matrix.
 
         Since 0 % any value is 0, the zero values can be ignored for
         this operation.
@@ -1137,9 +1136,9 @@ class Sparse(Base):
         other._sortInternal(sort)
         otherData = other._getSparseData()
         if opName == '__rmod__':
-            ret = numpy.mod(otherData.data, selfData.data)
+            ret = np.mod(otherData.data, selfData.data)
         else:
-            ret = numpy.mod(selfData.data, otherData.data)
+            ret = np.mod(selfData.data, otherData.data)
         coo = scipy.sparse.coo_matrix((ret, (selfData.row, selfData.col)),
                                       shape=self.shape)
         coo.eliminate_zeros() # remove any zeros introduced into data
@@ -1183,7 +1182,7 @@ class Sparse(Base):
                 sortPrime = self._data.col
                 sortOff = self._data.row
             # sort least significant axis first
-            sortKeys = numpy.lexsort((sortOff, sortPrime))
+            sortKeys = np.lexsort((sortOff, sortPrime))
 
             self._data.data = self._data.data[sortKeys]
             self._data.row = self._data.row[sortKeys]
@@ -1200,7 +1199,7 @@ class Sparse(Base):
                 sortedAxis = self._data.col
                 sortedLength = len(self.features)
 
-            indices = numpy.searchsorted(sortedAxis, range(sortedLength + 1))
+            indices = np.searchsorted(sortedAxis, range(sortedLength + 1))
             self._sorted['indices'] = indices
 
     def _getSparseData(self):
@@ -1230,7 +1229,7 @@ class Sparse(Base):
         return NimbleElementIterator(array, order, only)
 
     def _isBooleanData(self):
-        return self._data.dtype in [bool, numpy.bool_]
+        return self._data.dtype in [bool, np.bool_]
 
     def _resetSorted(self):
         self._sorted['axis'] = None
@@ -1300,7 +1299,7 @@ class SparseView(BaseView, Sparse):
             return Sparse(coo, pointNames=pNames, featureNames=fNames)
 
         if len(self.points) == 0 or len(self.features) == 0:
-            emptyStandin = numpy.empty(self._shape)
+            emptyStandin = np.empty(self._shape)
             intermediate = nimble.data('Matrix', emptyStandin, useLog=False)
             return intermediate.copy(to=to)
 
@@ -1362,7 +1361,7 @@ class SparseView(BaseView, Sparse):
     def __abs__(self):
         """ Perform element wise absolute value on this object """
         ret = self.copy(to="Sparse")
-        numpy.absolute(ret._data.data, out=ret._data.data)
+        np.absolute(ret._data.data, out=ret._data.data)
         ret._name = None
 
         return ret
@@ -1393,4 +1392,4 @@ class SparseView(BaseView, Sparse):
         return selfConv._iterateElements_implementation(order, only)
 
     def _isBooleanData(self):
-        return self._source._data.dtype in [bool, numpy.bool_]
+        return self._source._data.dtype in [bool, np.bool_]

--- a/nimble/core/data/stretch.py
+++ b/nimble/core/data/stretch.py
@@ -1,7 +1,7 @@
 """
 Stretch object to allow for broadcasting operations.
 """
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import ImproperObjectAction
@@ -190,7 +190,7 @@ class Stretch(object):
         self._stretchArithmetic_validation(opName, other)
 
         try:
-            with numpy.errstate(divide='raise', invalid='raise'):
+            with np.errstate(divide='raise', invalid='raise'):
                 ret = self._stretchArithmetic_implementation(opName, other)
         except (TypeError, ValueError, FloatingPointError) as error:
             self._source._diagnoseFailureAndRaiseException(opName, otherSource,

--- a/nimble/core/interfaces/custom_learner.py
+++ b/nimble/core/interfaces/custom_learner.py
@@ -6,7 +6,7 @@ import abc
 import inspect
 import copy
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentValue, ImproperObjectAction
@@ -259,7 +259,7 @@ class CustomLearner(metaclass=abc.ABCMeta):
         """
         if self.__class__.learnerType == 'classification':
             labels = dtypeConvert(trainY.copy(to='numpyarray'))
-            self.labelList = numpy.unique(labels)
+            self.labelList = np.unique(labels)
 
         self.train(trainX, trainY, **arguments)
 
@@ -273,7 +273,7 @@ class CustomLearner(metaclass=abc.ABCMeta):
             flattenedY = dtypeConvert(trainY.copy(to='numpyarray').flatten())
             if self.labelList is None: # no previous training
                 self.labelList = []
-            self.labelList = numpy.union1d(self.labelList, flattenedY)
+            self.labelList = np.union1d(self.labelList, flattenedY)
         self.incrementalTrain(trainX, trainY, **arguments)
         return self
 

--- a/nimble/core/interfaces/keras_interface.py
+++ b/nimble/core/interfaces/keras_interface.py
@@ -6,7 +6,7 @@ import os
 import logging
 import warnings
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble._utility import inspectArguments, dtypeConvert
@@ -61,7 +61,7 @@ class Keras(PredefinedInterface):
                         and not splitList[0].startswith('_')):
                     possibilities.append(splitList[0])
 
-        possibilities = numpy.unique(possibilities).tolist()
+        possibilities = np.unique(possibilities).tolist()
         if 'utils' in possibilities:
             possibilities.remove('utils')
         self.keras.__all__.extend(possibilities)
@@ -369,10 +369,10 @@ To install keras
         if (hasattr(learner, 'decision_function')
                 or hasattr(learner, 'predict_proba')):
             if trainY is not None:
-                labelOrder = numpy.unique(trainY)
+                labelOrder = np.unique(trainY)
             else:
                 allLabels = learner.predict(trainX)
-                labelOrder = numpy.unique(allLabels)
+                labelOrder = np.unique(allLabels)
 
             learner.UIgetScoreOrder = labelOrder
 

--- a/nimble/core/interfaces/mlpy_interface.py
+++ b/nimble/core/interfaces/mlpy_interface.py
@@ -7,7 +7,7 @@ not allowed as a Kernel.
 TODO: multinomialHMM requires special input processing for obs param
 """
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentValue
@@ -255,7 +255,7 @@ To install mlpy
                               customDict):
         if outputFormat == "label" and len(outputValue.shape) == 1:
             # we are sometimes given a matrix, this will take care of that
-            outputValue = numpy.array(outputValue).flatten()
+            outputValue = np.array(outputValue).flatten()
             # In the case of prediction we are given a row vector,
             # yet we want a column vector
             outputValue = outputValue.reshape(len(outputValue), 1)

--- a/nimble/core/interfaces/scikit_learn_interface.py
+++ b/nimble/core/interfaces/scikit_learn_interface.py
@@ -11,7 +11,7 @@ from unittest import mock
 import pkgutil
 import abc
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentValue, ImproperObjectAction
@@ -150,10 +150,10 @@ class _SciKitLearnAPI(PredefinedInterface):
         if (hasattr(learner, 'decision_function')
                 or hasattr(learner, 'predict_proba')):
             if trainY is not None:
-                labelOrder = numpy.unique(trainY)
+                labelOrder = np.unique(trainY)
             else:
                 allLabels = learner.predict(trainX)
-                labelOrder = numpy.unique(allLabels)
+                labelOrder = np.unique(allLabels)
 
             learner.UIgetScoreOrder = labelOrder
 
@@ -508,11 +508,11 @@ To install scikit-learn
         # this particular learner requires integer inputs
         if learnerName == 'MultinomialHMM':
             if trainX is not None:
-                trainX = numpy.array(trainX, numpy.int32)
+                trainX = np.array(trainX, np.int32)
             if trainY is not None:
-                trainY = numpy.array(trainY, numpy.int32)
+                trainY = np.array(trainY, np.int32)
             if testX is not None:
-                testX = numpy.array(testX, numpy.int32)
+                testX = np.array(testX, np.int32)
 
         instantiatedArgs = {}
         for arg, val in arguments.items():

--- a/nimble/core/interfaces/shogun_interface.py
+++ b/nimble/core/interfaces/shogun_interface.py
@@ -8,7 +8,7 @@ import importlib
 import multiprocessing
 import warnings
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentValue
@@ -223,7 +223,7 @@ To install shogun
         if hasattr(predObj, 'get_multiclass_confidences'):
             # setup an array in the right shape, number of predicted labels
             # by number of possible labels
-            scoresPerPoint = numpy.empty((len(predLabels), numLabels))
+            scoresPerPoint = np.empty((len(predLabels), numLabels))
             for i in range(len(predLabels)):
                 currConfidences = predObj.get_multiclass_confidences(i)
                 if len(currConfidences) == 0:
@@ -339,7 +339,7 @@ To install shogun
             # with a function call
             retRaw = outputValue.get_labels()
             # prep for next call
-            retRaw = numpy.atleast_2d(retRaw)
+            retRaw = np.atleast_2d(retRaw)
             # we are given a column organized return, we want row first
             # organization, to match up with our input rows as points standard
             retRaw = retRaw.transpose()
@@ -381,7 +381,7 @@ To install shogun
         # TODO online training prep learner.start_train()
         # batch training if data is passed
         if trainY is not None:
-            labelOrder = numpy.unique(trainY.get_labels())
+            labelOrder = np.unique(trainY.get_labels())
             if customDict['remap'] is None:
                 learner.UIgetScoreOrder = labelOrder
             else:
@@ -455,7 +455,7 @@ To install shogun
             if problemType == self._access('Classifier', 'PT_CLASS'):
                 # could be either binary or multiclass
                 flattened = labelsObj.copy(to='numpyarray', outputAs1D=True)
-                if len(numpy.unique(flattened)) == 2:
+                if len(np.unique(flattened)) == 2:
                     problemType = self._access('Classifier', 'PT_BINARY')
                 else:
                     problemType = self._access('Classifier', 'PT_MULTICLASS')

--- a/nimble/core/interfaces/universal_interface.py
+++ b/nimble/core/interfaces/universal_interface.py
@@ -13,7 +13,7 @@ import numbers
 import time
 import warnings
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentValue, ImproperObjectAction
@@ -225,7 +225,7 @@ class UniversalInterface(metaclass=abc.ABCMeta):
                 return TrainedLearners(trainedLearners, 'OneVsOne', labelSet)
 
         # separate training data / labels if needed
-        if isinstance(trainY, (str, int, numpy.integer)):
+        if isinstance(trainY, (str, int, np.integer)):
             trainX = trainX.copy()
             trainY = trainX.features.extract(toExtract=trainY, useLog=False)
         return self._train(learnerName, trainX, trainY, arguments,
@@ -1297,7 +1297,7 @@ class TrainedLearner(object):
             self._transformedArguments[arg] = value
 
         # separate training data / labels if needed
-        if isinstance(trainY, (str, int, numpy.integer)):
+        if isinstance(trainY, (str, int, np.integer)):
             trainX = trainX.copy()
             trainY = trainX.features.extract(toExtract=trainY, useLog=False)
 
@@ -1424,7 +1424,7 @@ class TrainedLearner(object):
                 combinedScores = calculateSingleLabelScoresFromOneVsOneScores(
                     rawScores.pointView(i), numLabels)
                 scores.append(combinedScores)
-            scores = numpy.array(scores)
+            scores = np.array(scores)
             return nimble.data("Matrix", scores, useLog=False)
 
         return rawScores
@@ -1461,7 +1461,7 @@ class TrainedLearner(object):
             testX, None, nimbleTypeRawScores, usedArguments)
         internalOrder = self._interface._getScoresOrder(self._backend)
         naturalOrder = sorted(internalOrder)
-        if numpy.array_equal(naturalOrder, internalOrder):
+        if np.array_equal(naturalOrder, internalOrder):
             return formatedRawOrder
         desiredDict = {}
         for i, label in enumerate(naturalOrder):

--- a/nimble/core/learn.py
+++ b/nimble/core/learn.py
@@ -6,7 +6,7 @@ nimble import.
 from types import ModuleType
 import time
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble import match
@@ -404,7 +404,7 @@ def fillMatching(learnerName, matchingElements, trainX, arguments=None,
     else:
         matchingElements = match._convertMatchToFunction(matchingElements)
         matchMatrix = trainX.matchingElements(matchingElements, useLog=False)
-        if matchingElements(numpy.nan):
+        if matchingElements(np.nan):
             checkNans = False
     if checkNans:
         nanLocs = trainX.matchingElements(match.missing, useLog=False)
@@ -414,7 +414,7 @@ def fillMatching(learnerName, matchingElements, trainX, arguments=None,
 
     # do not fill actual trainX with nans in case trainAndApply fails
     toFill = trainX.copy()
-    toFill.features.fillMatching(numpy.nan, matchMatrix, useLog=False)
+    toFill.features.fillMatching(np.nan, matchMatrix, useLog=False)
     filled = trainAndApply(learnerName, toFill, arguments=merged, useLog=False)
 
     def transformer(elem, i, j):
@@ -859,7 +859,7 @@ def trainAndApply(learnerName, trainX, trainY=None, testX=None,
                            randomSeed=randomSeed, useLog=useLog, **kwarguments)
 
     if testX is None:
-        if isinstance(trainY, (str, int, numpy.integer)):
+        if isinstance(trainY, (str, int, np.integer)):
             testX = trainX.copy()
             testX.features.delete(trainY, useLog=False)
         else:
@@ -888,7 +888,7 @@ def _trainAndTestBackend(learnerName, trainX, trainY, testX, testY,
                            multiClassStrategy=multiClassStrategy, folds=folds,
                            randomSeed=randomSeed, useLog=useLog)
 
-    if isinstance(testY, (str, int, numpy.integer)):
+    if isinstance(testY, (str, int, np.integer)):
         testX = testX.copy()
         testY = testX.features.extract(testY, useLog=False)
     performance = trainedLearner.test(testX, testY, performanceFunction, {},

--- a/nimble/core/logger/data_set_analyzer.py
+++ b/nimble/core/logger/data_set_analyzer.py
@@ -7,7 +7,7 @@ st. dev., # of unique values (for non-real valued features), # of
 missing values
 """
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentValue
@@ -147,7 +147,7 @@ def produceAggregateTable(dataContainer):
     """
     shape = dataContainer._shape
     results = []
-    results.append(('Values', numpy.prod(shape)))
+    results.append(('Values', np.prod(shape)))
     if len(shape) > 2:
         results.append(('Dimensions', ' x '.join(map(str, shape))))
         # use as 2D to allow calculations of aggregate functions

--- a/nimble/core/logger/session_logger.py
+++ b/nimble/core/logger/session_logger.py
@@ -26,7 +26,7 @@ from ast import literal_eval
 import textwrap
 import datetime
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
@@ -414,11 +414,11 @@ class SessionLogger(object):
                     functionCall = "Unable to determine learner name"
             logInfo["learner"] = functionCall
             # integers or strings passed for Y values, convert if necessary
-            if isinstance(trainLabels, (str, int, numpy.int64)):
+            if isinstance(trainLabels, (str, int, np.int64)):
                 trainData = trainData.copy()
                 trainLabels = trainData.features.extract(trainLabels,
                                                          useLog=False)
-            if isinstance(testLabels, (str, int, numpy.int64)):
+            if isinstance(testLabels, (str, int, np.int64)):
                 testData = testData.copy()
                 testLabels = testData.features.extract(testLabels,
                                                        useLog=False)

--- a/nimble/fill/fill.py
+++ b/nimble/fill/fill.py
@@ -2,7 +2,7 @@
 Variety of functions to replace values in data with other values
 """
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.match import _convertMatchToFunction
@@ -351,7 +351,7 @@ def backwardFill(vector, match):
         raise InvalidArgumentValue(msg)
 
     def filler(vec):
-        ret = numpy.empty_like(vector, dtype=numpy.object_)
+        ret = np.empty_like(vector, dtype=np.object_)
         numValues = len(vec)
         # pylint: disable=unsupported-assignment-operation
         for i, (val, fill) in enumerate(zip(reversed(vector),
@@ -372,9 +372,9 @@ def interpolate(vector, match, **kwarguments):
     Fill matched values with the interpolated value
 
     The fill value is determined by the piecewise linear interpolant
-    returned by numpy.interp. By default, the unmatched values will be
+    returned by np.interp. By default, the unmatched values will be
     used as the discrete data points, but additional arguments for
-    numpy.interp can be passed as keyword arguments.
+    np.interp can be passed as keyword arguments.
 
     Parameters
     ----------
@@ -388,7 +388,7 @@ def interpolate(vector, match, **kwarguments):
           match module.
     kwarguments
         Collection of extra key:value argument pairs to pass to
-        numpy.interp.
+        np.interp.
 
     Returns
     -------
@@ -398,7 +398,7 @@ def interpolate(vector, match, **kwarguments):
 
     See Also
     --------
-    nimble.match, numpy.interp
+    nimble.match, np.interp
 
     Examples
     --------
@@ -442,7 +442,7 @@ def interpolate(vector, match, **kwarguments):
     if 'fp' not in kwarguments:
         kwarguments['fp'] = unmatchedVals
 
-    tmpV = numpy.interp(**kwarguments)
+    tmpV = np.interp(**kwarguments)
 
     def filler(vec):
         ret = []

--- a/nimble/learners/knn_classification.py
+++ b/nimble/learners/knn_classification.py
@@ -8,7 +8,7 @@ training points with lowest distances to the point you are predicting).
 If there is a tie, use k=1
 """
 
-import numpy
+import numpy as np
 
 from nimble import CustomLearner
 from nimble.core._createHelpers import initDataObject
@@ -85,9 +85,9 @@ class KNNClassifier(CustomLearner):
         trainArray = dtypeConvert(self._trainX.copy('numpy array'))
         testArray = dtypeConvert(testX.copy('numpy array'))
         # euclidean distance for each point in test
-        dists = numpy.sqrt(-2 * numpy.dot(testArray, trainArray.T)
-                           + numpy.sum(trainArray**2, axis=1)
-                           + numpy.sum(testArray**2, axis=1)[:, numpy.newaxis])
+        dists = np.sqrt(-2 * np.dot(testArray, trainArray.T)
+                           + np.sum(trainArray**2, axis=1)
+                           + np.sum(testArray**2, axis=1)[:, np.newaxis])
         return dists
 
 

--- a/nimble/learners/knn_imputation.py
+++ b/nimble/learners/knn_imputation.py
@@ -1,7 +1,7 @@
 """
 Contains the KNNImputation learner class.
 """
-import numpy
+import numpy as np
 
 import nimble
 from nimble import CustomLearner
@@ -44,7 +44,7 @@ class KNNImputation(CustomLearner):
                 msg += 'regression mode.'
                 raise InvalidArgumentValue(msg)
 
-        match = _convertMatchToFunction(numpy.nan)
+        match = _convertMatchToFunction(np.nan)
         self.match = trainX.matchingElements(match, useLog=False)
 
     def apply(self, testX):

--- a/nimble/learners/ridge_regression.py
+++ b/nimble/learners/ridge_regression.py
@@ -2,7 +2,7 @@
 Contains the RidgeRegression custom learner class.
 """
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble import CustomLearner
@@ -23,7 +23,7 @@ class RidgeRegression(CustomLearner):
         self.lamb = lamb
 
         # setup for intercept term
-        #		ones = nimble.data("Matrix", numpy.ones(len(trainX.points)))
+        #		ones = nimble.data("Matrix", np.ones(len(trainX.points)))
         #		ones.transpose()
         #		trainX = trainX.copy()
         #		trainX.features.append(ones)
@@ -36,16 +36,16 @@ class RidgeRegression(CustomLearner):
         rawXFxP = rawXPxF.transpose()
         rawYPxF = dtypeConvert(trainY.copy(to="numpyarray"))
 
-        featureSpace = numpy.matmul(rawXFxP, rawXPxF)
-        lambdaMatrix = lamb * numpy.identity(len(trainX.features))
+        featureSpace = np.matmul(rawXFxP, rawXPxF)
+        lambdaMatrix = lamb * np.identity(len(trainX.features))
         #		lambdaMatrix[len(trainX.features)-1][len(trainX.features)-1] = 0
 
-        inv = numpy.linalg.inv(featureSpace + lambdaMatrix)
-        self.w = numpy.matmul(numpy.matmul(inv, rawXFxP), rawYPxF)
+        inv = np.linalg.inv(featureSpace + lambdaMatrix)
+        self.w = np.matmul(np.matmul(inv, rawXFxP), rawYPxF)
 
     def apply(self, testX):
     # setup intercept
-    #		ones = nimble.data("Matrix", numpy.ones(len(testX.points)))
+    #		ones = nimble.data("Matrix", np.ones(len(testX.points)))
     #		ones.transpose()
     #		testX = testX.copy()
     #		testX.features.append(ones)
@@ -54,6 +54,6 @@ class RidgeRegression(CustomLearner):
         rawXPxF = dtypeConvert(testX.copy(to="numpyarray"))
         rawXFxP = rawXPxF.transpose()
 
-        pred = numpy.dot(self.w.transpose(), rawXFxP)
+        pred = np.dot(self.w.transpose(), rawXFxP)
 
         return nimble.data("Matrix", pred.transpose(), useLog=False)

--- a/nimble/match/match.py
+++ b/nimble/match/match.py
@@ -2,7 +2,7 @@
 Variety of functions to determine if data matches given conditions
 """
 
-import numpy
+import numpy as np
 
 import nimble # pylint: disable=unused-import
 
@@ -61,7 +61,7 @@ def numeric(value):
     --------
     >>> numeric(0)
     True
-    >>> numeric(numpy.float32(8))
+    >>> numeric(np.float32(8))
     True
     >>> numeric(float('nan'))
     True
@@ -70,7 +70,7 @@ def numeric(value):
     >>> numeric(None)
     False
     """
-    return (isinstance(value, (int, float, complex, numpy.number))
+    return (isinstance(value, (int, float, complex, np.number))
             and not boolean(value))
 
 def nonNumeric(value):
@@ -271,7 +271,7 @@ def infinity(value):
     False
     """
     try:
-        return numpy.isinf(value)
+        return np.isinf(value)
     except TypeError:
         return False
 
@@ -304,7 +304,7 @@ def boolean(value):
     >>> boolean('False')
     False
     """
-    return isinstance(value, (bool, numpy.bool_))
+    return isinstance(value, (bool, np.bool_))
 
 def true(value):
     """
@@ -1352,7 +1352,7 @@ def _convertMatchToFunction(match):
                 and not isinstance(match, str)):
             matchList = match
             # if nans in the list, need to include separate check in function
-            if not all([val == val for val in matchList]):
+            if not all(val == val for val in matchList):
                 match = lambda x: x != x or x in matchList
             else:
                 match = lambda x: x in matchList

--- a/nimble/random/randomness.py
+++ b/nimble/random/randomness.py
@@ -5,7 +5,7 @@ nimble functions and tests.
 
 import random
 
-import numpy
+import numpy as np
 
 import nimble # pylint: disable=unused-import
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
@@ -15,7 +15,7 @@ from nimble.core.logger import handleLogging
 from nimble.core._createHelpers import validateReturnType, initDataObject
 
 pythonRandom = random.Random(42)
-numpyRandom = numpy.random.RandomState(42) # pylint: disable=no-member
+numpyRandom = np.random.RandomState(42) # pylint: disable=no-member
 
 class _RandomControl:
     """
@@ -34,7 +34,7 @@ def setSeed(seed, useLog=None):
     ----------
     seed : int
         Seed for random state. Must be convertible to 32 bit unsigned
-        integer for compliance with numpy. If seed is None, then we use
+        integer for compliance with np. If seed is None, then we use
         os system time.
     """
 
@@ -173,7 +173,7 @@ def data(
                 raise PackageException(msg)
             # The point value is determined by counting how many groups of
             # numFeatures fit into the position number
-            pointIndices = numpy.floor(nzLocation / numFeatures)
+            pointIndices = np.floor(nzLocation / numFeatures)
             # The feature value is determined by counting the offset from each
             # point edge.
             featureIndices = nzLocation % numFeatures
@@ -181,9 +181,9 @@ def data(
                 (dataVector, (pointIndices, featureIndices)),
                 (numPoints, numFeatures))
         else:
-            randData = numpy.zeros(size)
-            # numpy.put indexes as if flat so can use nzLocation
-            numpy.put(randData, nzLocation, dataVector)
+            randData = np.zeros(size)
+            # np.put indexes as if flat so can use nzLocation
+            np.put(randData, nzLocation, dataVector)
     else:
         if elementType == 'int':
             randData = numpyRandom.randint(1, 100, size=size)
@@ -273,7 +273,7 @@ def _startAlternateControl(seed=None):
     ----------
     seed : int
         Seed for random state. Must be convertible to 32 bit unsigned
-        integer for compliance with numpy. If seed is None, then we use
+        integer for compliance with np. If seed is None, then we use
         os system time.
     """
     _RandomControl.pythonState = pythonRandom.getstate()

--- a/tests/calculate/confidence_test.py
+++ b/tests/calculate/confidence_test.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     import mock
 
-import numpy
+import numpy as np
 from nose.tools import raises
 from nose.plugins.attrib import attr
 
@@ -28,7 +28,7 @@ def fractionOfTimeInCI(getActual, getPredictions, ciFunc, expError):
         isInCI = expError > lower and expError < upper
         results.append(isInCI)
 
-    assert abs(numpy.mean(results) - confidence) <= 0.015
+    assert abs(np.mean(results) - confidence) <= 0.015
 
 @raises(PackageException)
 @mock.patch('nimble.calculate.confidence.scipy.nimbleAccessible', new=lambda: False)
@@ -64,7 +64,7 @@ def test_meanAbsoluteErrorConfidenceInterval():
     def getPredictions(actual):
         return actual + 0.1 * getActual(len(actual))
 
-    expectedError = numpy.mean(abs(0.1 * getActual(1000000)))
+    expectedError = np.mean(abs(0.1 * getActual(1000000)))
 
     fractionOfTimeInCI(getActual, getPredictions,
                        meanAbsoluteErrorConfidenceInterval, expectedError)

--- a/tests/calculate/linalg_test.py
+++ b/tests/calculate/linalg_test.py
@@ -5,7 +5,7 @@ Functions tested in this file:
 inverse, pseudoInverse, solve, leastSquaresSolution.
 """
 
-import numpy
+import numpy as np
 from nose.tools import raises
 
 import nimble
@@ -182,8 +182,8 @@ def testLeastSquareSolutionOverdetermined():
     """
     Test success for leastSquareSolution overdetermined system.
     """
-    aArray = numpy.array([[1, 2], [4, 5], [3, 4]])
-    bArrays = [numpy.array([1, 2, 3]), numpy.array([[1], [2], [3]])]
+    aArray = np.array([[1, 2], [4, 5], [3, 4]])
+    bArrays = [np.array([1, 2, 3]), np.array([[1], [2], [3]])]
     featureNames = ['f1', 'f2']
 
     _backendNonSquareSolverSucces(aArray, bArrays, featureNames)
@@ -193,16 +193,16 @@ def testLeastSquareSolutionUnderdetermined():
     """
     Test success for leastSquareSolution under-determined system.
     """
-    aArray = numpy.array([[1, 2, 3], [4, 5, 6]])
-    bArrays = [numpy.array([1, 2]), numpy.array([[1], [2]])]
+    aArray = np.array([[1, 2, 3], [4, 5, 6]])
+    bArrays = [np.array([1, 2]), np.array([[1], [2]])]
     featureNames = ['f1', 'f2', 'f3']
 
     _backendNonSquareSolverSucces(aArray, bArrays, featureNames)
 
 
 def _backendSolverSuccess(solverFunction):
-    aArray = numpy.array([[1, 20], [-30, 4]])
-    bArrays = [numpy.array([-30, 4]), numpy.array([[-30], [4]])]
+    aArray = np.array([[1, 20], [-30, 4]])
+    bArrays = [np.array([-30, 4]), np.array([[-30], [4]])]
 
     for constructor in getDataConstructors():
         for constructorB in getDataConstructors():

--- a/tests/calculate/loss_test.py
+++ b/tests/calculate/loss_test.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 from nose.tools import *
 
 import nimble
@@ -22,8 +22,8 @@ def testGenericErrorCalculatorEmptyKnownInput():
     """
     Test that _computeError raises an exception if knownLabels is empty
     """
-    knownLabels = numpy.array([])
-    predictedLabels = numpy.array([1, 2, 3])
+    knownLabels = np.array([])
+    predictedLabels = np.array([1, 2, 3])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -36,8 +36,8 @@ def testGenericErrorCalculatorEmptyPredictedInput():
     """
     Test that _computeError raises an exception if predictedLabels is empty
     """
-    knownLabels = numpy.array([1, 2, 3])
-    predictedLabels = numpy.array([])
+    knownLabels = np.array([1, 2, 3])
+    predictedLabels = np.array([])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -51,8 +51,8 @@ def testGenericErrorCalculatorDivideByZero():
     Test that _computeError raises a divide by zero exception if the
     outerFunction argument would lead to division by zero.
     """
-    knownLabels = numpy.array([1, 2, 3])
-    predictedLabels = numpy.array([1, 2, 3])
+    knownLabels = np.array([1, 2, 3])
+    predictedLabels = np.array([1, 2, 3])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -61,8 +61,8 @@ def testGenericErrorCalculatorDivideByZero():
 
 
 def testGenericErrorCalculator():
-    knownLabels = numpy.array([1.0, 2.0, 3.0])
-    predictedLabels = numpy.array([1.0, 2.0, 3.0])
+    knownLabels = np.array([1.0, 2.0, 3.0])
+    predictedLabels = np.array([1.0, 2.0, 3.0])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -82,8 +82,8 @@ def testMeanAbsoluteErrorEmptyKnownValues():
     Check that the mean absolute error calculator correctly throws an
     exception if knownLabels vector is empty
     """
-    knownLabels = numpy.array([])
-    predictedLabels = numpy.array([1, 2, 3])
+    knownLabels = np.array([])
+    predictedLabels = np.array([1, 2, 3])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -97,8 +97,8 @@ def testMeanAbsoluteErrorEmptyPredictedValues():
     Check that the mean absolute error calculator correctly throws an
     exception if predictedLabels vector is empty
     """
-    predictedLabels = numpy.array([])
-    knownLabels = numpy.array([1, 2, 3])
+    predictedLabels = np.array([])
+    knownLabels = np.array([1, 2, 3])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -112,8 +112,8 @@ def testMeanAbsoluteError():
     all inputs are zero, or predictions are exactly the same as all known
     values, and are non-zero
     """
-    predictedLabels = numpy.array([0, 0, 0])
-    knownLabels = numpy.array([0, 0, 0])
+    predictedLabels = np.array([0, 0, 0])
+    knownLabels = np.array([0, 0, 0])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels,
@@ -124,8 +124,8 @@ def testMeanAbsoluteError():
     maeRate = meanAbsoluteError(knownLabelsMatrix, predictedLabelsMatrix)
     assert maeRate == 0.0
 
-    predictedLabels = numpy.array([1.0, 2.0, 3.0])
-    knownLabels = numpy.array([1.0, 2.0, 3.0])
+    predictedLabels = np.array([1.0, 2.0, 3.0])
+    knownLabels = np.array([1.0, 2.0, 3.0])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     knownLabelsMatrix.transpose(useLog=False)
@@ -136,8 +136,8 @@ def testMeanAbsoluteError():
     maeRate = meanAbsoluteError(knownLabelsMatrix, predictedLabelsMatrix)
     assert maeRate == 0.0
 
-    predictedLabels = numpy.array([1.0, 2.0, 3.0])
-    knownLabels = numpy.array([1.5, 2.5, 3.5])
+    predictedLabels = np.array([1.0, 2.0, 3.0])
+    knownLabels = np.array([1.5, 2.5, 3.5])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     knownLabelsMatrix.transpose(useLog=False)
@@ -158,8 +158,8 @@ def testRmseEmptyKnownValues():
     """
     rootMeanSquareError calculator throws exception if knownLabels is empty
     """
-    knownLabels = numpy.array([])
-    predictedLabels = numpy.array([1, 2, 3])
+    knownLabels = np.array([])
+    predictedLabels = np.array([1, 2, 3])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -173,8 +173,8 @@ def testRmseEmptyPredictedValues():
     rootMeanSquareError calculator throws exception if predictedLabels is empty
     """
 
-    predictedLabels = numpy.array([])
-    knownLabels = numpy.array([1, 2, 3])
+    predictedLabels = np.array([])
+    knownLabels = np.array([1, 2, 3])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -188,8 +188,8 @@ def testRmse():
     all inputs are zero, and when all known values are
     the same as predicted values.
     """
-    predictedLabels = numpy.array([[0], [0], [0]])
-    knownLabels = numpy.array([[0], [0], [0]])
+    predictedLabels = np.array([[0], [0], [0]])
+    knownLabels = np.array([[0], [0], [0]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels,
@@ -198,8 +198,8 @@ def testRmse():
     rmseRate = rootMeanSquareError(knownLabelsMatrix, predictedLabelsMatrix)
     assert rmseRate == 0.0
 
-    predictedLabels = numpy.array([[1.0], [2.0], [3.0]])
-    knownLabels = numpy.array([[1.0], [2.0], [3.0]])
+    predictedLabels = np.array([[1.0], [2.0], [3.0]])
+    knownLabels = np.array([[1.0], [2.0], [3.0]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels,
@@ -208,8 +208,8 @@ def testRmse():
     rmseRate = rootMeanSquareError(knownLabelsMatrix, predictedLabelsMatrix)
     assert rmseRate == 0.0
 
-    predictedLabels = numpy.array([[1.0], [2.0], [3.0]])
-    knownLabels = numpy.array([[1.5], [2.5], [3.5]])
+    predictedLabels = np.array([[1.0], [2.0], [3.0]])
+    knownLabels = np.array([[1.5], [2.5], [3.5]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels,
@@ -226,8 +226,8 @@ def testRmse():
 
 @raises(InvalidArgumentValueCombination)
 def testMFRMSE_badshapePoints():
-    predictedLabels = numpy.array([[0, 2], [0, 2], [0, 2], [0, 2]])
-    knownLabels = numpy.array([[0, 0], [0, 0], [0, 0]])
+    predictedLabels = np.array([[0, 2], [0, 2], [0, 2], [0, 2]])
+    knownLabels = np.array([[0, 0], [0, 0], [0, 0]])
 
     knowns = nimble.data('Matrix', source=knownLabels)
     predicted = nimble.data('Matrix', source=predictedLabels)
@@ -237,8 +237,8 @@ def testMFRMSE_badshapePoints():
 
 @raises(InvalidArgumentValueCombination)
 def testMFRMSE_badshapeFeatures():
-    predictedLabels = numpy.array([[0], [0], [0], [0]])
-    knownLabels = numpy.array([[0, 0], [0, 0], [0, 0], [0, 0]])
+    predictedLabels = np.array([[0], [0], [0], [0]])
+    knownLabels = np.array([[0, 0], [0, 0], [0, 0], [0, 0]])
 
     knowns = nimble.data('Matrix', source=knownLabels)
     predicted = nimble.data('Matrix', source=predictedLabels)
@@ -247,8 +247,8 @@ def testMFRMSE_badshapeFeatures():
 
 @noLogEntryExpected
 def testMFRMSE_simpleSuccess():
-    predictedLabels = numpy.array([[0, 2], [0, 2], [0, 2], [0, 2]])
-    knownLabels = numpy.array([[0, 0], [0, 0], [0, 0], [0, 0]])
+    predictedLabels = np.array([[0, 2], [0, 2], [0, 2], [0, 2]])
+    knownLabels = np.array([[0, 0], [0, 0], [0, 0], [0, 0]])
 
     knowns = nimble.data('Matrix', source=knownLabels, useLog=False)
     predicted = nimble.data('Matrix', source=predictedLabels, useLog=False)
@@ -265,8 +265,8 @@ def testFractionCorrectEmptyKnownValues():
     """
     fractionCorrect calculator throws exception if knownLabels is empty
     """
-    knownLabels = numpy.array([])
-    predictedLabels = numpy.array([1, 2, 3])
+    knownLabels = np.array([])
+    predictedLabels = np.array([1, 2, 3])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -280,8 +280,8 @@ def testFractionCorrectEmptyPredictedValues():
     fractionCorrect calculator throws exception if predictedLabels is empty
     """
 
-    predictedLabels = numpy.array([])
-    knownLabels = numpy.array([1, 2, 3])
+    predictedLabels = np.array([])
+    knownLabels = np.array([1, 2, 3])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -295,8 +295,8 @@ def testFractionCorrect():
     all inputs are zero, and when all known values are
     the same as predicted values.
     """
-    predictedLabels = numpy.array([[0], [0], [0]])
-    knownLabels = numpy.array([[0], [0], [0]])
+    predictedLabels = np.array([[0], [0], [0]])
+    knownLabels = np.array([[0], [0], [0]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels,
@@ -305,8 +305,8 @@ def testFractionCorrect():
     fc = fractionCorrect(knownLabelsMatrix, predictedLabelsMatrix)
     assert fc == 1.0
 
-    predictedLabels = numpy.array([[1.0], [2.0], [3.0]])
-    knownLabels = numpy.array([[1.0], [2.0], [3.0]])
+    predictedLabels = np.array([[1.0], [2.0], [3.0]])
+    knownLabels = np.array([[1.0], [2.0], [3.0]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels,
@@ -315,8 +315,8 @@ def testFractionCorrect():
     fc = fractionCorrect(knownLabelsMatrix, predictedLabelsMatrix)
     assert fc == 1.0
 
-    predictedLabels = numpy.array([[1.0], [2.0], [3.0], [4.0]])
-    knownLabels = numpy.array([[1.0], [2.0], [1.0], [2.0]])
+    predictedLabels = np.array([[1.0], [2.0], [3.0], [4.0]])
+    knownLabels = np.array([[1.0], [2.0], [1.0], [2.0]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels,
@@ -334,8 +334,8 @@ def testFractionIncorrectEmptyKnownValues():
     """
     fractionIncorrect calculator throws exception if knownLabels is empty
     """
-    knownLabels = numpy.array([])
-    predictedLabels = numpy.array([1, 2, 3])
+    knownLabels = np.array([])
+    predictedLabels = np.array([1, 2, 3])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -349,8 +349,8 @@ def testFractionIncorrectEmptyPredictedValues():
     fractionIncorrect calculator throws exception if predictedLabels is empty
     """
 
-    predictedLabels = numpy.array([])
-    knownLabels = numpy.array([1, 2, 3])
+    predictedLabels = np.array([])
+    knownLabels = np.array([1, 2, 3])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -364,8 +364,8 @@ def testFractionIncorrect():
     all inputs are zero, and when all known values are
     the same as predicted values.
     """
-    predictedLabels = numpy.array([[0], [0], [0]])
-    knownLabels = numpy.array([[0], [0], [0]])
+    predictedLabels = np.array([[0], [0], [0]])
+    knownLabels = np.array([[0], [0], [0]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels,
@@ -374,8 +374,8 @@ def testFractionIncorrect():
     fi = fractionIncorrect(knownLabelsMatrix, predictedLabelsMatrix)
     assert fi == 0.0
 
-    predictedLabels = numpy.array([[1.0], [2.0], [3.0]])
-    knownLabels = numpy.array([[1.0], [2.0], [3.0]])
+    predictedLabels = np.array([[1.0], [2.0], [3.0]])
+    knownLabels = np.array([[1.0], [2.0], [3.0]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels,
@@ -384,8 +384,8 @@ def testFractionIncorrect():
     fi = fractionIncorrect(knownLabelsMatrix, predictedLabelsMatrix)
     assert fi == 0.0
 
-    predictedLabels = numpy.array([[1.0], [2.0], [3.0], [4.0]])
-    knownLabels = numpy.array([[1.0], [2.0], [1.0], [2.0]])
+    predictedLabels = np.array([[1.0], [2.0], [3.0], [4.0]])
+    knownLabels = np.array([[1.0], [2.0], [1.0], [2.0]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels,
@@ -403,8 +403,8 @@ def testVarianceFractionRemainingEmptyKnownValues():
     """
     varianceFractionRemaining calculator throws exception if knownLabels is empty
     """
-    knownLabels = numpy.array([])
-    predictedLabels = numpy.array([1, 2, 3])
+    knownLabels = np.array([])
+    predictedLabels = np.array([1, 2, 3])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -418,8 +418,8 @@ def testVarianceFractionRemainingEmptyPredictedValues():
     varianceFractionRemaining calculator throws exception if predictedLabels is empty
     """
 
-    predictedLabels = numpy.array([])
-    knownLabels = numpy.array([1, 2, 3])
+    predictedLabels = np.array([])
+    knownLabels = np.array([1, 2, 3])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -431,8 +431,8 @@ def testVarianceFractionRemaining():
     """
     Check that the varianceFractionRemaining calculator works correctly.
     """
-    predictedLabels = numpy.array([[1.0], [2.0], [3.0]])
-    knownLabels = numpy.array([[1.0], [2.0], [3.0]])
+    predictedLabels = np.array([[1.0], [2.0], [3.0]])
+    knownLabels = np.array([[1.0], [2.0], [3.0]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels,
@@ -441,8 +441,8 @@ def testVarianceFractionRemaining():
     vfr = varianceFractionRemaining(knownLabelsMatrix, predictedLabelsMatrix)
     assert vfr == 0.0
 
-    predictedLabels = numpy.array([[1.0], [2.0], [3.0], [4.0]])
-    knownLabels = numpy.array([[1.0], [2.0], [4.0], [3.0]])
+    predictedLabels = np.array([[1.0], [2.0], [3.0], [4.0]])
+    knownLabels = np.array([[1.0], [2.0], [4.0], [3.0]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels,
@@ -460,8 +460,8 @@ def testRSquaredEmptyKnownValues():
     """
     rSquared calculator throws exception if knownLabels is empty
     """
-    knownLabels = numpy.array([])
-    predictedLabels = numpy.array([1, 2, 3])
+    knownLabels = np.array([])
+    predictedLabels = np.array([1, 2, 3])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -475,8 +475,8 @@ def testRSquaredEmptyPredictedValues():
     rSquared calculator throws exception if predictedLabels is empty
     """
 
-    predictedLabels = numpy.array([])
-    knownLabels = numpy.array([1, 2, 3])
+    predictedLabels = np.array([])
+    knownLabels = np.array([1, 2, 3])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -488,8 +488,8 @@ def testRSquared():
     """
     Check that the rSquared calculator works correctly.
     """
-    predictedLabels = numpy.array([[1.0], [2.0], [3.0]])
-    knownLabels = numpy.array([[1.0], [2.0], [3.0]])
+    predictedLabels = np.array([[1.0], [2.0], [3.0]])
+    knownLabels = np.array([[1.0], [2.0], [3.0]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels,
@@ -498,8 +498,8 @@ def testRSquared():
     rsq = rSquared(knownLabelsMatrix, predictedLabelsMatrix)
     assert rsq == 1.0
 
-    predictedLabels = numpy.array([[1.0], [2.0], [3.0], [4.0]])
-    knownLabels = numpy.array([[1.0], [2.0], [4.0], [3.0]])
+    predictedLabels = np.array([[1.0], [2.0], [3.0], [4.0]])
+    knownLabels = np.array([[1.0], [2.0], [4.0], [3.0]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels, useLog=False)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels,

--- a/tests/calculate/normalize_test.py
+++ b/tests/calculate/normalize_test.py
@@ -1,5 +1,5 @@
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.calculate import meanNormalize, meanStandardDeviationNormalize
@@ -12,10 +12,10 @@ from tests.helpers import getDataConstructors
 @noLogEntryExpected
 def assertExpected(func, raw1, raw2, exp1, exp2):
     for shape in [(1, -1), (-1, 1)]:
-        raw1 = numpy.array(raw1).reshape(shape)
-        raw2 = numpy.array(raw2).reshape(shape)
-        exp1 = numpy.array(exp1).reshape(shape)
-        exp2 = numpy.array(exp2).reshape(shape)
+        raw1 = np.array(raw1).reshape(shape)
+        raw2 = np.array(raw2).reshape(shape)
+        exp1 = np.array(exp1).reshape(shape)
+        exp2 = np.array(exp2).reshape(shape)
         for con1 in getDataConstructors():
             for con2 in getDataConstructors():
                 data1 = con1(raw1, useLog=False)
@@ -41,19 +41,19 @@ def test_meanNormalize():
     assertExpected(meanNormalize, data1, data2, exp1, exp2)
 
 def test_meanNormalize_withNan():
-    data1 = [3, -1, numpy.nan, 3, -1]
-    data2 = [-2, 0, numpy.nan, 6]
+    data1 = [3, -1, np.nan, 3, -1]
+    data2 = [-2, 0, np.nan, 6]
 
-    exp1 = [2, -2, numpy.nan, 2, -2]
-    exp2 = [-3, -1, numpy.nan, 5]
+    exp1 = [2, -2, np.nan, 2, -2]
+    exp2 = [-3, -1, np.nan, 5]
 
     assertExpected(meanNormalize, data1, data2, exp1, exp2)
 
 def test_meanStandardDeviationNormalize():
     data1 = [0, 1, -3, 5, 4, 5]
     data2 = [-2, 0, 1, 2, 6]
-    mean = numpy.mean(data1)
-    std = numpy.std(data1)
+    mean = np.mean(data1)
+    std = np.std(data1)
 
     def zScore(v):
         return (v - mean) / std
@@ -64,13 +64,13 @@ def test_meanStandardDeviationNormalize():
     assertExpected(meanStandardDeviationNormalize, data1, data2, exp1, exp2)
 
 def test_meanStandardDeviationNormalize_withNan():
-    data1 = [-3, 0, 1, numpy.nan, 5, 5]
-    data2 = [0, numpy.nan, 2, -2, 6]
-    mean = numpy.nanmean(data1)
-    std = numpy.nanstd(data1)
+    data1 = [-3, 0, 1, np.nan, 5, 5]
+    data2 = [0, np.nan, 2, -2, 6]
+    mean = np.nanmean(data1)
+    std = np.nanstd(data1)
 
     def zScoreNan(v):
-        if numpy.isnan(v):
+        if np.isnan(v):
             return v
         return (v - mean) / std
 
@@ -82,8 +82,8 @@ def test_meanStandardDeviationNormalize_withNan():
 def test_meanStandardDeviationNormalize_allEqual():
     data1 = [7, 7, 7, 7, 7]
     data2 = [7, 7, 6, 9]
-    mean = numpy.mean(data1)
-    std = numpy.std(data1)
+    mean = np.mean(data1)
+    std = np.std(data1)
 
     def zScoreStdZero(v):
         assert std == 0
@@ -104,11 +104,11 @@ def test_range0to1Normalize():
     assertExpected(range0to1Normalize, data1, data2, exp1, exp2)
 
 def test_range0to1Normalize_withNan():
-    data1 = [-4, -1, 1, 6, numpy.nan]
-    data2 = [-5, -3, numpy.nan, 7]
+    data1 = [-4, -1, 1, 6, np.nan]
+    data2 = [-5, -3, np.nan, 7]
 
-    exp1 = [0, 0.3, 0.5, 1, numpy.nan]
-    exp2 = [-0.1, 0.1, numpy.nan, 1.1]
+    exp1 = [0, 0.3, 0.5, 1, np.nan]
+    exp2 = [-0.1, 0.1, np.nan, 1.1]
 
     assertExpected(range0to1Normalize, data1, data2, exp1, exp2)
 
@@ -134,11 +134,11 @@ def test_rangeNormalize():
     assertExpected(range1To5, data1, data2, exp1, exp2)
 
 def test_rangeNormalize_withNan():
-    data1 = [-4, 3, -1, numpy.nan, 6, 1]
-    data2 = [7, -5, numpy.nan, 1, 2]
+    data1 = [-4, 3, -1, np.nan, 6, 1]
+    data2 = [7, -5, np.nan, 1, 2]
 
-    exp1 = [1, 1.7, 1.3, numpy.nan, 2, 1.5]
-    exp2 = [2.1, 0.9, numpy.nan, 1.5, 1.6]
+    exp1 = [1, 1.7, 1.3, np.nan, 2, 1.5]
+    exp2 = [2.1, 0.9, np.nan, 1.5, 1.6]
 
     def range1To2(values1, values2=None):
         return rangeNormalize(values1, values2, start=1, end=2)
@@ -172,16 +172,16 @@ def test_percentileNormalize():
     assertExpected(percentileNormalize, data1, data2, exp1, exp2)
 
 def test_percentileNormalize_withNan():
-    data1 = [-4, 3, -1, numpy.nan, 6, 1, 1]
-    data2 = [7, -5, -3, 1, 0, numpy.nan]
+    data1 = [-4, 3, -1, np.nan, 6, 1, 1]
+    data2 = [7, -5, -3, 1, 0, np.nan]
 
     # both 1's should be same percentile
-    exp1 = [0.0, 0.8, 0.2, numpy.nan, 1.0, 0.5, 0.5]
+    exp1 = [0.0, 0.8, 0.2, np.nan, 1.0, 0.5, 0.5]
     # -3 is 1/3 of the way to covering distance between -4 (0) and -1 (0.2)
     expNeg3Percentile = 0 + (1/3) * (0.2 - 0)
     # 0 is 1/2 of the way to covering distance between -1 (0.2) and 1 (0.5)
     expZeroPercentile = 0.2 + (1/2) * (0.5 - 0.2)
-    exp2 = [1, 0, expNeg3Percentile, 0.5, expZeroPercentile, numpy.nan]
+    exp2 = [1, 0, expNeg3Percentile, 0.5, expZeroPercentile, np.nan]
     assertExpected(percentileNormalize, data1, data2, exp1, exp2)
 
 def test_percentileNormalize_allEqual():

--- a/tests/calculate/similarity_test.py
+++ b/tests/calculate/similarity_test.py
@@ -1,6 +1,6 @@
 import math
 
-import numpy
+import numpy as np
 from nose.tools import raises
 
 import nimble
@@ -16,9 +16,9 @@ from tests.helpers import getDataConstructors
 ####################
 @noLogEntryExpected
 def test_cosineSimilarity():
-    orig = numpy.array([[1], [0]])
-    orth = numpy.array([[0], [1]])
-    neg = numpy.array([[-1], [0]])
+    orig = np.array([[1], [0]])
+    orth = np.array([[0], [1]])
+    neg = np.array([[-1], [0]])
 
     origMatrix = nimble.data('Matrix', source=orig, useLog=False)
     orthMatrix = nimble.data('Matrix', source=orth, useLog=False)
@@ -43,23 +43,23 @@ def test_cosineSimilarityZeros():
 
 @raises(InvalidArgumentType)
 def test_cosineSimilarityKnownWrongType():
-    orig = numpy.array([[1], [0]])
+    orig = np.array([[1], [0]])
     origMatrix = nimble.data('Matrix', source=orig)
 
     result = cosineSimilarity(orig, origMatrix)
 
 @raises(InvalidArgumentType)
 def test_cosineSimilarityPredictedWrongType():
-    orig = numpy.array([[1], [0]])
+    orig = np.array([[1], [0]])
     origMatrix = nimble.data('Matrix', source=orig)
 
     result = cosineSimilarity(origMatrix, orig)
 
 @raises(InvalidArgumentValue)
 def test_cosineSimilarityPredictedWrongShape():
-    orig = numpy.array([[1], [0]])
+    orig = np.array([[1], [0]])
     origMatrix = nimble.data('Matrix', source=orig)
-    pred = numpy.array([[1, 1], [0, 0]])
+    pred = np.array([[1, 1], [0, 0]])
     predMatrix = nimble.data('Matrix', source=pred)
 
     result = cosineSimilarity(origMatrix, predMatrix)

--- a/tests/calculate/utility_test.py
+++ b/tests/calculate/utility_test.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 from nose.tools import *
 
 import nimble
@@ -24,25 +24,25 @@ from tests.helpers import noLogEntryExpected
 def test_detectBestResult_labels_inconsistentForDifferentKnowns():
     def foo(knowns, predicted):
         rawKnowns = knowns.copy(to="numpyarray")
-        rawPred = predicted.copy(to="numpy.array")
+        rawPred = predicted.copy(to="np.array")
 
         # case: knowns all zeros
-        if not numpy.any(rawKnowns):
+        if not np.any(rawKnowns):
             # case: predictd all right
-            if not numpy.any(rawPred):
+            if not np.any(rawPred):
                 return 0
             # case: predicted all wrong
-            elif numpy.all(rawPred):
+            elif np.all(rawPred):
                 return 1
             else:
                 return nimble.calculate.meanAbsoluteError(knowns, predicted)
         # case: knowns all ones
-        elif numpy.all(rawKnowns):
+        elif np.all(rawKnowns):
             # case: predicted all wrong
-            if not numpy.any(rawPred):
+            if not np.any(rawPred):
                 return 0
             # case: predictd all right
-            elif numpy.all(rawPred):
+            elif np.all(rawPred):
                 return 1
             else:
                 return 1 - nimble.calculate.meanAbsoluteError(knowns, predicted)

--- a/tests/customLearners/custom_learner_test.py
+++ b/tests/customLearners/custom_learner_test.py
@@ -1,7 +1,5 @@
 from nose.tools import raises
-
-import numpy
-import numpy.testing
+import numpy as np
 
 import nimble
 from nimble import CustomLearner
@@ -147,9 +145,9 @@ class LoveAtFirstSightClassifier(CustomLearner):
 
     def incrementalTrain(self, trainX, trainY):
         if hasattr(self, 'scope'):
-            self.scope = numpy.union1d(self.scope, trainY.copy(to='numpyarray').flatten())
+            self.scope = np.union1d(self.scope, trainY.copy(to='numpyarray').flatten())
         else:
-            self.scope = numpy.unique(trainY.copy(to='numpyarray'))
+            self.scope = np.unique(trainY.copy(to='numpyarray'))
         self.prediction = trainY[0, 0]
 
     def apply(self, testX):
@@ -451,8 +449,8 @@ class MeanConstant(CustomLearner):
         self.mean = trainY.features.statistics('mean')[0, 0]
 
     def apply(self, testX):
-        raw = numpy.zeros(len(testX.points))
-        numpy.ndarray.fill(raw, self.mean)
+        raw = np.zeros(len(testX.points))
+        np.ndarray.fill(raw, self.mean)
 
         ret = nimble.data("Matrix", raw, useLog=False)
         ret.transpose(useLog=False)

--- a/tests/customLearners/custom_ridge_test.py
+++ b/tests/customLearners/custom_ridge_test.py
@@ -1,4 +1,4 @@
-import numpy.testing
+import numpy as np
 
 import nimble
 from nimble.learners import RidgeRegression
@@ -19,6 +19,5 @@ def testRidgeRegressionShapes():
 
         assert len(ret.points) == 2
         assert len(ret.features) == 1
-        numpy.testing.assert_approx_equal(ret[0, 0], 10.5, significant=3)
-        numpy.testing.assert_approx_equal(ret[1, 0], 18, significant=2)
-
+        np.testing.assert_approx_equal(ret[0, 0], 10.5, significant=3)
+        np.testing.assert_approx_equal(ret[1, 0], 18, significant=2)

--- a/tests/data/baseObject.py
+++ b/tests/data/baseObject.py
@@ -1,9 +1,10 @@
 import inspect
 from functools import wraps
 
-import numpy
+import numpy as np
 
 import nimble
+from nimble.core._createHelpers import DEFAULT_MISSING
 
 def objConstructorMaker(returnType):
     """
@@ -12,10 +13,8 @@ def objConstructorMaker(returnType):
 
     def constructor(
             source, pointNames='automatic', featureNames='automatic',
-            name=None, convertToType=None,
-            treatAsMissing=(float('nan'), numpy.nan, None, '', 'None', 'nan',
-                            'NULL', 'NA'),
-            replaceMissingWith=numpy.nan, paths=(None, None)):
+            name=None, convertToType=None, treatAsMissing=DEFAULT_MISSING,
+            replaceMissingWith=np.nan, paths=(None, None)):
         # Case: source is a path to a file
         if isinstance(source, str):
             return nimble.data(
@@ -45,10 +44,8 @@ def viewConstructorMaker(concreteType):
 
     def constructor(
             source, pointNames='automatic', featureNames='automatic',
-            name=None, convertToType=None,
-            treatAsMissing=(float('nan'), numpy.nan, None, '', 'None', 'nan',
-                            'NULL', 'NA'),
-            replaceMissingWith=numpy.nan, paths=(None, None)):
+            name=None, convertToType=None, treatAsMissing=DEFAULT_MISSING,
+            replaceMissingWith=np.nan, paths=(None, None)):
         construct = objConstructorMaker(concreteType)
         orig = construct(source, pointNames, featureNames, name, convertToType,
                          treatAsMissing, replaceMissingWith, paths)
@@ -58,14 +55,14 @@ def viewConstructorMaker(concreteType):
         # data in the concrete object
         origPaths = (orig.absolutePath, orig.relativePath)
         if len(orig.points) != 0:
-            firstPRaw = numpy.zeros([1] + orig._shape[1:], dtype=int).tolist()
+            firstPRaw = np.zeros([1] + orig._shape[1:], dtype=int).tolist()
             fNamesParam = orig.features._getNamesNoGeneration()
             firstPoint = nimble.core._createHelpers.initDataObject(
                 concreteType, rawData=firstPRaw, pointNames=['firstPNonView'],
                 featureNames=fNamesParam, name=name,
                 convertToType=convertToType, paths=origPaths)
 
-            lastPRaw = (numpy.ones([1] + orig._shape[1:], dtype=int) * 3).tolist()
+            lastPRaw = (np.ones([1] + orig._shape[1:], dtype=int) * 3).tolist()
             lastPoint = nimble.core._createHelpers.initDataObject(
                 concreteType, rawData=lastPRaw, pointNames=['lastPNonView'],
                 featureNames=fNamesParam, name=name,

--- a/tests/data/data_specific_backend.py
+++ b/tests/data/data_specific_backend.py
@@ -4,7 +4,7 @@ Define data test objects for methods of properties specific to the type
 """
 from unittest.mock import patch
 
-import numpy
+import numpy as np
 
 from tests.helpers import CalledFunctionException, calledException
 from .baseObject import DataTestObject
@@ -43,11 +43,11 @@ class DataFrameSpecificDataSafe(DataTestObject):
         obj = self.constructor(data)
         startDtypes = tuple(obj._data.dtypes)
 
-        assert startDtypes == (numpy.dtype(int), numpy.dtype(int),
-                               numpy.dtype(float))
+        assert startDtypes == (np.dtype(int), np.dtype(int),
+                               np.dtype(float))
 
         # truediv and pow will always convert to floats
-        floatDtypes = (numpy.dtype(float),) * 3
+        floatDtypes = (np.dtype(float),) * 3
 
         ret = obj + 2
         assert tuple(obj._data.dtypes) == startDtypes
@@ -123,11 +123,11 @@ class DataFrameSpecificDataModifying(DataTestObject):
         obj = self.constructor(data)
         startDtypes = tuple(obj._data.dtypes)
 
-        assert startDtypes == (numpy.dtype(int), numpy.dtype(int),
-                               numpy.dtype(float))
+        assert startDtypes == (np.dtype(int), np.dtype(int),
+                               np.dtype(float))
 
         # truediv and pow will always convert to floats
-        floatDtypes = (numpy.dtype(float),) * 3
+        floatDtypes = (np.dtype(float),) * 3
 
         toTest = obj.copy()
         toTest += 2
@@ -194,7 +194,7 @@ class DataFrameSpecificDataModifying(DataTestObject):
         replace = self.constructor([[11., 22], [-11., -22]])
 
         obj.replaceRectangle(replace, 0, 0, 1, 1)
-        expDtypes = (numpy.dtype(float), numpy.dtype(int), numpy.dtype(float))
+        expDtypes = (np.dtype(float), np.dtype(int), np.dtype(float))
         assert tuple(obj._data.dtypes) == expDtypes
 
     def test_dtypes_flattenUnflatten(self):
@@ -221,7 +221,7 @@ class DataFrameSpecificDataModifying(DataTestObject):
                 [9, 8, 7., 6.], [-9, -8, -7., -6.]]
         obj = self.constructor(data)
         startDtypes = tuple(obj._data.dtypes)
-        ftExpDtypes = (numpy.dtype(int), numpy.dtype(float))
+        ftExpDtypes = (np.dtype(int), np.dtype(float))
 
         ptCp = obj.points.copy([1, 2])
         assert tuple(ptCp._data.dtypes) == startDtypes
@@ -271,7 +271,7 @@ class DataFrameSpecificDataModifying(DataTestObject):
         assert tuple(rep._data.dtypes) == startDtypes * 2
 
         rep = obj.features.repeat(2, True)
-        expDtypes = (numpy.dtype(int),) * 4 + (numpy.dtype(float),) * 2
+        expDtypes = (np.dtype(int),) * 4 + (np.dtype(float),) * 2
         assert tuple(rep._data.dtypes) == expDtypes
 
     def test_dtypes_splitByCollapsingFeatures(self):
@@ -284,8 +284,8 @@ class DataFrameSpecificDataModifying(DataTestObject):
         toCollapse = ["coll0", "coll1", "coll2", "coll3"]
         toTest.points.splitByCollapsingFeatures(toCollapse, "ftNames",
                                                 "ftValues")
-        expDtypes = (numpy.dtype(int), numpy.dtype(int), numpy.dtype(object),
-                     numpy.dtype(int))
+        expDtypes = (np.dtype(int), np.dtype(int), np.dtype(object),
+                     np.dtype(int))
         assert tuple(toTest._data.dtypes) == expDtypes
 
     def test_dtypes_combineByExpandingFeatures(self):
@@ -297,8 +297,8 @@ class DataFrameSpecificDataModifying(DataTestObject):
         fNames = ['type', 'dist', 'run', 'time']
         toTest = self.constructor(data, pointNames=pNames, featureNames=fNames)
 
-        expDtypes = (numpy.dtype(object), numpy.dtype(int), numpy.dtype(float),
-                     numpy.dtype(float))
+        expDtypes = (np.dtype(object), np.dtype(int), np.dtype(float),
+                     np.dtype(float))
         toTest.points.combineByExpandingFeatures('run', 'time')
         assert tuple(toTest._data.dtypes) == expDtypes
 
@@ -309,8 +309,8 @@ class DataFrameSpecificDataModifying(DataTestObject):
         toTest = self.constructor(data, pointNames=pNames, featureNames=fNames)
 
         toTest.features.splitByParsing(1, 1, ["split0", "split1"])
-        expDtypes = (numpy.dtype(int), numpy.dtype(object),
-                     numpy.dtype(object), numpy.dtype(float))
+        expDtypes = (np.dtype(int), np.dtype(object),
+                     np.dtype(object), np.dtype(float))
         assert tuple(toTest._data.dtypes) == expDtypes
 
 class DataFrameSpecificAll(DataFrameSpecificDataSafe,

--- a/tests/data/high_dimension_backend.py
+++ b/tests/data/high_dimension_backend.py
@@ -5,7 +5,7 @@ import sys
 from io import StringIO
 import tempfile
 
-import numpy
+import numpy as np
 import pandas as pd
 import scipy.sparse
 from nose.tools import raises
@@ -132,25 +132,25 @@ class HighDimensionSafe(DataTestObject):
                 assert listCopy == tensor
 
                 arrCopy = toTest.copy('numpy array')
-                assert numpy.array_equal(arrCopy, numpy.array(tensor))
+                assert np.array_equal(arrCopy, np.array(tensor))
                 assert arrCopy.shape == toTest.dimensions
 
-                objArr = numpy.empty(toTest._shape[:2], dtype=numpy.object_)
+                objArr = np.empty(toTest._shape[:2], dtype=np.object_)
                 for i, lst in enumerate(tensor):
                     objArr[i] = lst
 
                 matCopy = toTest.copy('numpy matrix')
-                assert numpy.array_equal(matCopy, numpy.matrix(objArr))
+                assert np.array_equal(matCopy, np.matrix(objArr))
 
                 cooCopy = toTest.copy('scipy coo')
                 expCoo = scipy.sparse.coo_matrix(objArr)
                 # coo __eq__ fails for object dtype b/c attempt conversion to csr
-                assert numpy.array_equal(cooCopy.data, expCoo.data)
-                assert numpy.array_equal(cooCopy.row, expCoo.row)
-                assert numpy.array_equal(cooCopy.col, expCoo.col)
+                assert np.array_equal(cooCopy.data, expCoo.data)
+                assert np.array_equal(cooCopy.row, expCoo.row)
+                assert np.array_equal(cooCopy.col, expCoo.col)
 
                 dfCopy = toTest.copy('pandas dataframe')
-                assert numpy.array_equal(dfCopy, pd.DataFrame(objArr))
+                assert np.array_equal(dfCopy, pd.DataFrame(objArr))
 
                 for cType in ['listofdict', 'dictoflist', 'scipycsc',
                               'scipycsr']:

--- a/tests/data/high_level_backend.py
+++ b/tests/data/high_level_backend.py
@@ -27,7 +27,7 @@ import tempfile
 import inspect
 import datetime
 
-import numpy
+import numpy as np
 from nose.tools import *
 from nose.plugins.attrib import attr
 try:
@@ -119,7 +119,7 @@ class HighLevelDataSafe(DataTestObject):
     @raises(ImproperObjectAction)
     def test_points_calculate_exceptionPEmpty(self):
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         origObj = self.constructor(data)
 
         def emitLower(point):
@@ -130,7 +130,7 @@ class HighLevelDataSafe(DataTestObject):
     @raises(ImproperObjectAction)
     def test_points_calculate_exceptionFEmpty(self):
         data = [[], []]
-        data = numpy.array(data)
+        data = np.array(data)
         origObj = self.constructor(data)
 
         def emitLower(point):
@@ -463,7 +463,7 @@ class HighLevelDataSafe(DataTestObject):
     @raises(ImproperObjectAction)
     def test_features_calculate_exceptionPEmpty(self):
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         origObj = self.constructor(data)
 
         def emitAllEqual(feature):
@@ -478,7 +478,7 @@ class HighLevelDataSafe(DataTestObject):
     @raises(ImproperObjectAction)
     def test_features_calculate_exceptionFEmpty(self):
         data = [[], []]
-        data = numpy.array(data)
+        data = np.array(data)
         origObj = self.constructor(data)
 
         def emitAllEqual(feature):
@@ -1075,18 +1075,18 @@ class HighLevelDataSafe(DataTestObject):
     def test_points_mapReduce_ExceptionNoFeatures(self):
         """ Test points.mapReduce() for ImproperObjectAction when there are no features  """
         data = [[], []]
-        data = numpy.array(data)
+        data = np.array(data)
         toTest = self.constructor(data)
         toTest.points.mapReduce(simpleMapper, simpleReducer)
 
     def test_points_mapReduce_emptyResultNoPoints(self):
         """ Test points.mapReduce() when given point empty data """
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         toTest = self.constructor(data)
         ret = toTest.points.mapReduce(simpleMapper, simpleReducer)
 
-        data = numpy.empty(shape=(0, 0))
+        data = np.empty(shape=(0, 0))
         exp = self.constructor(data)
         assert ret.isIdentical(exp)
 
@@ -1181,18 +1181,18 @@ class HighLevelDataSafe(DataTestObject):
     def test_features_mapReduce_ExceptionNoPoints(self):
         """ Test features.mapReduce() for ImproperObjectAction when there are no points  """
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         toTest = self.constructor(data)
         toTest.features.mapReduce(simpleMapper, simpleReducer)
 
     def test_features_mapReduce_emptyResultNoFeatures(self):
         """ Test features.mapReduce() when given feature empty data """
         data = [[], []]
-        data = numpy.array(data)
+        data = np.array(data)
         toTest = self.constructor(data)
         ret = toTest.features.mapReduce(simpleMapper, simpleReducer)
 
-        data = numpy.empty(shape=(0, 0))
+        data = np.empty(shape=(0, 0))
         exp = self.constructor(data)
         assert ret.isIdentical(exp)
 
@@ -1337,7 +1337,7 @@ class HighLevelDataSafe(DataTestObject):
         for x in range(2):
             points = 100
             features = 40
-            data = numpy.zeros((points, features))
+            data = np.zeros((points, features))
 
             for i in range(points):
                 for j in range(features):
@@ -2201,12 +2201,12 @@ class HighLevelDataSafe(DataTestObject):
         obj = self.constructor(raw)
         matches = obj.matchingElements(lambda x: x > 0)
 
-        assert matches[0, 0] is True or matches[0, 0] is numpy.bool_(True)
-        assert matches[0, 1] is True or matches[0, 1] is numpy.bool_(True)
-        assert matches[0, 2] is True or matches[0, 2] is numpy.bool_(True)
-        assert matches[1, 0] is False or matches[1, 0] is numpy.bool_(False)
-        assert matches[1, 1] is False or matches[1, 1] is numpy.bool_(False)
-        assert matches[1, 2] is False or matches[1, 2] is numpy.bool_(False)
+        assert matches[0, 0] is True or matches[0, 0] is np.bool_(True)
+        assert matches[0, 1] is True or matches[0, 1] is np.bool_(True)
+        assert matches[0, 2] is True or matches[0, 2] is np.bool_(True)
+        assert matches[1, 0] is False or matches[1, 0] is np.bool_(False)
+        assert matches[1, 1] is False or matches[1, 1] is np.bool_(False)
+        assert matches[1, 2] is False or matches[1, 2] is np.bool_(False)
 
     def test_matchingElements_valueInput(self):
         raw = [[1, 2, 3], [-1, -2, -3], [0, 'a', 0]]
@@ -2225,37 +2225,37 @@ class HighLevelDataSafe(DataTestObject):
 
         match1 = obj.matchingElements(lambda x: x == 0)
         match2 = obj.matchingElements('==0')
-        ws1, ws2, ws3 = [' ' * numpy.random.randint(1, 5) for _ in range(3)]
+        ws1, ws2, ws3 = [' ' * np.random.randint(1, 5) for _ in range(3)]
         match3 = obj.matchingElements(ws1 + '==' + ws2 + '0' + ws3)
         assert match1 == match2 == match3
 
         match1 = obj.matchingElements(lambda x: x != 0)
         match2 = obj.matchingElements('!=0')
-        ws1, ws2, ws3 = [' ' * numpy.random.randint(1, 5) for _ in range(3)]
+        ws1, ws2, ws3 = [' ' * np.random.randint(1, 5) for _ in range(3)]
         match3 = obj.matchingElements(ws1 + '!=' + ws2 + '0' + ws3)
         assert match1 == match2 == match3
 
         match1 = obj.matchingElements(lambda x: x > 0)
         match2 = obj.matchingElements('>0')
-        ws1, ws2, ws3 = [' ' * numpy.random.randint(1, 5) for _ in range(3)]
+        ws1, ws2, ws3 = [' ' * np.random.randint(1, 5) for _ in range(3)]
         match3 = obj.matchingElements(ws1 + '>' + ws2 + '0' + ws3)
         assert match1 == match2 == match3
 
         match1 = obj.matchingElements(lambda x: x < 0)
         match2 = obj.matchingElements('<0')
-        ws1, ws2, ws3 = [' ' * numpy.random.randint(1, 5) for _ in range(3)]
+        ws1, ws2, ws3 = [' ' * np.random.randint(1, 5) for _ in range(3)]
         match3 = obj.matchingElements(ws1 + '<' + ws2 + '0' + ws3)
         assert match1 == match2 == match3
 
         match1 = obj.matchingElements(lambda x: x >= 0)
         match2 = obj.matchingElements('>=0')
-        ws1, ws2, ws3 = [' ' * numpy.random.randint(1, 5) for _ in range(3)]
+        ws1, ws2, ws3 = [' ' * np.random.randint(1, 5) for _ in range(3)]
         match3 = obj.matchingElements(ws1 + '>=' + ws2 + '0' + ws3)
         assert match1 == match2 == match3
 
         match1 = obj.matchingElements(lambda x: x <= 0)
         match2 = obj.matchingElements('<=0')
-        ws1, ws2, ws3 = [' ' * numpy.random.randint(1, 5) for _ in range(3)]
+        ws1, ws2, ws3 = [' ' * np.random.randint(1, 5) for _ in range(3)]
         match3 = obj.matchingElements(ws1 + '<=' + ws2 + '0' + ws3)
         assert match1 == match2 == match3
 
@@ -2287,7 +2287,7 @@ class HighLevelDataSafe(DataTestObject):
 
         assert greaterEqualToNeg1 == expObj
 
-        raw = [['a', None, 'c'], [numpy.nan, None, -3], [0, 'zero', None]]
+        raw = [['a', None, 'c'], [np.nan, None, -3], [0, 'zero', None]]
         obj = self.constructor(raw)
 
         exp = [[False, True, False], [True, True, False], [False, False, True]]
@@ -2299,7 +2299,7 @@ class HighLevelDataSafe(DataTestObject):
         # None is converted to nan by nimble.data, here we explicitly pass the
         # value the underlying representation uses, so we avoid making it
         # look like None is considered a numeric
-        raw = [['a', numpy.nan, 'c'], [numpy.nan, numpy.nan, -3], [0, 'zero', numpy.nan]]
+        raw = [['a', np.nan, 'c'], [np.nan, np.nan, -3], [0, 'zero', np.nan]]
         obj = self.constructor(raw)
         exp = [[True, False, True], [False, False, False], [False, True, False]]
 
@@ -2376,7 +2376,7 @@ class HighLevelDataSafe(DataTestObject):
 
         assert anyGreaterNeg1 == expObj
 
-        raw = [[None, None, numpy.nan], [numpy.nan, None, -3], [0, 'zero', None]]
+        raw = [[None, None, np.nan], [np.nan, None, -3], [0, 'zero', None]]
         obj = self.constructor(raw)
 
         exp = [[True], [False], [False]]
@@ -2393,7 +2393,7 @@ class HighLevelDataSafe(DataTestObject):
         # None is converted to nan by nimble.data, here we explicitly pass the
         # value the underlying representation uses, so we avoid making it
         # look like None is considered a numeric
-        raw = [['a', numpy.nan, 'c'], [numpy.nan, numpy.nan, -3], [0, 'zero', numpy.nan]]
+        raw = [['a', np.nan, 'c'], [np.nan, np.nan, -3], [0, 'zero', np.nan]]
         obj = self.constructor(raw)
 
         exp = [[True], [False], [True]]
@@ -2422,9 +2422,9 @@ class HighLevelDataSafe(DataTestObject):
 
         assert len(matches.features) == 1
         assert len(matches.points) == 3
-        assert matches[0, 0] is True or matches[0, 0] is numpy.bool_(True)
-        assert matches[1, 0] is False or matches[1, 0] is numpy.bool_(False)
-        assert matches[2, 0] is False or matches[2, 0] is numpy.bool_(False)
+        assert matches[0, 0] is True or matches[0, 0] is np.bool_(True)
+        assert matches[1, 0] is False or matches[1, 0] is np.bool_(False)
+        assert matches[2, 0] is False or matches[2, 0] is np.bool_(False)
 
     def test_points_matching_varietyOfFuncs(self):
         self.back_pointsfeatures_matching_varietyOfFuncs('point')
@@ -2471,9 +2471,9 @@ class HighLevelDataSafe(DataTestObject):
 
         assert len(matches.points) == 1
         assert len(matches.features) == 3
-        assert matches[0, 0] is True or matches[0, 0] is numpy.bool_(True)
-        assert matches[0, 1] is False or matches[0, 1] is numpy.bool_(False)
-        assert matches[0, 2] is False or matches[0, 2] is numpy.bool_(False)
+        assert matches[0, 0] is True or matches[0, 0] is np.bool_(True)
+        assert matches[0, 1] is False or matches[0, 1] is np.bool_(False)
+        assert matches[0, 2] is False or matches[0, 2] is np.bool_(False)
 
     def test_features_matching_varietyOfFuncs(self):
         self.back_pointsfeatures_matching_varietyOfFuncs('feature')
@@ -2516,7 +2516,7 @@ class HighLevelModifying(DataTestObject):
     def test_replaceFeatureWithBinaryFeatures_PemptyException(self):
         """ Test replaceFeatureWithBinaryFeatures() with a point empty object """
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         toTest = self.constructor(data)
         toTest.replaceFeatureWithBinaryFeatures(0)
 
@@ -2524,7 +2524,7 @@ class HighLevelModifying(DataTestObject):
     def test_replaceFeatureWithBinaryFeatures_FemptyException(self):
         """ Test replaceFeatureWithBinaryFeatures() with a feature empty object """
         data = [[], []]
-        data = numpy.array(data)
+        data = np.array(data)
         toTest = self.constructor(data)
         toTest.replaceFeatureWithBinaryFeatures(0)
 
@@ -2590,7 +2590,7 @@ class HighLevelModifying(DataTestObject):
     def test_transformFeatureToIntegers_PemptyException(self):
         """ Test transformFeatureToIntegers() with an point empty object """
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         toTest = self.constructor(data)
         toTest.transformFeatureToIntegers(0)
 
@@ -2598,7 +2598,7 @@ class HighLevelModifying(DataTestObject):
     def test_transformFeatureToIntegers_FemptyException(self):
         """ Test transformFeatureToIntegers() with an feature empty object """
         data = [[], []]
-        data = numpy.array(data)
+        data = np.array(data)
         toTest = self.constructor(data)
         toTest.transformFeatureToIntegers(0)
 
@@ -2618,7 +2618,7 @@ class HighLevelModifying(DataTestObject):
         # ensure data was transformed to a numeric type.
         for i in range(len(toTest.points)):
             # Matrix and Sparse might store values as floats or numpy types
-            assert isinstance(toTest[i, 0], (int, float, numpy.number))
+            assert isinstance(toTest[i, 0], (int, float, np.number))
 
         # check ret
         assert len(ret) == 3
@@ -2651,7 +2651,7 @@ class HighLevelModifying(DataTestObject):
         # ensure data was transformed to a numeric type.
         for i in range(len(toTest.points)):
             # Matrix and Sparse might store values as floats or numpy types
-            assert isinstance(toTest[i, 0], (int, float, numpy.number))
+            assert isinstance(toTest[i, 0], (int, float, np.number))
 
         # check ret
         assert len(ret) == 3
@@ -2681,7 +2681,7 @@ class HighLevelModifying(DataTestObject):
         # ensure data was transformed to a numeric type.
         for i in range(len(toTest.points)):
             # Matrix and Sparse might store values as floats or numpy types
-            assert isinstance(toTest[i, 0], (int, float, numpy.number))
+            assert isinstance(toTest[i, 0], (int, float, np.number))
 
         # check ret
         assert len(ret) == 3
@@ -2822,7 +2822,7 @@ class HighLevelModifying(DataTestObject):
     def test_points_permute_exceptionIndicesPEmpty(self):
         """ tests points.permute() throws an IndexError when given invalid indices """
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         toTest = self.constructor(data)
         toTest.points.permute([1, 3])
 
@@ -2947,7 +2947,7 @@ class HighLevelModifying(DataTestObject):
     def test_features_permute_exceptionIndicesFEmpty(self):
         """ tests features.permute() throws an IndexError when given invalid indices """
         data = [[], []]
-        data = numpy.array(data)
+        data = np.array(data)
         toTest = self.constructor(data)
         toTest.features.permute([1, 3])
 
@@ -2965,7 +2965,7 @@ class HighLevelModifying(DataTestObject):
     def test_features_permute_exceptionNotUniqueIds(self):
         """ tests features.permute() throws an InvalidArgumentValue when given duplicate indices """
         data = [[3, 2, 1], [6, 5, 4],[9, 8, 7]]
-        data = numpy.array(data)
+        data = np.array(data)
         toTest = self.constructor(data)
         toTest.features.permute([1, 1, 0])
 
@@ -3307,9 +3307,9 @@ class HighLevelModifying(DataTestObject):
         obj3 = self.constructor(data)
         obj1.features.fillMatching(float('nan'), 999)
         obj2.features.fillMatching(None, 999)
-        obj3.features.fillMatching(numpy.nan, 999)
-        obj1.features.fillMatching(0, numpy.nan)
-        obj2.features.fillMatching(0, numpy.nan)
+        obj3.features.fillMatching(np.nan, 999)
+        obj1.features.fillMatching(0, np.nan)
+        obj2.features.fillMatching(0, np.nan)
         obj3.features.fillMatching(0, float('nan'))
 
         exp = self.constructor([[1, 2, 0, 4], [5, 0, 0, 8], [9, 10, 11, 0]])
@@ -3321,7 +3321,7 @@ class HighLevelModifying(DataTestObject):
         data = [[1, 2, 999, 4], [5, 999, 999, 8], [9, 10, 11, 999]]
         obj = self.constructor(data)
         obj.features.fillMatching(None, 999)
-        obj.features.fillMatching(0, [1, numpy.nan])
+        obj.features.fillMatching(0, [1, np.nan])
 
         exp = self.constructor([[0, 2, 0, 4], [5, 0, 0, 8], [9, 10, 11, 0]])
         assert obj == exp
@@ -3559,9 +3559,9 @@ class HighLevelModifying(DataTestObject):
         obj3 = self.constructor(data)
         obj1.points.fillMatching(float('nan'), 999)
         obj2.points.fillMatching(None, 999)
-        obj3.points.fillMatching(numpy.nan, 999)
-        obj1.points.fillMatching(0, numpy.nan)
-        obj2.points.fillMatching(0, numpy.nan)
+        obj3.points.fillMatching(np.nan, 999)
+        obj1.points.fillMatching(0, np.nan)
+        obj2.points.fillMatching(0, np.nan)
         obj3.points.fillMatching(0, float('nan'))
 
         exp = self.constructor([[1, 2, 0, 4], [5, 0, 0, 8], [9, 10, 11, 0]])
@@ -3573,7 +3573,7 @@ class HighLevelModifying(DataTestObject):
         data = [[1, 2, 999, 4], [5, 999, 999, 8], [9, 10, 11, 999]]
         obj = self.constructor(data)
         obj.points.fillMatching(None, 999)
-        obj.points.fillMatching(0, [1, numpy.nan])
+        obj.points.fillMatching(0, [1, np.nan])
 
         exp = self.constructor([[0, 2, 0, 4], [5, 0, 0, 8], [9, 10, 11, 0]])
         assert obj == exp

--- a/tests/data/low_level_backend.py
+++ b/tests/data/low_level_backend.py
@@ -19,7 +19,7 @@ points.getIndices, features.getIndices, constructIndicesList, copy
 features.hasName, points.hasName, __bool__, _treatAs2D
 """
 
-import numpy
+import numpy as np
 try:
     from unittest import mock #python >=3.3
 except ImportError:
@@ -1176,7 +1176,7 @@ class LowLevelBackend(object):
                 lambda lst: nimble.data(retType, lst, convertToType=object))
 
     def testconstructIndicesList_numpyArray(self):
-        self.constructIndicesList_backend(lambda lst: numpy.array(lst,dtype=object))
+        self.constructIndicesList_backend(lambda lst: np.array(lst,dtype=object))
 
     def testconstructIndicesList_pandasSeries(self):
         self.constructIndicesList_backend(lambda lst: pd.Series(lst))
@@ -1299,7 +1299,7 @@ class LowLevelBackend(object):
         featureNames = ['f1', 'f2', 'f3']
         toTest = self.constructor(pointNames=pointNames, featureNames=featureNames)
 
-        array2D = numpy.array([[1,2,3],[4,5,6]])
+        array2D = np.array([[1,2,3],[4,5,6]])
 
         constructIndicesList(toTest, 'feature', array2D)
 

--- a/tests/data/numerical_backend.py
+++ b/tests/data/numerical_backend.py
@@ -16,7 +16,7 @@ __or__, __xor__
 """
 
 import sys
-import numpy
+import numpy as np
 import os
 import os.path
 from unittest.mock import patch
@@ -631,7 +631,7 @@ def back_fShapeException(callerCon, calleeCon, attr1, attr2=None):
 
 def back_pEmptyException(callerCon, calleeCon, attr1, attr2=None):
     """ Test operation raises exception for point empty data """
-    data = numpy.zeros((0, 2))
+    data = np.zeros((0, 2))
     caller = callerCon(data)
     callee = calleeConstructor(data, calleeCon)
 
@@ -673,7 +673,7 @@ def back_byZeroException(callerCon, calleeCon, opName):
 
 def back_byInf(callerCon, calleeCon, opName):
     """ Test operation when other data contains zero """
-    inf = numpy.inf
+    inf = np.inf
     data1 = [[1, 2, 6], [4, 5, 3], [7, 8, 6]]
     data2 = [[inf, inf, inf], [inf, inf, inf], [inf, inf, inf]]
     if opName.startswith('__r'):
@@ -691,7 +691,7 @@ def back_byInf(callerCon, calleeCon, opName):
     ret = toCall(callee)
 
     if 'div' in opName:
-        exp = callerCon(numpy.zeros((3, 3)))
+        exp = callerCon(np.zeros((3, 3)))
     elif opName == '__rmod__' and calleeCon is None:
         exp = callerCon([[callee] * 3] * 3)
     elif opName == '__rmod__':
@@ -710,8 +710,8 @@ def makeAllData(constructor, rhsCons, numPts, numFts, sparsity):
     randomrf = nimble.random.data('Matrix', numPts, numFts, sparsity, useLog=False)
     lhsf = randomlf.copy(to="numpyarray")
     rhsf = randomrf.copy(to="numpyarray")
-    lhsi = numpy.array(numpyRandom.random_integers(1, 10, (numPts, numFts)))
-    rhsi = numpy.array(numpyRandom.random_integers(1, 10, (numPts, numFts)))
+    lhsi = np.array(numpyRandom.random_integers(1, 10, (numPts, numFts)))
+    rhsi = np.array(numpyRandom.random_integers(1, 10, (numPts, numFts)))
 
     lhsfObj = constructor(lhsf)
     lhsiObj = constructor(lhsi)
@@ -764,8 +764,8 @@ def back_autoVsNumpyObjCallee(constructor, opName, nimbleinplace, sparsity):
             assert expiObj.isIdentical(resiObj)
             # data type in object should not change unless required or inplace
             if not ('truediv' in opName or 'pow' in opName):
-                assert isinstance(lhsiObj[0, 0], (int, numpy.integer))
-                assert isinstance(rhsiObj[0, 0], (int, numpy.integer))
+                assert isinstance(lhsiObj[0, 0], (int, np.integer))
+                assert isinstance(rhsiObj[0, 0], (int, np.integer))
 
         assertNoNamesGenerated(lhsfObj)
         assertNoNamesGenerated(lhsiObj)
@@ -805,7 +805,7 @@ def back_autoVsNumpyScalar(constructor, opName, nimbleinplace, sparsity):
             assert expiObj.isIdentical(resiObj)
             # data type in object should not change unless required or inplace
             if not ('truediv' in opName or 'pow' in opName):
-                assert isinstance(lhsiObj[0, 0], (int, numpy.integer))
+                assert isinstance(lhsiObj[0, 0], (int, np.integer))
 
         assertNoNamesGenerated(lhsfObj)
         assertNoNamesGenerated(lhsiObj)
@@ -859,8 +859,8 @@ def back_autoVsNumpyObjCalleeDiffTypes(constructor, opName, nimbleinplace, spars
 
             # data type in object should not change unless required or inplace
             if not ('truediv' in opName or 'pow' in opName):
-                assert isinstance(lhsiObj[0, 0], (int, numpy.integer))
-                assert isinstance(rhsiObj[0, 0], (int, numpy.integer))
+                assert isinstance(lhsiObj[0, 0], (int, np.integer))
+                assert isinstance(rhsiObj[0, 0], (int, np.integer))
 
         assertNoNamesGenerated(lhsfObj)
         assertNoNamesGenerated(lhsiObj)
@@ -1485,23 +1485,23 @@ class NumericalDataSafe(DataTestObject):
         lhsObj ** rhs
 
     def test_pow_nimbleObj_inf(self):
-        inf = numpy.inf
+        inf = np.inf
         lhs = [[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]]
         rhs = [[inf, inf, inf], [inf, inf, inf], [inf, inf, inf]]
         lhsObj = self.constructor(lhs)
         rhsObj = self.constructor(rhs)
 
         ret = lhsObj ** rhsObj
-        exp = self.constructor(numpy.zeros((3, 3)))
+        exp = self.constructor(np.zeros((3, 3)))
         assert ret == exp
 
     def test_pow_scalar_inf(self):
         lhs = [[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]]
-        rhs = numpy.inf
+        rhs = np.inf
         lhsObj = self.constructor(lhs)
 
         ret = lhsObj ** rhs
-        exp = self.constructor(numpy.zeros((3, 3)))
+        exp = self.constructor(np.zeros((3, 3)))
         assert ret == exp
 
     def test_pow_binaryscalar_pfname_preservations(self):
@@ -1541,13 +1541,13 @@ class NumericalDataSafe(DataTestObject):
         num ** obj
 
     def test_rpow_scalar_inf(self):
-        inf = numpy.inf
+        inf = np.inf
         lhs = [[inf, inf, inf], [inf, inf, inf], [inf, inf, inf]]
         num = 0.1
         lhsObj = self.constructor(lhs)
 
         ret = num ** lhsObj
-        exp = self.constructor(numpy.zeros((3, 3)))
+        exp = self.constructor(np.zeros((3, 3)))
         assert ret == exp
 
     def test_rpow_binaryscalar_pfname_preservations(self):
@@ -1666,8 +1666,8 @@ class NumericalDataSafe(DataTestObject):
 
     @raises(ImproperObjectAction)
     def back_logical_exception_pEmpty(self, logicOp):
-        lhs = numpy.empty((0, 3))
-        rhs = numpy.empty((0, 3))
+        lhs = np.empty((0, 3))
+        rhs = np.empty((0, 3))
 
         lhsObj = self.constructor(lhs)
         rhsObj = self.constructor(rhs)
@@ -1676,8 +1676,8 @@ class NumericalDataSafe(DataTestObject):
 
     @raises(ImproperObjectAction)
     def back_logical_exception_fEmpty(self, logicOp):
-        lhs = numpy.empty((3, 0))
-        rhs = numpy.empty((3, 0))
+        lhs = np.empty((3, 0))
+        rhs = np.empty((3, 0))
 
         lhsObj = self.constructor(lhs)
         rhsObj = self.constructor(rhs)
@@ -1797,10 +1797,10 @@ class NumericalDataSafe(DataTestObject):
         boolsObj = self.constructor(bools)
         boolsInvert = ~boolsObj
 
-        assert boolsInvert[0, 0] is False or boolsInvert[0, 0] is numpy.bool_(False)
-        assert boolsInvert[0, 1] is False or boolsInvert[0, 1] is numpy.bool_(False)
-        assert boolsInvert[1, 0] is True or boolsInvert[1, 0] is numpy.bool_(True)
-        assert boolsInvert[1, 1] is True or boolsInvert[1, 1] is numpy.bool_(True)
+        assert boolsInvert[0, 0] is False or boolsInvert[0, 0] is np.bool_(False)
+        assert boolsInvert[0, 1] is False or boolsInvert[0, 1] is np.bool_(False)
+        assert boolsInvert[1, 0] is True or boolsInvert[1, 0] is np.bool_(True)
+        assert boolsInvert[1, 1] is True or boolsInvert[1, 1] is np.bool_(True)
 
     @noLogEntryExpected
     def test_invert_TrueFalse(self):
@@ -2113,23 +2113,23 @@ class NumericalModifying(DataTestObject):
         lhsObj **= rhs
 
     def test_ipow_nimbleObj_inf(self):
-        inf = numpy.inf
+        inf = np.inf
         lhs = [[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]]
         rhs = [[inf, inf, inf], [inf, inf, inf], [inf, inf, inf]]
         lhsObj = self.constructor(lhs)
         rhsObj = self.constructor(rhs)
 
         lhsObj **= rhsObj
-        exp = self.constructor(numpy.zeros((3, 3)))
+        exp = self.constructor(np.zeros((3, 3)))
         assert lhsObj == exp
 
     def test_ipow_scalar_inf(self):
         lhs = [[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [0.1, 0.1, 0.1]]
-        rhs = numpy.inf
+        rhs = np.inf
         lhsObj = self.constructor(lhs)
 
         lhsObj **= rhs
-        exp = self.constructor(numpy.zeros((3, 3)))
+        exp = self.constructor(np.zeros((3, 3)))
         assert lhsObj == exp
 
     def test_ipow_binaryscalar_pfname_preservations(self):

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -18,7 +18,7 @@ import re
 import textwrap
 from unittest.mock import patch
 
-import numpy
+import numpy as np
 from nose.tools import *
 from nose.plugins.attrib import attr
 
@@ -69,8 +69,8 @@ class QueryBackend(DataTestObject):
     def test_pointCount_empty(self):
         """ test pointCount when given different kinds of emptiness """
         data = [[], []]
-        dataPEmpty = numpy.array(data).T
-        dataFEmpty = numpy.array(data)
+        dataPEmpty = np.array(data).T
+        dataFEmpty = np.array(data)
 
         objPEmpty = self.constructor(dataPEmpty)
         objFEmpty = self.constructor(dataFEmpty)
@@ -104,8 +104,8 @@ class QueryBackend(DataTestObject):
     def test_featureCount_empty(self):
         """ test featureCount when given different kinds of emptiness """
         data = [[], []]
-        dataPEmpty = numpy.array(data).T
-        dataFEmpty = numpy.array(data)
+        dataPEmpty = np.array(data).T
+        dataFEmpty = np.array(data)
 
         pEmpty = self.constructor(dataPEmpty)
         fEmpty = self.constructor(dataFEmpty)
@@ -147,7 +147,7 @@ class QueryBackend(DataTestObject):
     def test_isIdentical_FalseBozoTypes(self):
         """ Test isIdentical() against some non-equal input of crazy types """
         toTest = self.constructor([[4, 5]])
-        assert not toTest.isIdentical(numpy.array([[1, 1], [2, 2]]))
+        assert not toTest.isIdentical(np.array([[1, 1], [2, 2]]))
         assert not toTest.isIdentical('self.constructor([[1,2,3]])')
         assert not toTest.isIdentical(toTest.isIdentical)
         assertNoNamesGenerated(toTest)
@@ -164,8 +164,8 @@ class QueryBackend(DataTestObject):
 
     def test_isIdentical_FalseWithNaN(self):
         """ Test isIdentical() against some non-equal input with nan"""
-        toTest1 = self.constructor([[1, numpy.nan, 5]])
-        toTest2 = self.constructor(deepcopy([[1, numpy.nan, 3]]))
+        toTest1 = self.constructor([[1, np.nan, 5]])
+        toTest2 = self.constructor(deepcopy([[1, np.nan, 3]]))
         assert not toTest1.isIdentical(toTest2)
         assert not toTest2.isIdentical(toTest1)
         assertNoNamesGenerated(toTest1)
@@ -173,8 +173,8 @@ class QueryBackend(DataTestObject):
 
     def test_isIdentical_TrueWithNaN(self):
         """ Test isIdentical() against some actually equal input with nan """
-        toTest1 = self.constructor([[1, numpy.nan, 5]])
-        toTest2 = self.constructor(deepcopy([[1, numpy.nan, 5]]))
+        toTest1 = self.constructor([[1, np.nan, 5]])
+        toTest2 = self.constructor(deepcopy([[1, np.nan, 5]]))
         assert toTest1.isIdentical(toTest2)
         assert toTest2.isIdentical(toTest1)
         assertNoNamesGenerated(toTest1)
@@ -641,7 +641,7 @@ class QueryBackend(DataTestObject):
         obj = self.constructor(raw)
 
         idxObj = obj.points.matching(lambda pt: sum(pt) > 6)
-        assert isinstance(idxObj[0], (bool, numpy.bool_))
+        assert isinstance(idxObj[0], (bool, np.bool_))
         ret = obj[idxObj, :]
 
         expData = [[4, 5, 6], [7, 8, 9]]
@@ -654,7 +654,7 @@ class QueryBackend(DataTestObject):
         obj = self.constructor(raw)
 
         idxObj = obj.features.matching(lambda ft: sum(ft) < 18)
-        assert isinstance(idxObj[0], (bool, numpy.bool_))
+        assert isinstance(idxObj[0], (bool, np.bool_))
         ret = obj[:, idxObj]
 
         expData = [[1, 2], [4, 5], [7, 8]]
@@ -721,7 +721,7 @@ class QueryBackend(DataTestObject):
         obj = self.constructor(raw)
 
         idxObj = obj.points.matching(lambda pt: sum(pt) > 6)
-        assert isinstance(idxObj[0], (bool, numpy.bool_))
+        assert isinstance(idxObj[0], (bool, np.bool_))
         ret = obj.points[idxObj]
 
         expData = [[4, 5, 6], [7, 8, 9]]
@@ -734,7 +734,7 @@ class QueryBackend(DataTestObject):
         obj = self.constructor(raw)
 
         idxObj = obj.features.matching(lambda ft: sum(ft) < 18)
-        assert isinstance(idxObj[0], (bool, numpy.bool_))
+        assert isinstance(idxObj[0], (bool, np.bool_))
         ret = obj.points[idxObj]
 
         expData = [[1, 2, 3], [4, 5, 6]]
@@ -747,7 +747,7 @@ class QueryBackend(DataTestObject):
         obj = self.constructor(raw)
 
         idxObj = obj.points.matching(lambda pt: sum(pt) > 6)
-        assert isinstance(idxObj[0], (bool, numpy.bool_))
+        assert isinstance(idxObj[0], (bool, np.bool_))
         ret = obj.features[idxObj]
 
         expData = [[2, 3], [5, 6], [8, 9]]
@@ -760,7 +760,7 @@ class QueryBackend(DataTestObject):
         obj = self.constructor(raw)
 
         idxObj = obj.features.matching(lambda ft: sum(ft) < 18)
-        assert isinstance(idxObj[0], (bool, numpy.bool_))
+        assert isinstance(idxObj[0], (bool, np.bool_))
         ret = obj.features[idxObj]
 
         expData = [[1, 2], [4, 5], [7, 8]]
@@ -775,7 +775,7 @@ class QueryBackend(DataTestObject):
     def test_pointView_FEmpty(self):
         """ Test pointView() when accessing a feature empty object """
         data = [[], []]
-        data = numpy.array(data)
+        data = np.array(data)
         toTest = self.constructor(data)
 
         v = toTest.pointView(0)
@@ -807,7 +807,7 @@ class QueryBackend(DataTestObject):
     def test_featureView_FEmpty(self):
         """ Test featureView() when accessing a point empty object """
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         toTest = self.constructor(data)
 
         v = toTest.featureView(0)
@@ -1175,12 +1175,12 @@ class QueryBackend(DataTestObject):
         # no checks, but this at least confirms that it is runnable
         names = ['n1', 'n2', 'n3']
 
-        rawPEmpty = numpy.zeros((0, 3))
+        rawPEmpty = np.zeros((0, 3))
         objPEmpty = self.constructor(rawPEmpty, featureNames=names)
 
         assert objPEmpty.toString() == ""
 
-        rawFEmpty = numpy.zeros((3, 0))
+        rawFEmpty = np.zeros((3, 0))
         objFEmpty = self.constructor(rawFEmpty, pointNames=names)
 
         assert objFEmpty.toString() == ""
@@ -1505,7 +1505,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def backend_Sim_SampleCovarianceResult(self, axis):
         data = [[3, 0, 3], [0, 0, 3], [3, 0, 0]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         orig = self.constructor(data)
         trans = self.constructor(dataT)
         sameAsOrig = self.constructor(data)
@@ -1525,7 +1525,7 @@ class QueryBackend(DataTestObject):
         expObj = self.constructor(expData)
 
         # numpy computted result -- bias=0 -> divisor of n-1
-        npExpRaw = numpy.cov(data, bias=0)
+        npExpRaw = np.cov(data, bias=0)
         npExpObj = self.constructor(npExpRaw)
         assert ret.isApproximatelyEqual(npExpObj)
 
@@ -1544,7 +1544,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def backend_Sim_populationCovarianceResult(self, axis):
         data = [[3, 0, 3], [0, 0, 3], [3, 0, 0]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         orig = self.constructor(data)
         trans = self.constructor(dataT)
         sameAsOrig = self.constructor(data)
@@ -1564,7 +1564,7 @@ class QueryBackend(DataTestObject):
         expObj = self.constructor(expData)
 
         # numpy computted result -- bias=1 -> divisor of n
-        npExpRaw = numpy.cov(data, bias=1)
+        npExpRaw = np.cov(data, bias=1)
         npExpObj = self.constructor(npExpRaw)
         assert ret.isApproximatelyEqual(npExpObj)
 
@@ -1583,7 +1583,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def backend_Sim_STDandVarianceIdentity(self, axis):
         data = [[3, 0, 3], [0, 0, 3], [3, 0, 0]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         orig = self.constructor(data)
         trans = self.constructor(dataT)
 
@@ -1595,9 +1595,9 @@ class QueryBackend(DataTestObject):
             stdVector = trans.features.statistics("\npopulationstd")
             ret.transpose(useLog=False)
 
-        numpy.testing.assert_approx_equal(ret[0, 0], stdVector[0] * stdVector[0])
-        numpy.testing.assert_approx_equal(ret[1, 1], stdVector[1] * stdVector[1])
-        numpy.testing.assert_approx_equal(ret[2, 2], stdVector[2] * stdVector[2])
+        np.testing.assert_approx_equal(ret[0, 0], stdVector[0] * stdVector[0])
+        np.testing.assert_approx_equal(ret[1, 1], stdVector[1] * stdVector[1])
+        np.testing.assert_approx_equal(ret[2, 2], stdVector[2] * stdVector[2])
 
 
     # test results correlation
@@ -1612,7 +1612,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def backend_Sim_CorrelationResult(self, axis):
         data = [[3, 0, 3], [0, 0, 3], [3, 0, 0]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         orig = self.constructor(data)
         trans = self.constructor(dataT)
         sameAsOrig = self.constructor(data)
@@ -1630,7 +1630,7 @@ class QueryBackend(DataTestObject):
         expData = [expRow0, expRow1, expRow2]
         expObj = self.constructor(expData)
 
-        npExpRaw = numpy.corrcoef(data)
+        npExpRaw = np.corrcoef(data)
         npExpObj = self.constructor(npExpRaw)
 
         assert ret.isApproximatelyEqual(npExpObj)
@@ -1648,7 +1648,7 @@ class QueryBackend(DataTestObject):
 
     def backend_Sim_CorrelationHelpersEquiv(self, axis):
         data = [[3, 0, 3], [0, 0, 3], [3, 0, 0]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         orig = self.constructor(data)
         trans = self.constructor(dataT)
         sameAsOrig = self.constructor(data)
@@ -1684,8 +1684,8 @@ class QueryBackend(DataTestObject):
             popRet = explicitCorr(orig, False)
             ret.transpose()
 
-        npExpRawB0 = numpy.corrcoef(data, bias=0)
-        npExpRawB1 = numpy.corrcoef(data, bias=1)
+        npExpRawB0 = np.corrcoef(data, bias=0)
+        npExpRawB1 = np.corrcoef(data, bias=1)
         npExpB0 = self.constructor(npExpRawB0)
         npExpB1 = self.constructor(npExpRawB1)
 
@@ -1708,7 +1708,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def backend_Sim_DotProductResult(self, axis):
         data = [[1, 1, 1], [0, 1, 1], [1, 0, 0]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         orig = self.constructor(data)
         trans = self.constructor(dataT)
         sameAsOrig = self.constructor(data)
@@ -1775,7 +1775,7 @@ class QueryBackend(DataTestObject):
 
     def backend_Sim_NamePath_Preservation(self, axis):
         data = [[3, 0, 3], [0, 0, 3], [3, 0, 0]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         orig = self.constructor(data, name=preserveName, paths=preservePair)
         trans = self.constructor(dataT, name=preserveName, paths=preservePair)
 
@@ -1863,7 +1863,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def backend_Stat_max(self, axis):
         data = [[1, 2, 1], [-10, -1, -21], [-1, 0, 0]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         fnames = _fnames(3)
         pnames = _pnames(3)
         orig = self.constructor(data, featureNames=fnames, pointNames=pnames)
@@ -1911,7 +1911,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def backend_Stat_mean(self, axis):
         data = [[1, 1, 1], [0, 1, 1], [1, 0, 0]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         fnames = _fnames(3)
         pnames = _pnames(3)
         orig = self.constructor(data, featureNames=fnames, pointNames=pnames)
@@ -1946,7 +1946,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def backend_Stat_median(self, axis):
         data = [[1, 1, 1], [0, 1, 1], [1, 0, 0]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         fnames = _fnames(3)
         pnames = _pnames(3)
         orig = self.constructor(data, featureNames=fnames, pointNames=pnames)
@@ -1982,7 +1982,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def backend_Stat_min(self, axis):
         data = [[1, 2, 1], [-10, -1, -21], [-1, 0, 0]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         fnames = _fnames(3)
         pnames = _pnames(3)
         orig = self.constructor(data, featureNames=fnames, pointNames=pnames)
@@ -2017,7 +2017,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def backend_Stat_uniqueCount(self, axis):
         data = [[1, 1, 1], [0, 1, 1], [1, 0, -1]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         fnames = _fnames(3)
         pnames = _pnames(3)
         orig = self.constructor(data, featureNames=fnames, pointNames=pnames)
@@ -2052,7 +2052,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def backend_Stat_proportionMissing(self, axis):
         data = [[1, None, 1], [0, 1, float('nan')], [1, float('nan'), None]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         fnames = _fnames(3)
         pnames = _pnames(3)
         orig = self.constructor(data, featureNames=fnames, pointNames=pnames)
@@ -2087,7 +2087,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def backend_Stat_proportionZero(self, axis):
         data = [[1, 1, 1], [0, 1, 1], [1, 0, 0]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         fnames = _fnames(3)
         pnames = _pnames(3)
         orig = self.constructor(data, featureNames=fnames, pointNames=pnames)
@@ -2124,7 +2124,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def backend_Stat_sampleStandardDeviation(self, axis):
         data = [[1, 1, 1], [0, 1, 1], [1, 0, 0]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         fnames = _fnames(3)
         pnames = _pnames(3)
         orig = self.constructor(data, featureNames=fnames, pointNames=pnames)
@@ -2141,7 +2141,7 @@ class QueryBackend(DataTestObject):
         assert len(ret.points) == 3
         assert len(ret.features) == 1
 
-        npExpRaw = numpy.std(data, axis=1, ddof=1, keepdims=True)
+        npExpRaw = np.std(data, axis=1, ddof=1, keepdims=True)
         npExpObj = self.constructor(npExpRaw)
 
         assert npExpObj.isApproximatelyEqual(ret)
@@ -2169,7 +2169,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def backend_Stat_populationStandardDeviation(self, axis):
         data = [[1, 1, 1], [0, 1, 1], [1, 0, 0]]
-        dataT = numpy.array(data).T.tolist()
+        dataT = np.array(data).T.tolist()
         fnames = _fnames(3)
         pnames = _pnames(3)
         orig = self.constructor(data, featureNames=fnames, pointNames=pnames)
@@ -2186,7 +2186,7 @@ class QueryBackend(DataTestObject):
         assert len(ret.points) == 3
         assert len(ret.features) == 1
 
-        npExpRaw = numpy.std(data, axis=1, ddof=0, keepdims=True)
+        npExpRaw = np.std(data, axis=1, ddof=0, keepdims=True)
         npExpObj = self.constructor(npExpRaw)
 
         assert npExpObj.isApproximatelyEqual(ret)
@@ -2486,7 +2486,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def test_points_iter_FemptyCorrectness(self):
         data = [[], []]
-        data = numpy.array(data)
+        data = np.array(data)
         toTest = self.constructor(data)
         pIter = iter(toTest.points)
 
@@ -2504,7 +2504,7 @@ class QueryBackend(DataTestObject):
     def test_points_iter_noNextPempty(self):
         """ test .points() has no next value when object is point empty """
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         toTest = self.constructor(data)
         viewIter = iter(toTest.points)
         try:
@@ -2578,7 +2578,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def test_features_iter_PemptyCorrectness(self):
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         toTest = self.constructor(data)
         fIter = iter(toTest.features)
 
@@ -2596,7 +2596,7 @@ class QueryBackend(DataTestObject):
     def test_features_iter_noNextFempty(self):
         """ test .features() has no next value when object is feature empty """
         data = [[], []]
-        data = numpy.array(data)
+        data = np.array(data)
         toTest = self.constructor(data)
         viewIter = iter(toTest.features)
         try:
@@ -2678,7 +2678,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def test_iter_noNextPempty(self):
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         toTest = self.constructor(data)
         viewIter = iter(toTest)
         try:
@@ -2690,7 +2690,7 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def test_iter_noNextFempty(self):
         data = [[], []]
-        data = numpy.array(data)
+        data = np.array(data)
         toTest = self.constructor(data)
         viewIter = iter(toTest)
         try:
@@ -2737,7 +2737,7 @@ class QueryBackend(DataTestObject):
     def test_iterateElements_noNextPempty(self):
         """ test iterateElements() has no next value when object is point empty """
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         toTest = self.constructor(data)
         viewIter = iter(toTest.iterateElements())
         try:
@@ -2749,7 +2749,7 @@ class QueryBackend(DataTestObject):
     def test_iterateElements_noNextFempty(self):
         """ test iterateElements() has no next value when object is feature empty """
         data = [[], []]
-        data = numpy.array(data)
+        data = np.array(data)
         toTest = self.constructor(data)
         viewIter = iter(toTest.iterateElements())
         try:
@@ -2918,7 +2918,7 @@ class QueryBackend(DataTestObject):
     def test_inverse_multiplicative(self):
         """ Test computation of multiplicative inverse."""
         from scipy import linalg
-        data = numpy.array([[1, 1, 0], [1, 0, 1], [1, 1, 1]])
+        data = np.array([[1, 1, 0], [1, 0, 1], [1, 1, 1]])
         pointNames =  ['1', 'one', '2']
         featureNames = ['one', 'two', 'three']
 
@@ -2937,7 +2937,7 @@ class QueryBackend(DataTestObject):
     def test_inverse_pseudoInverse(self):
         """ Test computation of pseudo-inverse using singular-value decomposition. """
         from scipy import linalg
-        data = numpy.array([[3, 2, 1], [2, 2, 0], [1, 0, 1]])
+        data = np.array([[3, 2, 1], [2, 2, 0], [1, 0, 1]])
         pointNames =  ['1', 'one', '2']
         featureNames = ['one', 'two', 'three']
 
@@ -2967,10 +2967,10 @@ class QueryBackend(DataTestObject):
     @noLogEntryExpected
     def backend_solveLinearSystem(self, solveFunction):
         from scipy import linalg
-        A = numpy.array([[1, 20], [-30, 4]])
-        b = numpy.array([[-30], [4]])
+        A = np.array([[1, 20], [-30, 4]])
+        b = np.array([[-30], [4]])
 
-        x = numpy.transpose(linalg.solve(A, b))
+        x = np.transpose(linalg.solve(A, b))
 
         pointNames =  ['1', 'one']
         featureNames = ['one', 'two']
@@ -2989,16 +2989,16 @@ class QueryBackend(DataTestObject):
 
     @raises(InvalidArgumentType)
     def test_solveLinearSystem_b_InvalidType(self):
-        A = numpy.array([[1, 20], [-30, 4]])
-        b = numpy.array([[-30], [4]])
+        A = np.array([[1, 20], [-30, 4]])
+        b = np.array([[-30], [4]])
 
         Aobj = self.constructor(A)
         Aobj.solveLinearSystem(b)
 
     @raises(InvalidArgumentType)
     def test_solveLinearSystem_InvalidParamType(self):
-        A = numpy.array([[1, 20], [-30, 4]])
-        b = numpy.array([[-30], [4]])
+        A = np.array([[1, 20], [-30, 4]])
+        b = np.array([[-30], [4]])
 
         Aobj = self.constructor(A)
         bobj = self.constructor(b)
@@ -3007,8 +3007,8 @@ class QueryBackend(DataTestObject):
 
     @raises(InvalidArgumentValue)
     def test_solveLinearSystem_InvalidParamValue(self):
-        A = numpy.array([[1, 20], [-30, 4]])
-        b = numpy.array([[-30], [4]])
+        A = np.array([[1, 20], [-30, 4]])
+        b = np.array([[-30], [4]])
 
         Aobj = self.constructor(A)
         bobj = self.constructor(b)
@@ -3092,7 +3092,7 @@ class QueryBackend(DataTestObject):
             if axis == 'points':
                 obj = self.constructor(data, featureNames=offAxisNames)
             else:
-                obj = self.constructor(numpy.array(data).T,
+                obj = self.constructor(np.array(data).T,
                                        pointNames=offAxisNames)
             return getattr(obj, axis)
 
@@ -3351,7 +3351,7 @@ def test_elementQueryFunction():
                 assert func6('hi hello')
                 assert not func6('hello hi')
 
-        whitespace = ' ' * numpy.random.randint(3, 7)
+        whitespace = ' ' * np.random.randint(3, 7)
         query = whitespace + optr + whitespace + '0' + whitespace
         func7 = elementQueryFunction(query)
         if '=' in optr:

--- a/tests/data/randomized_sequence_test.py
+++ b/tests/data/randomized_sequence_test.py
@@ -15,7 +15,7 @@ import pdb
 import functools
 import random
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.core.data import Base
@@ -251,7 +251,7 @@ def genObj(dataObj, seed, matchType=True, matchPoints=False, matchFeatures=False
         features = shape[1]
 
     if points == 0 or features == 0:
-        rawData = numpy.empty((points, features))
+        rawData = np.empty((points, features))
         ret = nimble.data('Matrix', rawData)
         ret = ret.copy(to=dataType)
     else:

--- a/tests/data/stretch_backend.py
+++ b/tests/data/stretch_backend.py
@@ -5,7 +5,7 @@ Tests for using stretch attribute to trigger broadcasting operations
 import operator
 
 from nose.tools import raises
-import numpy
+import numpy as np
 
 import nimble
 from nimble.exceptions import ImproperObjectAction, InvalidArgumentValue
@@ -24,13 +24,13 @@ class StretchDataSafe(DataTestObject):
 
     @raises(ImproperObjectAction)
     def test_stretch_exception_ptEmpty(self):
-        empty = numpy.empty((0, 3))
+        empty = np.empty((0, 3))
         emptyObj = self.constructor(empty)
         emptyObj.stretch
 
     @raises(ImproperObjectAction)
     def test_stretch_exception_ftEmpty(self):
-        empty = numpy.empty((3, 0))
+        empty = np.empty((3, 0))
         emptyObj = self.constructor(empty)
         emptyObj.stretch
 

--- a/tests/data/structure_backend.py
+++ b/tests/data/structure_backend.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     import mock
 
-import numpy
+import numpy as np
 from nose.tools import *
 
 import nimble
@@ -183,12 +183,12 @@ class StructureDataSafe(StructureShared):
     def test_T_empty(self):
         """ Test T property on different kinds of emptiness """
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         toTest = self.constructor(data)
         orig = toTest.copy()
 
         exp1 = [[], []]
-        exp1 = numpy.array(exp1)
+        exp1 = np.array(exp1)
         ret1 = self.constructor(exp1)
         assert ret1.isIdentical(toTest.T)
         assert toTest.isIdentical(orig)
@@ -290,7 +290,7 @@ class StructureDataSafe(StructureShared):
     def test_copy_Pempty(self):
         """ test copy() produces the correct outputs when given an point empty object """
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
 
         orig = self.constructor(data)
         sparseObj = nimble.data(returnType="Sparse", source=data, useLog=False)
@@ -318,22 +318,22 @@ class StructureDataSafe(StructureShared):
         assert pyList == []
 
         numpyArray = orig.copy(to='numpy array')
-        assert numpy.array_equal(numpyArray, data)
+        assert np.array_equal(numpyArray, data)
 
         numpyMatrix = orig.copy(to='numpy matrix')
-        assert numpy.array_equal(numpyMatrix, numpy.matrix(data))
+        assert np.array_equal(numpyMatrix, np.matrix(data))
 
         scipyCsr = orig.copy(to='scipy csr')
-        assert numpy.array_equal(sparseMatrixToArray(scipyCsr), data)
+        assert np.array_equal(sparseMatrixToArray(scipyCsr), data)
 
         scipyCsc = orig.copy(to='scipy csc')
-        assert numpy.array_equal(sparseMatrixToArray(scipyCsc), data)
+        assert np.array_equal(sparseMatrixToArray(scipyCsc), data)
 
         scipyCoo = orig.copy(to='scipy coo')
-        assert numpy.array_equal(sparseMatrixToArray(scipyCoo), data)
+        assert np.array_equal(sparseMatrixToArray(scipyCoo), data)
 
         pandasDF = orig.copy(to='pandas dataframe')
-        assert numpy.array_equal(pandasDF, data)
+        assert np.array_equal(pandasDF, data)
 
         listOfDict = orig.copy(to='list of dict')
         assert listOfDict == []
@@ -346,7 +346,7 @@ class StructureDataSafe(StructureShared):
     def test_copy_Fempty(self):
         """ test copy() produces the correct outputs when given an feature empty object """
         data = [[], []]
-        data = numpy.array(data)
+        data = np.array(data)
 
         orig = self.constructor(data)
         sparseObj = nimble.data(returnType="Sparse", source=data, useLog=False)
@@ -374,23 +374,23 @@ class StructureDataSafe(StructureShared):
         assert pyList == [[], []]
 
         numpyArray = orig.copy(to='numpy array')
-        assert numpy.array_equal(numpyArray, data)
+        assert np.array_equal(numpyArray, data)
 
         numpyMatrix = orig.copy(to='numpy matrix')
-        assert numpy.array_equal(numpyMatrix, numpy.matrix(data))
+        assert np.array_equal(numpyMatrix, np.matrix(data))
 
         scipyCsr = orig.copy(to='scipy csr')
-        assert numpy.array_equal(sparseMatrixToArray(scipyCsr), data)
+        assert np.array_equal(sparseMatrixToArray(scipyCsr), data)
 
         scipyCsc = orig.copy(to='scipy csc')
-        assert numpy.array_equal(sparseMatrixToArray(scipyCsc), data)
+        assert np.array_equal(sparseMatrixToArray(scipyCsc), data)
 
         scipyCoo = orig.copy(to='scipy coo')
-        assert numpy.array_equal(sparseMatrixToArray(scipyCoo), data)
+        assert np.array_equal(sparseMatrixToArray(scipyCoo), data)
 
 
         pandasDF = orig.copy(to='pandas dataframe')
-        assert numpy.array_equal(pandasDF, data)
+        assert np.array_equal(pandasDF, data)
 
         listOfDict = orig.copy(to='list of dict')
         assert listOfDict == [{}, {}]
@@ -401,7 +401,7 @@ class StructureDataSafe(StructureShared):
     @noLogEntryExpected
     def test_copy_Trueempty(self):
         """ test copy() produces the correct outputs when given a point and feature empty object """
-        data = numpy.empty(shape=(0, 0))
+        data = np.empty(shape=(0, 0))
 
         orig = self.constructor(data)
         sparseObj = nimble.data(returnType="Sparse", source=data, useLog=False)
@@ -429,22 +429,22 @@ class StructureDataSafe(StructureShared):
         assert pyList == []
 
         numpyArray = orig.copy(to='numpy array')
-        assert numpy.array_equal(numpyArray, data)
+        assert np.array_equal(numpyArray, data)
 
         numpyMatrix = orig.copy(to='numpy matrix')
-        assert numpy.array_equal(numpyMatrix, numpy.matrix(data))
+        assert np.array_equal(numpyMatrix, np.matrix(data))
 
         scipyCsr = orig.copy(to='scipy csr')
-        assert numpy.array_equal(sparseMatrixToArray(scipyCsr), data)
+        assert np.array_equal(sparseMatrixToArray(scipyCsr), data)
 
         scipyCsc = orig.copy(to='scipy csc')
-        assert numpy.array_equal(sparseMatrixToArray(scipyCsc), data)
+        assert np.array_equal(sparseMatrixToArray(scipyCsc), data)
 
         scipyCoo = orig.copy(to='scipy coo')
-        assert numpy.array_equal(sparseMatrixToArray(scipyCoo), data)
+        assert np.array_equal(sparseMatrixToArray(scipyCoo), data)
 
         pandasDF = orig.copy(to='pandas dataframe')
-        assert numpy.array_equal(pandasDF, data)
+        assert np.array_equal(pandasDF, data)
 
         listOfDict = orig.copy(to='list of dict')
         assert listOfDict == []
@@ -527,12 +527,12 @@ class StructureDataSafe(StructureShared):
         assert orig[0, 0] == 1
 
         numpyArray = orig.copy(to='numpy array')
-        assert type(numpyArray) == type(numpy.array([]))
+        assert type(numpyArray) == type(np.array([]))
         numpyArray[0, 0] = 5
         assert orig[0, 0] == 1
 
         numpyMatrix = orig.copy(to='numpy matrix')
-        assert type(numpyMatrix) == type(numpy.matrix([]))
+        assert type(numpyMatrix) == type(np.matrix([]))
         numpyMatrix[0, 0] = 5
         assert orig[0, 0] == 1
 
@@ -556,8 +556,8 @@ class StructureDataSafe(StructureShared):
 
         pandasDF = orig.copy(to='pandas dataframe')
         assert type(pandasDF) == type(pd.DataFrame([]))
-        assert numpy.array_equal(pandasDF.columns, featureNames)
-        assert numpy.array_equal(pandasDF.index, pointNames)
+        assert np.array_equal(pandasDF.columns, featureNames)
+        assert np.array_equal(pandasDF.index, pointNames)
         pandasDF.iloc[0, 0] = 5
         assert orig[0, 0] == 1
 
@@ -577,7 +577,7 @@ class StructureDataSafe(StructureShared):
     def test_copy_rowsArePointsFalse(self):
         """ Test copy() will return data in the right places when rowsArePoints is False"""
         data = [[1, 2, 3], [1, 0, 3], [2, 4, 6], [0, 0, 0]]
-        dataT = numpy.array(data).T
+        dataT = np.array(data).T
 
         featureNames = ['one', 'two', 'three']
         pointNames = ['1', 'one', '2', '0']
@@ -594,24 +594,24 @@ class StructureDataSafe(StructureShared):
         assert out == dataT.tolist()
 
         out = orig.copy(to='numpyarray', rowsArePoints=False)
-        assert numpy.array_equal(out, dataT)
+        assert np.array_equal(out, dataT)
 
         out = orig.copy(to='numpymatrix', rowsArePoints=False)
-        assert numpy.array_equal(out, dataT)
+        assert np.array_equal(out, dataT)
 
         out = orig.copy(to='scipycsr', rowsArePoints=False)
-        assert numpy.array_equal(sparseMatrixToArray(out), dataT)
+        assert np.array_equal(sparseMatrixToArray(out), dataT)
 
         out = orig.copy(to='scipycsc', rowsArePoints=False)
-        assert numpy.array_equal(sparseMatrixToArray(out), dataT)
+        assert np.array_equal(sparseMatrixToArray(out), dataT)
 
         out = out = orig.copy(to='scipycoo', rowsArePoints=False)
-        assert numpy.array_equal(sparseMatrixToArray(out), dataT)
+        assert np.array_equal(sparseMatrixToArray(out), dataT)
 
         out = orig.copy(to='pandasdataframe', rowsArePoints=False)
-        assert numpy.array_equal(out, dataT)
-        assert numpy.array_equal(out.columns, pointNames)
-        assert numpy.array_equal(out.index, featureNames)
+        assert np.array_equal(out, dataT)
+        assert np.array_equal(out.columns, pointNames)
+        assert np.array_equal(out.index, featureNames)
 
         out = orig.copy(to='list of dict', rowsArePoints=False)
 
@@ -709,7 +709,7 @@ class StructureDataSafe(StructureShared):
         assert outPV == [1, 2, 0, 3]
 
         outFV = origFV.copy(to='numpy array', outputAs1D=True)
-        assert numpy.array_equal(outFV, numpy.array([1, 2, 3, 0]))
+        assert np.array_equal(outFV, np.array([1, 2, 3, 0]))
 
     def test_copy_NameAndPath(self):
         """ Test copy() will preserve name and path attributes"""
@@ -907,7 +907,7 @@ class StructureDataSafe(StructureShared):
         ret = toTest.points.copy(allFalse)
 
         data = [[], [], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         expRet = self.constructor(data)
 
         assert ret.isIdentical(expRet)
@@ -2065,15 +2065,15 @@ class StructureModifying(StructureShared):
     def test_createEmptyData1(self):
         """
         create data object using tuple, list,
-        dict, numpy.ndarray, numpy.matrix, pd.DataFrame,
+        dict, np.ndarray, np.matrix, pd.DataFrame,
         pd.Series, pd.SparseDataFrame, scipy sparse matrix
         as input type.
         """
         orig1 = self.constructor([])
         orig2 = self.constructor(())
         orig3 = self.constructor({})
-        orig4 = self.constructor(numpy.empty([0, 0]))
-        orig5 = self.constructor(numpy.matrix(numpy.empty([0, 0])))
+        orig4 = self.constructor(np.empty([0, 0]))
+        orig5 = self.constructor(np.matrix(np.empty([0, 0])))
         orig6 = self.constructor(pd.DataFrame())
         orig7 = self.constructor(pd.Series())
         try: # SparseDataFrame removed in 1.0 in favor of using SparseDType
@@ -2092,14 +2092,14 @@ class StructureModifying(StructureShared):
     def test_createEmptyData2(self):
         """
         create data object using tuple, list,
-        dict, numpy.ndarray, numpy.matrix, pd.DataFrame,
+        dict, np.ndarray, np.matrix, pd.DataFrame,
         pd.Series, pd.SparseDataFrame, scipy sparse matrix
         as input type.
         """
         orig1 = self.constructor([[]])
         orig2 = self.constructor([{}])
-        orig3 = self.constructor(numpy.empty([1, 0]))
-        orig4 = self.constructor(numpy.matrix(numpy.empty([1, 0])))
+        orig3 = self.constructor(np.empty([1, 0]))
+        orig4 = self.constructor(np.matrix(np.empty([1, 0])))
         orig5 = self.constructor(pd.DataFrame([[]]))
         orig6 = self.constructor(scipy.sparse.coo_matrix([[]]))
         try: # SparseDataFrame removed in 1.0 in favor of using SparseDType
@@ -2117,14 +2117,14 @@ class StructureModifying(StructureShared):
     def test_createEmptyData3(self):
         """
         create data object using tuple, list,
-        dict, numpy.ndarray, numpy.matrix, pd.DataFrame,
+        dict, np.ndarray, np.matrix, pd.DataFrame,
         pd.Series, pd.SparseDataFrame, scipy sparse matrix
         as input type.
         """
         orig1 = self.constructor([[], []])
         orig2 = self.constructor([{}, {}])
-        orig3 = self.constructor(numpy.empty([2, 0]))
-        orig4 = self.constructor(numpy.matrix(numpy.empty([2, 0])))
+        orig3 = self.constructor(np.empty([2, 0]))
+        orig4 = self.constructor(np.matrix(np.empty([2, 0])))
         orig5 = self.constructor(pd.DataFrame([[], []]))
         orig6 = self.constructor(scipy.sparse.coo_matrix([[], []]))
         try: # SparseDataFrame removed in 1.0 in favor of using SparseDType
@@ -2142,7 +2142,7 @@ class StructureModifying(StructureShared):
     def test_create1DData(self):
         """
         create data object using tuple, list,
-        dict, numpy.ndarray, numpy.matrix, pd.DataFrame,
+        dict, np.ndarray, np.matrix, pd.DataFrame,
         pd.Series, pd.SparseDataFrame, scipy sparse matrix
         as input type.
         """
@@ -2152,8 +2152,8 @@ class StructureModifying(StructureShared):
         orig3.features.sort()
         orig4 = self.constructor([{'a':1, 'b':2, 'c':3}])
         orig4.features.sort()
-        orig5 = self.constructor(numpy.array([1,2,3]), featureNames=['a', 'b', 'c'])
-        orig6 = self.constructor(numpy.matrix([1,2,3]), featureNames=['a', 'b', 'c'])
+        orig5 = self.constructor(np.array([1,2,3]), featureNames=['a', 'b', 'c'])
+        orig6 = self.constructor(np.matrix([1,2,3]), featureNames=['a', 'b', 'c'])
         orig7 = self.constructor(pd.DataFrame([[1,2,3]]), featureNames=['a', 'b', 'c'])
         orig8 = self.constructor(pd.Series([1,2,3]), featureNames=['a', 'b', 'c'])
         orig9 = self.constructor(scipy.sparse.coo_matrix([1,2,3]), featureNames=['a', 'b', 'c'])
@@ -2177,7 +2177,7 @@ class StructureModifying(StructureShared):
     def test_create2DData(self):
         """
         create data object using tuple, list,
-        dict, numpy.ndarray, numpy.matrix, pd.DataFrame,
+        dict, np.ndarray, np.matrix, pd.DataFrame,
         pd.Series, pd.SparseDataFrame, scipy sparse matrix
         as input type.
         """
@@ -2187,10 +2187,10 @@ class StructureModifying(StructureShared):
         orig3.features.sort()
         orig4 = self.constructor([{'a':1, 'b':2, 'c':'a'}, {'a':3, 'b':4, 'c':'b'}])
         orig4.features.sort()
-        orig5 = self.constructor(numpy.array([[1,2,'a'], [3,4,'b']], dtype=object), featureNames=['a', 'b', 'c'])
-        orig6 = self.constructor(numpy.matrix([[1,2,'a'], [3,4,'b']], dtype=object), featureNames=['a', 'b', 'c'])
+        orig5 = self.constructor(np.array([[1,2,'a'], [3,4,'b']], dtype=object), featureNames=['a', 'b', 'c'])
+        orig6 = self.constructor(np.matrix([[1,2,'a'], [3,4,'b']], dtype=object), featureNames=['a', 'b', 'c'])
         orig7 = self.constructor(pd.DataFrame([[1,2,'a'], [3,4,'b']]), featureNames=['a', 'b', 'c'])
-        orig8 = self.constructor(scipy.sparse.coo_matrix(numpy.matrix([[1,2,'a'], [3,4,'b']], dtype=object)),
+        orig8 = self.constructor(scipy.sparse.coo_matrix(np.matrix([[1,2,'a'], [3,4,'b']], dtype=object)),
                                  featureNames=['a', 'b', 'c'])
         try: # SparseDataFrame removed in 1.0 in favor of using SparseDType
             orig9 = self.constructor(pd.DataFrame([[1,2,'a'], [3,4,'b']], dtype='Sparse[object]'),
@@ -2321,15 +2321,15 @@ class StructureModifying(StructureShared):
 
     def test_init_coo_matrix_duplicates(self):
         # Constructing a matrix with duplicate indices
-        row  = numpy.array([0, 0, 1, 3, 1, 0, 0])
-        col  = numpy.array([0, 2, 1, 3, 1, 0, 0])
-        data = numpy.array([1, 7, 1, 6, 4, 2, 1])
+        row  = np.array([0, 0, 1, 3, 1, 0, 0])
+        col  = np.array([0, 2, 1, 3, 1, 0, 0])
+        data = np.array([1, 7, 1, 6, 4, 2, 1])
         coo = scipy.sparse.coo_matrix((data, (row, col)),shape=(4,4))
         ret = self.constructor(coo)
         # Expected coo_matrix duplicates sum
-        row  = numpy.array([0, 0, 1, 3])
-        col  = numpy.array([0, 2, 1, 3])
-        data = numpy.array([4, 7, 5, 6])
+        row  = np.array([0, 0, 1, 3])
+        col  = np.array([0, 2, 1, 3])
+        data = np.array([4, 7, 5, 6])
         coo = scipy.sparse.coo_matrix((data, (row, col)),shape=(4,4))
         exp = self.constructor(coo)
 
@@ -2340,15 +2340,15 @@ class StructureModifying(StructureShared):
 
     def test_init_coo_matrix_duplicates_introduces_zero(self):
         # Constructing a matrix with duplicate indices
-        row  = numpy.array([0, 0, 1, 3, 1, 0, 0])
-        col  = numpy.array([0, 2, 1, 3, 1, 0, 0])
-        data = numpy.array([1, 7, 1, 6, -1, 2, 1])
+        row  = np.array([0, 0, 1, 3, 1, 0, 0])
+        col  = np.array([0, 2, 1, 3, 1, 0, 0])
+        data = np.array([1, 7, 1, 6, -1, 2, 1])
         coo = scipy.sparse.coo_matrix((data, (row, col)),shape=(4,4))
         ret = self.constructor(coo)
         # Expected coo_matrix duplicates sum
-        row  = numpy.array([0, 0, 3])
-        col  = numpy.array([0, 2, 3])
-        data = numpy.array([4, 7, 6])
+        row  = np.array([0, 0, 3])
+        col  = np.array([0, 2, 3])
+        data = np.array([4, 7, 6])
         coo = scipy.sparse.coo_matrix((data, (row, col)),shape=(4,4))
         exp = self.constructor(coo)
 
@@ -2361,17 +2361,17 @@ class StructureModifying(StructureShared):
     def test_init_coo_matrix_duplicateswithNoDupStrings(self):
         # Constructing a matrix with duplicate indices
         # with String, but not in duplicate entry
-        row  = numpy.array([0, 0, 1, 3, 1, 0, 0])
-        col  = numpy.array([0, 2, 1, 3, 1, 0, 0])
+        row  = np.array([0, 0, 1, 3, 1, 0, 0])
+        col  = np.array([0, 2, 1, 3, 1, 0, 0])
         # need to specify object dtype, otherwise it will generate a all string object
-        data = numpy.array([1, 7, 1, 'AAA', 4, 2, 1], dtype='O')
+        data = np.array([1, 7, 1, 'AAA', 4, 2, 1], dtype='O')
         coo_str = scipy.sparse.coo_matrix((data, (row, col)),shape=(4,4))
         ret = self.constructor(coo_str)
         # Expected coo_matrix duplicates sum
         # with String, but not in duplicate entry
-        row  = numpy.array([0, 0, 1, 3])
-        col  = numpy.array([0, 2, 1, 3])
-        data = numpy.array([4, 7, 5, 'AAA'], dtype='O')
+        row  = np.array([0, 0, 1, 3])
+        col  = np.array([0, 2, 1, 3])
+        data = np.array([4, 7, 5, 'AAA'], dtype='O')
         coo = scipy.sparse.coo_matrix((data, (row, col)),shape=(4,4))
         exp = self.constructor(coo_str)
 
@@ -2384,9 +2384,9 @@ class StructureModifying(StructureShared):
     def test_init_coo_matrix_duplicateswithDupStrings(self):
         # Constructing a matrix with duplicate indices
         # # with String, in a duplicate entry
-        row  = numpy.array([0, 0, 1, 3, 1, 0, 0])
-        col  = numpy.array([0, 2, 1, 3, 1, 0, 0])
-        data = numpy.array([1, 7, 1, 'AAA', 4, 2, 'BBB'], dtype='O')
+        row  = np.array([0, 0, 1, 3, 1, 0, 0])
+        col  = np.array([0, 2, 1, 3, 1, 0, 0])
+        data = np.array([1, 7, 1, 'AAA', 4, 2, 'BBB'], dtype='O')
         coo_str = scipy.sparse.coo_matrix((data, (row, col)),shape=(4,4))
         ret = self.constructor(coo_str)
 
@@ -2407,20 +2407,20 @@ class StructureModifying(StructureShared):
     def test_transpose_empty(self):
         """ Test transpose() on different kinds of emptiness """
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         toTest = self.constructor(data)
 
         toTest.transpose()
 
         exp1 = [[], []]
-        exp1 = numpy.array(exp1)
+        exp1 = np.array(exp1)
         ret1 = self.constructor(exp1)
         assert ret1.isIdentical(toTest)
 
         toTest.transpose()
 
         exp2 = [[], []]
-        exp2 = numpy.array(exp2).T
+        exp2 = np.array(exp2).T
         ret2 = self.constructor(exp2)
         assert ret2.isIdentical(toTest)
 
@@ -2517,10 +2517,10 @@ class StructureModifying(StructureShared):
         empty = [[], []]
 
         if axis == 'point':
-            empty = numpy.array(empty).T
+            empty = np.array(empty).T
             data = [[1, 2]]
         else:
-            empty = numpy.array(empty)
+            empty = np.array(empty)
             data = [[1], [2]]
 
         toTest = self.constructor(empty)
@@ -3765,7 +3765,7 @@ class StructureModifying(StructureShared):
         assert ret.isIdentical(expRet)
 
         data = [[], [], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         exp = self.constructor(data)
 
         assert toTest.isIdentical(exp)
@@ -3850,7 +3850,7 @@ class StructureModifying(StructureShared):
         assert ret.isIdentical(expRet)
 
         data = [[], [], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         exp = self.constructor(data)
 
         assert toTest.isIdentical(exp)
@@ -3863,7 +3863,7 @@ class StructureModifying(StructureShared):
         ret = toTest.points.extract(allFalse)
 
         data = [[], [], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         expRet = self.constructor(data)
 
         assert ret.isIdentical(expRet)
@@ -3993,7 +3993,7 @@ class StructureModifying(StructureShared):
         assert ret.isIdentical(expRet)
 
         data = [[], [], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         exp = self.constructor(data, featureNames=featureNames)
 
         assert toTest.isIdentical(exp)
@@ -4468,7 +4468,7 @@ class StructureModifying(StructureShared):
         assert ret.isIdentical(expRet)
 
         data = [[], [], [], []]
-        data = numpy.array(data)
+        data = np.array(data)
         exp = self.constructor(data)
 
         assert toTest.isIdentical(exp)
@@ -4484,7 +4484,7 @@ class StructureModifying(StructureShared):
         assert ret.isIdentical(expRet)
 
         data = [[], [], [], []]
-        data = numpy.array(data)
+        data = np.array(data)
         exp = self.constructor(data)
 
         assert toTest.isIdentical(exp)
@@ -4594,7 +4594,7 @@ class StructureModifying(StructureShared):
         assert ret.isIdentical(expRet)
 
         data = [[], [], []]
-        data = numpy.array(data)
+        data = np.array(data)
         exp = self.constructor(data)
 
         assert toTest.isIdentical(exp)
@@ -4607,7 +4607,7 @@ class StructureModifying(StructureShared):
         ret = toTest.features.extract(allFalse)
 
         data = [[], [], []]
-        data = numpy.array(data)
+        data = np.array(data)
         expRet = self.constructor(data)
 
         assert ret.isIdentical(expRet)
@@ -4723,7 +4723,7 @@ class StructureModifying(StructureShared):
         assert ret.isIdentical(expRet)
 
         data = [[], [], []]
-        data = numpy.array(data)
+        data = np.array(data)
         exp = self.constructor(data)
 
         assert toTest.isIdentical(exp)
@@ -4973,7 +4973,7 @@ class StructureModifying(StructureShared):
         toTest.points.delete([0, 1, 2, 3])
 
         data = [[], [], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         exp = self.constructor(data)
 
         assert toTest.isIdentical(exp)
@@ -5043,7 +5043,7 @@ class StructureModifying(StructureShared):
         toTest.points.delete(allTrue)
 
         data = [[], [], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         exp = self.constructor(data)
 
         assert toTest.isIdentical(exp)
@@ -5165,7 +5165,7 @@ class StructureModifying(StructureShared):
         toTest.points.delete(start=0, end=2)
 
         data = [[], [], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         exp = self.constructor(data, featureNames=featureNames)
 
         assert toTest.isIdentical(exp)
@@ -5556,7 +5556,7 @@ class StructureModifying(StructureShared):
         toTest.features.delete([0, 1, 2])
 
         data = [[], [], [], []]
-        data = numpy.array(data)
+        data = np.array(data)
         exp = self.constructor(data)
 
         assert toTest.isIdentical(exp)
@@ -5568,7 +5568,7 @@ class StructureModifying(StructureShared):
         toTest.features.delete([2, 0, 1])
 
         data = [[], [], [], []]
-        data = numpy.array(data)
+        data = np.array(data)
         exp = self.constructor(data)
 
         assert toTest.isIdentical(exp)
@@ -5656,7 +5656,7 @@ class StructureModifying(StructureShared):
         toTest.features.delete(allTrue)
 
         data = [[], [], []]
-        data = numpy.array(data)
+        data = np.array(data)
         exp = self.constructor(data)
 
         assert toTest.isIdentical(exp)
@@ -5771,7 +5771,7 @@ class StructureModifying(StructureShared):
         toTest.features.delete(start=0, end=2)
 
         data = [[], [], []]
-        data = numpy.array(data)
+        data = np.array(data)
         exp = self.constructor(data)
 
         assert toTest.isIdentical(exp)
@@ -6045,7 +6045,7 @@ class StructureModifying(StructureShared):
         toTest.points.retain([])
 
         expData = [[], [], []]
-        expData = numpy.array(expData).T
+        expData = np.array(expData).T
         expTest = self.constructor(expData)
         assert toTest.isIdentical(expTest)
 
@@ -6143,7 +6143,7 @@ class StructureModifying(StructureShared):
 
         toTest.points.retain(allFalse)
 
-        expData = numpy.array([[], [], []])
+        expData = np.array([[], [], []])
         expData = expData.T
         expTest = self.constructor(expData)
 
@@ -6661,7 +6661,7 @@ class StructureModifying(StructureShared):
         toTest.features.retain([])
 
         expData = [[], [], [], []]
-        expData = numpy.array(expData)
+        expData = np.array(expData)
         expTest = self.constructor(expData)
         assert toTest.isIdentical(expTest)
 
@@ -6785,7 +6785,7 @@ class StructureModifying(StructureShared):
         toTest.features.retain(allFalse)
 
         data = [[], [], []]
-        data = numpy.array(data)
+        data = np.array(data)
         expTest = self.constructor(data)
 
         assert toTest.isIdentical(expTest)
@@ -7228,7 +7228,7 @@ class StructureModifying(StructureShared):
     @raises(ImproperObjectAction)
     def test_points_transform_exceptionPEmpty(self):
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         origObj = self.constructor(data)
 
         def emitLower(point):
@@ -7239,7 +7239,7 @@ class StructureModifying(StructureShared):
     @raises(ImproperObjectAction)
     def test_points_transform_exceptionFEmpty(self):
         data = [[], []]
-        data = numpy.array(data)
+        data = np.array(data)
         origObj = self.constructor(data)
 
         def emitLower(point):
@@ -7463,7 +7463,7 @@ class StructureModifying(StructureShared):
     @raises(ImproperObjectAction)
     def test_features_transform_exceptionPEmpty(self):
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         origObj = self.constructor(data)
 
         def emitAllEqual(feature):
@@ -7478,7 +7478,7 @@ class StructureModifying(StructureShared):
     @raises(ImproperObjectAction)
     def test_features_transform_exceptionFEmpty(self):
         data = [[], []]
-        data = numpy.array(data)
+        data = np.array(data)
         origObj = self.constructor(data)
 
         def emitAllEqual(feature):
@@ -8245,13 +8245,13 @@ class StructureModifying(StructureShared):
     def back_flatten_empty(self, order):
         checkMsg = False
 
-        pempty = self.constructor(numpy.empty((0,2)))
+        pempty = self.constructor(np.empty((0,2)))
         exceptionHelper(pempty, 'flatten', [order], ImproperObjectAction, checkMsg)
 
-        fempty = self.constructor(numpy.empty((4,0)))
+        fempty = self.constructor(np.empty((4,0)))
         exceptionHelper(fempty, 'flatten', [order], ImproperObjectAction, checkMsg)
 
-        trueEmpty = self.constructor(numpy.empty((0,0)))
+        trueEmpty = self.constructor(np.empty((0,0)))
         exceptionHelper(trueEmpty, 'flatten', [order], ImproperObjectAction, checkMsg)
 
 
@@ -8318,7 +8318,7 @@ class StructureModifying(StructureShared):
     def back_flatten_rectangleRandom(self, order):
         origRaw = numpyRandom.randint(0, 2, (30, 50))  # array of ones and zeroes
         npOrder = 'C' if order == 'point' else 'F'  # controls row or column major flattening
-        expRaw = numpy.reshape(origRaw,  (1, 1500), npOrder)
+        expRaw = np.reshape(origRaw,  (1, 1500), npOrder)
         expObj = self.constructor(expRaw, pointNames=['Flattened'])
 
         # No point or feature names
@@ -8406,13 +8406,13 @@ class StructureModifying(StructureShared):
     def back_unflatten_empty(self, order):
         checkMsg = False
 
-        ptEmpty = self.constructor(numpy.empty((0, 2)))
+        ptEmpty = self.constructor(np.empty((0, 2)))
         exceptionHelper(ptEmpty, 'unflatten', [2], ImproperObjectAction, checkMsg)
 
-        ftEmpty = self.constructor(numpy.empty((2, 0)))
+        ftEmpty = self.constructor(np.empty((2, 0)))
         exceptionHelper(ftEmpty, 'unflatten', [2], ImproperObjectAction, checkMsg)
 
-        trueEmpty = self.constructor(numpy.empty((0,0)))
+        trueEmpty = self.constructor(np.empty((0,0)))
         exceptionHelper(trueEmpty, 'unflatten', [2], ImproperObjectAction, checkMsg)
 
 
@@ -8512,10 +8512,10 @@ class StructureModifying(StructureShared):
         namesF = ["1", "2", "3"]
 
         if order == 'point':
-             expData = numpy.array([["el0", "el1", "el2"], ["el3", "el4", "el5"]])
+             expData = np.array([["el0", "el1", "el2"], ["el3", "el4", "el5"]])
              exp = self.constructor(expData, pointNames=namesP, featureNames=namesF)
         else:
-            expData = numpy.array([["el0", "el2", "el4"], ["el1", "el3", "el5"]])
+            expData = np.array([["el0", "el2", "el4"], ["el1", "el3", "el5"]])
             exp = self.constructor(expData, pointNames=namesP, featureNames=namesF)
 
         toTestPt.unflatten((2, 3), order)
@@ -8535,7 +8535,7 @@ class StructureModifying(StructureShared):
     def back_unflatten_handmadeDefaultNames(self, order):
         raw = [[1, 10, 20, 2]]
         toTest = self.constructor(raw)
-        expData = numpy.array([[1,10],[20,2]])
+        expData = np.array([[1,10],[20,2]])
 
         if order == 'point':
             exp = self.constructor(expData)
@@ -10673,7 +10673,7 @@ class StructureModifying(StructureShared):
         pNamesR = ["p5", "p6", "p7", "p8"]
         leftObj = self.constructor(dataL, pointNames=pNamesL)
         rightObj = self.constructor(dataR, pointNames=pNamesR)
-        expData = numpy.array([[],[],[]]).T
+        expData = np.array([[],[],[]]).T
         exp = self.constructor(expData)
         leftObj.merge(rightObj, point='intersection', feature='strict', force=True)
         assert leftObj == exp

--- a/tests/interfaces/autoimpute_interface_test.py
+++ b/tests/interfaces/autoimpute_interface_test.py
@@ -3,7 +3,7 @@ Tests for autoimpute interface.
 """
 import functools
 
-import numpy
+import numpy as np
 from nose.plugins.attrib import attr
 from nose.tools import raises
 
@@ -24,19 +24,19 @@ constructors = getDataConstructors(includeViews=False)
 def getDataWithMissing(constructor, assignNames=True, yBinary=False):
     if isinstance(constructor, str):
         constructor = functools.partial(nimble.data, constructor)
-    mu = numpy.array([5.0, 0.0])
-    r = numpy.array([
+    mu = np.array([5.0, 0.0])
+    r = np.array([
             [  3.40, -2.75],
             [ -2.75,  5.50],])
 
     # Generate the random samples.
     num = 100
-    d = numpy.random.multivariate_normal(mu, r, size=num)
+    d = np.random.multivariate_normal(mu, r, size=num)
     # insert missing values
-    rm1 = numpy.random.random_sample(num) > 0.85
-    d[rm1, 1] = numpy.nan
+    rm1 = np.random.random_sample(num) > 0.85
+    d[rm1, 1] = np.nan
     if yBinary:
-        d[:, 0] = numpy.random.choice(2, 100)
+        d[:, 0] = np.random.choice(2, 100)
 
     if assignNames:
         data = constructor(d, featureNames=['y', 'x'])
@@ -98,7 +98,7 @@ def test_autoimpute_MiLinearRegression():
         exp = nimble.trainAndTest('skl.LinearRegression', trainX, trainY,
                                   testX, testY, rootMeanSquareError)
 
-        numpy.testing.assert_almost_equal(rmse, exp)
+        np.testing.assert_almost_equal(rmse, exp)
 
 @autoimputeSkipDec
 def test_autoimpute_MiLinearRegression_noNames():
@@ -117,7 +117,7 @@ def test_autoimpute_MiLinearRegression_noNames():
         exp = nimble.trainAndTest('skl.LinearRegression', trainX, trainY,
                                   testX, testY, rootMeanSquareError)
 
-        numpy.testing.assert_almost_equal(rmse, exp)
+        np.testing.assert_almost_equal(rmse, exp)
 
 @autoimputeSkipDec
 @raises(InvalidArgumentValue)
@@ -148,7 +148,7 @@ def test_autoimpute_MiLogisticRegression():
         exp = nimble.trainAndTest('skl.LogisticRegression', trainX, trainY,
                                   testX, testY, fractionCorrect, randomSeed=0)
 
-        numpy.testing.assert_almost_equal(fc, exp)
+        np.testing.assert_almost_equal(fc, exp)
 
 @autoimputeSkipDec
 def test_autoimpute_MiLogisticRegression_directMultipleImputer():
@@ -177,7 +177,7 @@ def test_autoimpute_MiLogisticRegression_directMultipleImputer():
         exp = nimble.trainAndTest('skl.LogisticRegression', trainX, trainY,
                                   testX, testY, fractionCorrect)
 
-        numpy.testing.assert_almost_equal(fc, exp)
+        np.testing.assert_almost_equal(fc, exp)
 
 @autoimputeSkipDec
 def test_autoimpute_MiLogisticRegression_noNames():
@@ -197,7 +197,7 @@ def test_autoimpute_MiLogisticRegression_noNames():
         exp = nimble.trainAndTest('skl.LogisticRegression', trainX, trainY,
                                   testX, testY, fractionCorrect)
 
-        numpy.testing.assert_almost_equal(fc, exp)
+        np.testing.assert_almost_equal(fc, exp)
 
 @autoimputeSkipDec
 @raises(InvalidArgumentValue)

--- a/tests/interfaces/mlpy_interface_test.py
+++ b/tests/interfaces/mlpy_interface_test.py
@@ -3,7 +3,7 @@ Unit tests for mlpy_interface.py
 """
 
 from nose.tools import *
-import numpy.testing
+import numpy as np
 
 import nimble
 from nimble.exceptions import InvalidArgumentValue
@@ -62,7 +62,7 @@ def testMlpyHandmadeLogisticRegression():
     expected = [[1.]]
     expectedObj = nimble.data('Matrix', expected, useLog=False)
 
-    numpy.testing.assert_approx_equal(ret._data[0, 0], 1.)
+    np.testing.assert_approx_equal(ret._data[0, 0], 1.)
 
 @mlpySkipDec
 @oneLogEntryExpected
@@ -81,8 +81,8 @@ def testMlpyHandmadeKNN():
 
     assert ret is not None
 
-    numpy.testing.assert_approx_equal(ret._data[0, 0], 1.)
-    numpy.testing.assert_approx_equal(ret._data[1, 0], 0.)
+    np.testing.assert_approx_equal(ret._data[0, 0], 1.)
+    np.testing.assert_approx_equal(ret._data[1, 0], 0.)
 
 @mlpySkipDec
 @oneLogEntryExpected
@@ -439,4 +439,3 @@ def test_getScores_exception():
         assert False # expected InvalidArgumentValue
     except InvalidArgumentValue:
         pass
-

--- a/tests/interfaces/scikit_learn_interface_test.py
+++ b/tests/interfaces/scikit_learn_interface_test.py
@@ -6,7 +6,7 @@ import importlib
 import inspect
 import tempfile
 
-import numpy.testing
+import numpy as np
 from nose.plugins.attrib import attr
 from nose.tools import raises
 
@@ -81,7 +81,7 @@ def testSciKitLearnHandmadeRegression():
     expected = [[1.]]
     expectedObj = nimble.data('Matrix', expected, useLog=False)
 
-    numpy.testing.assert_approx_equal(ret[0, 0], 1.)
+    np.testing.assert_approx_equal(ret[0, 0], 1.)
 
 
 @sklSkipDec
@@ -726,12 +726,12 @@ def testConvertYTrainDType():
     testObj.features.retain([2,3,4,5], useLog=False)
 
     # case1 trainY passed as integer
-    assert trainObj[:,0]._data.dtype == numpy.object_
+    assert trainObj[:,0]._data.dtype == np.object_
     pred = nimble.trainAndApply('SciKitLearn.LogisticRegression', trainObj, 0, testObj)
 
     #case2 trainY passed as nimble object
     trainY = trainObj.features.extract(0, useLog=False)
-    assert trainY._data.dtype == numpy.object_
+    assert trainY._data.dtype == np.object_
     pred = nimble.trainAndApply('SciKitLearn.LogisticRegression', trainObj, trainY, testObj)
 
 @sklSkipDec
@@ -789,8 +789,8 @@ def test_getScores_acceptsNewArguments():
     testX = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
 
     # Need to set convertToType b/c conversion will not be done when check_input=False
-    trainObj = nimble.data('Matrix', train, convertToType=numpy.float32, useLog=False)
-    testObj = nimble.data('Matrix', testX, convertToType=numpy.float32, useLog=False)
+    trainObj = nimble.data('Matrix', train, convertToType=np.float32, useLog=False)
+    testObj = nimble.data('Matrix', testX, convertToType=np.float32, useLog=False)
 
     # DecisionTreeClassifier.predict_proba takes a 'check_input' argument. Default is True.
     tl = nimble.train('SciKitLearn.DecisionTreeClassifier', trainObj, 0)
@@ -808,8 +808,8 @@ def test_getScores_exception():
              [1, 1, 0, 0], [2, 0, 1, 0], [3, 0, 0, 1]]
     testX = [[1, 0, 0], [0, 1, 0], [0, 0, 1]]
 
-    trainObj = nimble.data('Matrix', train, convertToType=numpy.float32)
-    testObj = nimble.data('Matrix', testX, convertToType=numpy.float32)
+    trainObj = nimble.data('Matrix', train, convertToType=np.float32)
+    testObj = nimble.data('Matrix', testX, convertToType=np.float32)
 
     # DecisionTreeClassifier.predict_proba does not take a 'foo' argument.
     tl = nimble.train('SciKitLearn.DecisionTreeClassifier', trainObj, 0)

--- a/tests/interfaces/shogun_interface_test.py
+++ b/tests/interfaces/shogun_interface_test.py
@@ -10,7 +10,7 @@ import time
 import multiprocessing
 import signal
 
-import numpy
+import numpy as np
 from nose.tools import *
 from nose.plugins.attrib import attr
 try:
@@ -262,7 +262,7 @@ def testShogunEmbeddedRossData():
 
     data = [p0, p1, p2, p3, p4, p5, p6, p7]
 
-    numpyData = numpy.zeros((50, 10))
+    numpyData = np.zeros((50, 10))
 
     for i in range(50):
         for j in range(10):
@@ -550,7 +550,7 @@ def testShogunClassificationLearners():
         compareOutputs(learner)
 
 def trainCHAIDTree(data, toSet):
-    ft = numpy.array([1] * 20, dtype='int32')
+    ft = np.array([1] * 20, dtype='int32')
     toSet['feature_types'] = ft
     return shogunTrainBackend('CHAIDTree', data, toSet)
 

--- a/tests/interfaces/test_helpers.py
+++ b/tests/interfaces/test_helpers.py
@@ -2,7 +2,7 @@
 Functions that could be useful accross multple interface test suites
 """
 
-import numpy
+import numpy as np
 
 import nimble
 from nimble.core.data import Base
@@ -19,7 +19,7 @@ def test_OvOTournament():
     ret = calculateSingleLabelScoresFromOneVsOneScores(scores, 4)
     desired = [2.0 / 3.0, 2.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0]
 
-    assert numpy.allclose(ret, desired)
+    assert np.allclose(ret, desired)
 
 
 def checkLabelOrderingAndScoreAssociations(allLabels, bestScores, allScores):
@@ -35,8 +35,8 @@ def checkLabelOrderingAndScoreAssociations(allLabels, bestScores, allScores):
 
     assert len(bestScores) == len(allScores)
     for i in range(len(bestScores)):
-        currBest = numpy.array(bestScores[i]).flatten()
-        currAll = numpy.array(allScores[i]).flatten()
+        currBest = np.array(bestScores[i]).flatten()
+        currAll = np.array(allScores[i]).flatten()
         #score in bestScore matches winning score's slot in allScores
         for j in range(len(allLabels)):
             if currBest[0] == allLabels[j]:

--- a/tests/logger/testLoggingFlags.py
+++ b/tests/logger/testLoggingFlags.py
@@ -7,7 +7,7 @@ import os
 import tempfile
 
 from nose.plugins.attrib import attr
-import numpy
+import numpy as np
 
 import nimble
 from nimble.calculate import fractionIncorrect
@@ -644,7 +644,7 @@ def test_points_insert():
 
 def test_features_insert():
     def wrapped(obj, useLog):
-        insertData = numpy.zeros((18,1))
+        insertData = np.zeros((18,1))
         toInsert = nimble.data("Matrix", insertData, useLog=False)
         return obj.features.insert(0, toInsert, useLog=useLog)
 
@@ -663,7 +663,7 @@ def test_points_append():
 
 def test_features_append():
     def wrapped(obj, useLog):
-        appendData = numpy.zeros((18,1))
+        appendData = np.zeros((18,1))
         toAppend = nimble.data("Matrix", appendData, useLog=False)
         return obj.features.append(toAppend, useLog=useLog)
 

--- a/tests/logger/testLoggingIO.py
+++ b/tests/logger/testLoggingIO.py
@@ -16,7 +16,7 @@ from io import StringIO
 
 from nose import with_setup
 from nose.tools import raises
-import numpy
+import numpy as np
 
 import nimble
 from nimble.calculate import rootMeanSquareError as RMSE
@@ -514,7 +514,7 @@ def testPrepTypeFunctionsUseLog():
                                                     "reducer": "simpleReducer"})
 
     # features.mapReduce
-    dataObj = nimble.data("Matrix", numpy.array(data, dtype=object).T,
+    dataObj = nimble.data("Matrix", np.array(data, dtype=object).T,
                           featureNames=False, useLog=False)
     calculated = dataObj.features.mapReduce(simpleMapper,simpleReducer)
     checkLogContents('features.mapReduce', "Matrix", {"mapper": "simpleMapper",
@@ -627,7 +627,7 @@ def testPrepTypeFunctionsUseLog():
 
     # features.insert
     dataObj = nimble.data("Matrix", data, useLog=False)
-    insertData = numpy.zeros((18,1))
+    insertData = np.zeros((18,1))
     toInsert = nimble.data("Matrix", insertData, name='insert', useLog=False)
     dataObj.features.insert(0, toInsert)
     checkLogContents('features.insert', "Matrix", {'insertBefore': 0,
@@ -642,7 +642,7 @@ def testPrepTypeFunctionsUseLog():
 
     # features.append
     dataObj = nimble.data("Matrix", data, useLog=False)
-    appendData = numpy.zeros((18,1))
+    appendData = np.zeros((18,1))
     toAppend = nimble.data("Matrix", appendData, name='append', useLog=False)
     dataObj.features.append(toAppend)
     checkLogContents('features.append', "Matrix", {'toAppend': toAppend.name})

--- a/tests/manualScripts/plottingExample.py
+++ b/tests/manualScripts/plottingExample.py
@@ -8,7 +8,7 @@ be written as files in that directory
 import os
 import sys
 
-import numpy
+import numpy as np
 
 import nimble
 
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     if len(sys.argv) > 2:
         givenShow = True if sys.argv[2].lower() != "false" else False
 
-    rawNorm = numpy.random.normal(loc=0, scale=1, size=(1000, 1))
+    rawNorm = np.random.normal(loc=0, scale=1, size=(1000, 1))
     objNorm = nimble.data("Matrix", rawNorm, featureNames=["N(0,1)"])
 
     # 1000 samples of N(0,1)
@@ -64,8 +64,8 @@ if __name__ == "__main__":
 
     #compare two columns: col1= rand noise, col2 =3* col1 + noise
     def plotComparisonNoiseVsScaled(outDir, givenShow):
-        raw1 = numpy.random.rand(50, 1)
-        raw2 = numpy.random.rand(50, 1)
+        raw1 = np.random.rand(50, 1)
+        raw2 = np.random.rand(50, 1)
         scaled = (raw1 * 3) + raw2
         obj1 = nimble.data("Matrix", raw1)
         obj2 = nimble.data("Matrix", scaled)
@@ -81,7 +81,7 @@ if __name__ == "__main__":
                                        yMin=-0.2, yMax=5.2)
 
     def plotComparisonMultipleNoiseVsScaled(outDir, givenShow):
-        raw1 = numpy.random.rand(50, 3)
+        raw1 = np.random.rand(50, 3)
         raw1[:, 1] = raw1[:, 0] + raw1[:, 1]
         raw1[:, 2] = raw1[:, 0] + raw1[:, 2]
         obj1 = nimble.data("Matrix", raw1)
@@ -95,12 +95,12 @@ if __name__ == "__main__":
             0, 2, 10, outPath=outPath, show=givenShow, figureName='noise',
             label='2', title=title, yAxisLabel='')
 
-    checkObj = nimble.data("Matrix", numpy.zeros((15, 12)), name="Checkerboard")
+    checkObj = nimble.data("Matrix", np.zeros((15, 12)), name="Checkerboard")
 
     def plotClusters(outDir, givenShow):
         centers = nimble.data('Matrix', [[0, 0], [1, 1], [2, 2], [3, 3]])
 
-        obj = nimble.data("Matrix", numpy.random.rand(25, 2))
+        obj = nimble.data("Matrix", np.random.rand(25, 2))
 
         label = 'cluster0'
         # by setting yMin=0.5, it will trigger yMax to be set to ~1 for
@@ -118,7 +118,7 @@ if __name__ == "__main__":
                 show = givenShow
                 outPath = getOutPath(outDir, "Clusters")
 
-            obj = nimble.data("Matrix", numpy.random.rand(25, 2))
+            obj = nimble.data("Matrix", np.random.rand(25, 2))
             scaled = obj + centers.points[i].stretch
 
             label = 'cluster' + str(i)
@@ -224,7 +224,7 @@ if __name__ == "__main__":
                                legendTitle='Gender')
 
     def plotFeatureComparisons(outDir, givenShow):
-        d = numpy.random.rand(500, 6) * 2
+        d = np.random.rand(500, 6) * 2
         d[:, 1] /= 2
         d[:, 2] *= 2
         d[:, 3] += 0.5
@@ -244,7 +244,7 @@ if __name__ == "__main__":
             show=givenShow, yAxisLabel='MAD', color='orange')
 
     def plotPointComparison(outDir, givenShow):
-        d = numpy.random.rand(5, 10)
+        d = np.random.rand(5, 10)
         d[d < 0.5] = d[d < 0.5] + 0.5 # value range (0.5 - 1)
         d[0, 0] = 0.1
         d[1, :] = 0.75

--- a/tests/match/test_match.py
+++ b/tests/match/test_match.py
@@ -1,4 +1,4 @@
-import numpy
+import numpy as np
 
 import nimble
 from nimble import match
@@ -13,14 +13,14 @@ def backend_match_value(toMatch, true, false):
     for f in false:
         assert not toMatch(f)
 
-missingValues = [None, float('nan'), numpy.nan]
+missingValues = [None, float('nan'), np.nan]
 stringValues = ['a', str(1)]
-zeroValues = [0, float(0), numpy.int(0), numpy.float(0)]
-positiveValues = [3, float(3), numpy.int(3), numpy.float(3)]
-negativeValues = [-3, float(-3), numpy.int(-3), numpy.float(-3)]
-infinityValues = [float('inf'), -float('inf'), numpy.inf, -numpy.inf]
-trueValues = [True, numpy.bool(True), numpy.bool_(True)]
-falseValues = [False, numpy.bool(False), numpy.bool_(False)]
+zeroValues = [0, float(0), np.int(0), np.float(0)]
+positiveValues = [3, float(3), np.int(3), np.float(3)]
+negativeValues = [-3, float(-3), np.int(-3), np.float(-3)]
+infinityValues = [float('inf'), -float('inf'), np.inf, -np.inf]
+trueValues = [True, np.bool(True), np.bool_(True)]
+falseValues = [False, np.bool(False), np.bool_(False)]
 boolValues = trueValues + falseValues
 
 numericValues = (positiveValues + negativeValues + zeroValues
@@ -68,7 +68,7 @@ def test_match_infinity():
 @noLogEntryExpected
 def backend_match_anyAll(anyOrAll, func, data):
     """backend for match functions accepting 1D and 2D data and testing for any or all"""
-    data = numpy.array(data, dtype=numpy.object_)
+    data = np.array(data, dtype=np.object_)
     for constructor in getDataConstructors():
         toTest = constructor(data, useLog=False)
         # test whole matrix
@@ -108,12 +108,12 @@ def backend_match_anyAll(anyOrAll, func, data):
 
 
 def test_match_anyMissing():
-    fill = numpy.nan
+    fill = np.nan
     data = [[1,2,fill], [4,5,fill], [7,fill,fill]]
     backend_match_anyAll('any', match.anyMissing, data)
 
 def test_match_allMissing():
-    fill = numpy.nan
+    fill = np.nan
     data = [[1,2,fill], [4,5,fill], [7,fill,fill]]
     backend_match_anyAll('all', match.allMissing, data)
 

--- a/tests/testCrossValidate.py
+++ b/tests/testCrossValidate.py
@@ -8,7 +8,7 @@ import sys
 from unittest import mock
 import functools
 
-import numpy
+import numpy as np
 import nose
 from nose.tools import *
 from nose.plugins.attrib import attr

--- a/tests/testData.py
+++ b/tests/testData.py
@@ -1,5 +1,5 @@
 import tempfile
-import numpy
+import numpy as np
 import os
 import sys
 import copy
@@ -38,7 +38,7 @@ from tests.helpers import calledException, CalledFunctionException
 returnTypes = copy.copy(nimble.core.data.available)
 returnTypes.append(None)
 
-datetimeTypes = (datetime.datetime, numpy.datetime64, pd.Timestamp)
+datetimeTypes = (datetime.datetime, np.datetime64, pd.Timestamp)
 
 class NoIter(object):
     def __init__(self, vals):
@@ -220,7 +220,7 @@ def test_data_raw_stringConversion_int():
         toTest = nimble.data(t, [['1','2','3'], ['4','5','6'], ['7','8','9']],
                              convertToType=int)
         for elem in toTest.iterateElements():
-            assert isinstance(elem, (int, numpy.integer))
+            assert isinstance(elem, (int, np.integer))
 
 def test_data_raw_stringConversion_datetimeTypes():
     for datetimeType in datetimeTypes:
@@ -281,8 +281,8 @@ def test_data_raw_conversionList():
         toTest = nimble.data(t, [[1, 2, 3], [4, 5, 6], [7 , 8, 9]],
                              convertToType=[int, float, str])
         for i in range(len(toTest.points)):
-            assert isinstance(toTest[i, 0], (int, numpy.integer))
-            assert isinstance(toTest[i, 1], (float, numpy.floating))
+            assert isinstance(toTest[i, 0], (int, np.integer))
+            assert isinstance(toTest[i, 1], (float, np.floating))
             assert isinstance(toTest[i, 2], str)
 
 def test_data_raw_conversionList_None():
@@ -290,9 +290,9 @@ def test_data_raw_conversionList_None():
         toTest = nimble.data(t, [[1, 2, 3], [4, 5, 6], [7 , 8, 9]],
                              convertToType=[int, float, None])
         for i in range(len(toTest.points)):
-            assert isinstance(toTest[i, 0], (int, numpy.integer))
-            assert isinstance(toTest[i, 1], (float, numpy.floating))
-            assert isinstance(toTest[i, 2], (int, numpy.integer))
+            assert isinstance(toTest[i, 0], (int, np.integer))
+            assert isinstance(toTest[i, 1], (float, np.floating))
+            assert isinstance(toTest[i, 2], (int, np.integer))
 
 def test_data_raw_conversionList_datetimeTypes():
     dates = [[1, '3', '03-13-1913'],
@@ -332,8 +332,8 @@ def test_data_raw_conversionList_keepFeatures_allData():
                              convertToType=[int, float, None],
                              keepFeatures=[1, 0])
         for i in range(len(toTest.points)):
-            assert isinstance(toTest[i, 0], (float, numpy.floating))
-            assert isinstance(toTest[i, 1], (int, numpy.integer))
+            assert isinstance(toTest[i, 0], (float, np.floating))
+            assert isinstance(toTest[i, 1], (int, np.integer))
 
 def test_data_raw_conversionList_keepFeatures_keptData():
     for t in returnTypes:
@@ -341,8 +341,8 @@ def test_data_raw_conversionList_keepFeatures_keptData():
                              convertToType=[int, float],
                              keepFeatures=[1, 0])
         for i in range(len(toTest.points)):
-            assert isinstance(toTest[i, 0], (int, numpy.integer))
-            assert isinstance(toTest[i, 1], (float, numpy.floating))
+            assert isinstance(toTest[i, 0], (int, np.integer))
+            assert isinstance(toTest[i, 1], (float, np.floating))
 
 def test_data_raw_conversionDict():
     for t in returnTypes:
@@ -350,8 +350,8 @@ def test_data_raw_conversionDict():
                              featureNames = ['a', 'b', 'c'],
                              convertToType={'a': int, 1: float, 'c': str})
         for i in range(len(toTest.points)):
-            assert isinstance(toTest[i, 0], (int, numpy.integer))
-            assert isinstance(toTest[i, 1], (float, numpy.floating))
+            assert isinstance(toTest[i, 0], (int, np.integer))
+            assert isinstance(toTest[i, 1], (float, np.floating))
             assert isinstance(toTest[i, 2], str)
 
 def test_data_raw_conversionDict_limited():
@@ -360,9 +360,9 @@ def test_data_raw_conversionDict_limited():
                              featureNames = ['a', 'b', 'c'],
                              convertToType={'b': float})
         for i in range(len(toTest.points)):
-            assert isinstance(toTest[i, 0], (int, numpy.integer))
-            assert isinstance(toTest[i, 1], (float, numpy.floating))
-            assert isinstance(toTest[i, 0], (int, numpy.integer))
+            assert isinstance(toTest[i, 0], (int, np.integer))
+            assert isinstance(toTest[i, 1], (float, np.floating))
+            assert isinstance(toTest[i, 0], (int, np.integer))
 
 def test_data_raw_conversionDict_validUnusedFtName():
     for t in returnTypes:
@@ -388,9 +388,9 @@ def test_data_raw_conversionDict_indexAndNameSameFt_match():
                              featureNames = ['a', 'b', 'c'],
                              convertToType={'b': float, 1: float})
         for i in range(len(toTest.points)):
-            assert isinstance(toTest[i, 0], (int, numpy.integer))
-            assert isinstance(toTest[i, 1], (float, numpy.floating))
-            assert isinstance(toTest[i, 0], (int, numpy.integer))
+            assert isinstance(toTest[i, 0], (int, np.integer))
+            assert isinstance(toTest[i, 1], (float, np.floating))
+            assert isinstance(toTest[i, 0], (int, np.integer))
 
 def test_data_raw_conversionDict_datetimeTypes():
     dates = [[1, '3', '03-13-1913'],
@@ -424,8 +424,8 @@ def test_data_raw_conversionDict_keepFeatures_ftNames():
                              convertToType={'a': int, 'b': float},
                              keepFeatures=[0, 1])
         for i in range(len(toTest.points)):
-            assert isinstance(toTest[i, 0], (int, numpy.integer))
-            assert isinstance(toTest[i, 1], (float, numpy.floating))
+            assert isinstance(toTest[i, 0], (int, np.integer))
+            assert isinstance(toTest[i, 1], (float, np.floating))
 
 def test_data_raw_conversionDict_keepFeatures_index():
     for t in returnTypes:
@@ -474,7 +474,7 @@ def test_data_raw_pointAndFeatureIterators():
 def test_data_raw_datetime():
     for t in returnTypes:
         rawData = [[datetime.datetime(2020, 1, 1), -16, 2],
-                   [numpy.datetime64('2020-01-02'), -24, -6],
+                   [np.datetime64('2020-01-02'), -24, -6],
                    [pd.Timestamp(year=2020, month=2, day=3), -30, -18]]
         toTest = nimble.data(t, rawData)
         for date in toTest.features[0].iterateElements():
@@ -864,7 +864,7 @@ def test_data_HDF5_data():
         # HDF5 commonly uses two extensions .hdf5 and .h5
         for suffix in ['.hdf5', '.h5']:
             with tempfile.NamedTemporaryFile(suffix=suffix) as tmpHDF:
-                arr = numpy.array([[1, 2], [3, 4]])
+                arr = np.array([[1, 2], [3, 4]])
                 hdfFile = h5py.File(tmpHDF, 'w')
                 one = hdfFile.create_group('one')
                 one.create_dataset('mtx1', data=arr)
@@ -890,7 +890,7 @@ def test_data_HDF5_dataRandomExtension():
                                                     [[1, 2], [3, 4]]]])
 
         with tempfile.NamedTemporaryFile(suffix=".data") as tmpHDF:
-            arr = numpy.array([[1, 2], [3, 4]])
+            arr = np.array([[1, 2], [3, 4]])
             hdfFile = h5py.File(tmpHDF, 'w')
             one = hdfFile.create_group('one')
             one.create_dataset('mtx1', data=arr)
@@ -919,7 +919,7 @@ def test_data_HDF5_dataDifferentStructures():
         # Case 1: file contains single Dataset with all data
         with tempfile.NamedTemporaryFile(suffix=".h5") as tmpHDF:
             hdfFile = h5py.File(tmpHDF, 'w')
-            ds1 = hdfFile.create_dataset('data', data=numpy.array(data))
+            ds1 = hdfFile.create_dataset('data', data=np.array(data))
             hdfFile.flush()
             hdfFile.close()
             tmpHDF.seek(0)
@@ -933,8 +933,8 @@ def test_data_HDF5_dataDifferentStructures():
         # Case 2: Two Datasets
         with tempfile.NamedTemporaryFile(suffix=".h5") as tmpHDF:
             hdfFile = h5py.File(tmpHDF, 'w')
-            hdfFile.create_dataset('mtx1', data=numpy.array(data)[0])
-            hdfFile.create_dataset('mtx2', data=numpy.array(data)[1])
+            hdfFile.create_dataset('mtx1', data=np.array(data)[0])
+            hdfFile.create_dataset('mtx2', data=np.array(data)[1])
             hdfFile.flush()
             hdfFile.close()
             tmpHDF.seek(0)
@@ -953,18 +953,18 @@ def test_data_HDF5_dataDifferentStructures():
             hdfFile = h5py.File(tmpHDF, 'w')
             zero = hdfFile.create_group('index0')
             zeroZero = zero.create_group('index0')
-            zeroZero.create_dataset('index0', data=numpy.array(data)[0, 0, 0])
-            zeroZero.create_dataset('index1', data=numpy.array(data)[0, 0, 1])
+            zeroZero.create_dataset('index0', data=np.array(data)[0, 0, 0])
+            zeroZero.create_dataset('index1', data=np.array(data)[0, 0, 1])
             zeroOne = zero.create_group('index1')
-            zeroOne.create_dataset('index0', data=numpy.array(data)[0, 1, 0])
-            zeroOne.create_dataset('index1', data=numpy.array(data)[0, 1, 1])
+            zeroOne.create_dataset('index0', data=np.array(data)[0, 1, 0])
+            zeroOne.create_dataset('index1', data=np.array(data)[0, 1, 1])
             one = hdfFile.create_group('index1')
             oneZero = one.create_group('index0')
-            oneZero.create_dataset('index0', data=numpy.array(data)[1, 0, 0])
-            oneZero.create_dataset('index1', data=numpy.array(data)[1, 0, 1])
+            oneZero.create_dataset('index0', data=np.array(data)[1, 0, 0])
+            oneZero.create_dataset('index1', data=np.array(data)[1, 0, 1])
             oneOne = one.create_group('index1')
-            oneOne.create_dataset('index0', data=numpy.array(data)[1, 1, 0])
-            oneOne.create_dataset('index1', data=numpy.array(data)[1, 1, 1])
+            oneOne.create_dataset('index0', data=np.array(data)[1, 1, 0])
+            oneOne.create_dataset('index1', data=np.array(data)[1, 1, 1])
             hdfFile.flush()
             hdfFile.close()
             tmpHDF.seek(0)
@@ -1424,7 +1424,7 @@ def test_extractNames_HDF():
                                pointNames=pNames)
 
         with tempfile.NamedTemporaryFile(suffix=".data") as tmpHDF:
-            arr = numpy.array([[1, 2], [3, 4]])
+            arr = np.array([[1, 2], [3, 4]])
             hdfFile = h5py.File(tmpHDF, 'w')
             one = hdfFile.create_group('one')
             one.create_dataset('mtx1', data=arr)
@@ -1536,9 +1536,9 @@ def test_extractNames_pythonList():
 
 def test_extractNames_NPArray():
     """ Test of data() given numpy array, extracting names """
-    inDataRaw = numpy.array([[-111, 21, 22, 23], [11, 1, -1, -3]])
+    inDataRaw = np.array([[-111, 21, 22, 23], [11, 1, -1, -3]])
     for t in returnTypes:
-        specRaw = numpy.array([[1, -1, -3]])
+        specRaw = np.array([[1, -1, -3]])
         pNames = ['11']
         fNames = ['21', '22', '23']
         inData = nimble.data(
@@ -1547,7 +1547,7 @@ def test_extractNames_NPArray():
             returnType=t, source=specRaw, pointNames=pNames, featureNames=fNames)
         assert inData == specified
 
-        specRaw = numpy.array([[21, 22, 23], [1, -1, -3]])
+        specRaw = np.array([[21, 22, 23], [1, -1, -3]])
         pNames = ['-111', '11']
         inData = nimble.data(
             returnType=t, source=inDataRaw, pointNames=True, featureNames=False)
@@ -1555,7 +1555,7 @@ def test_extractNames_NPArray():
             returnType=t, source=specRaw, pointNames=pNames)
         assert inData == specified
 
-        specRaw = numpy.array([[11, 1, -1, -3]])
+        specRaw = np.array([[11, 1, -1, -3]])
         fNames = ['-111', '21', '22', '23']
         inData = nimble.data(
             returnType=t, source=inDataRaw, pointNames=False, featureNames=True)
@@ -1566,9 +1566,9 @@ def test_extractNames_NPArray():
 
 def test_extractNames_NPMatrix():
     """ Test of data() given numpy matrix, extracting names """
-    inDataRaw = numpy.array([[-111, 21, 22, 23], [11, 1, -1, -3]])
+    inDataRaw = np.array([[-111, 21, 22, 23], [11, 1, -1, -3]])
     for t in returnTypes:
-        specRaw = numpy.matrix([[1, -1, -3]])
+        specRaw = np.matrix([[1, -1, -3]])
         pNames = ['11']
         fNames = ['21', '22', '23']
         inData = nimble.data(
@@ -1577,7 +1577,7 @@ def test_extractNames_NPMatrix():
             returnType=t, source=specRaw, pointNames=pNames, featureNames=fNames)
         assert inData == specified
 
-        specRaw = numpy.matrix([[21, 22, 23], [1, -1, -3]])
+        specRaw = np.matrix([[21, 22, 23], [1, -1, -3]])
         pNames = ['-111', '11']
         inData = nimble.data(
             returnType=t, source=inDataRaw, pointNames=True, featureNames=False)
@@ -1585,7 +1585,7 @@ def test_extractNames_NPMatrix():
             returnType=t, source=specRaw, pointNames=pNames)
         assert inData == specified
 
-        specRaw = numpy.matrix([[11, 1, -1, -3]])
+        specRaw = np.matrix([[11, 1, -1, -3]])
         fNames = ['-111', '21', '22', '23']
         inData = nimble.data(
             returnType=t, source=inDataRaw, pointNames=False, featureNames=True)
@@ -1596,10 +1596,10 @@ def test_extractNames_NPMatrix():
 
 def test_extractNames_CooSparse():
     """ Test of data() given scipy Coo matrix, extracting names """
-    inDataRaw = numpy.array([[-111, 21, 22, 23], [11, 1, -1, -3]])
+    inDataRaw = np.array([[-111, 21, 22, 23], [11, 1, -1, -3]])
     inDataRaw = scipy.sparse.coo_matrix(inDataRaw)
     for t in returnTypes:
-        specRaw = numpy.array([[1, -1, -3]])
+        specRaw = np.array([[1, -1, -3]])
         specRaw = scipy.sparse.csc_matrix(specRaw)
         pNames = ['11']
         fNames = ['21', '22', '23']
@@ -1609,7 +1609,7 @@ def test_extractNames_CooSparse():
             returnType=t, source=specRaw, pointNames=pNames, featureNames=fNames)
         assert inData == specified
 
-        specRaw = numpy.array([[21, 22, 23], [1, -1, -3]])
+        specRaw = np.array([[21, 22, 23], [1, -1, -3]])
         specRaw = scipy.sparse.csc_matrix(specRaw)
         pNames = ['-111', '11']
         inData = nimble.data(
@@ -1618,7 +1618,7 @@ def test_extractNames_CooSparse():
             returnType=t, source=specRaw, pointNames=pNames)
         assert inData == specified
 
-        specRaw = numpy.array([[11, 1, -1, -3]])
+        specRaw = np.array([[11, 1, -1, -3]])
         specRaw = scipy.sparse.csc_matrix(specRaw)
         fNames = ['-111', '21', '22', '23']
         inData = nimble.data(
@@ -1630,10 +1630,10 @@ def test_extractNames_CooSparse():
 
 def test_extractNames_CscSparse():
     """ Test of data() given scipy Csc matrix, extracting names """
-    inDataRaw = numpy.array([[-111, 21, 22, 23], [11, 1, -1, -3]])
+    inDataRaw = np.array([[-111, 21, 22, 23], [11, 1, -1, -3]])
     inDataRaw = scipy.sparse.csc_matrix(inDataRaw)
     for t in returnTypes:
-        specRaw = numpy.array([[1, -1, -3]])
+        specRaw = np.array([[1, -1, -3]])
         specRaw = scipy.sparse.csc_matrix(specRaw)
         pNames = ['11']
         fNames = ['21', '22', '23']
@@ -1644,7 +1644,7 @@ def test_extractNames_CscSparse():
 
         assert inData == specified
 
-        specRaw = numpy.array([[21, 22, 23], [1, -1, -3]])
+        specRaw = np.array([[21, 22, 23], [1, -1, -3]])
         specRaw = scipy.sparse.csc_matrix(specRaw)
         pNames = ['-111', '11']
         inData = nimble.data(
@@ -1653,7 +1653,7 @@ def test_extractNames_CscSparse():
             returnType=t, source=specRaw, pointNames=pNames)
         assert inData == specified
 
-        specRaw = numpy.array([[11, 1, -1, -3]])
+        specRaw = np.array([[11, 1, -1, -3]])
         specRaw = scipy.sparse.csc_matrix(specRaw)
         fNames = ['-111', '21', '22', '23']
         inData = nimble.data(
@@ -1695,7 +1695,7 @@ def test_extractNames_pandasDataFrame():
 def test_names_dataUnmodified():
     """ Test original data unmodifed when names set to 'automatic' or True """
     autoData = [['pointNames', 'fname0', 'fname1', 'fname2'], ['pt', 1, -1, -3]]
-    autoArray = numpy.array(autoData, dtype=numpy.object_)
+    autoArray = np.array(autoData, dtype=np.object_)
     trueData = [[-111, 21, 22, 23], [11, 1, -1, -3]]
 
     def assertUnmodified(rawData, names):
@@ -1709,19 +1709,19 @@ def test_names_dataUnmodified():
         if isinstance(rawData, list):
             rawData == rawDataCopy
         elif scipy.sparse.isspmatrix(rawData):
-            numpy.testing.assert_array_equal(sparseMatrixToArray(rawData),
+            np.testing.assert_array_equal(sparseMatrixToArray(rawData),
                                              sparseMatrixToArray(rawDataCopy))
         else:
-            numpy.testing.assert_array_equal(rawData, rawDataCopy)
+            np.testing.assert_array_equal(rawData, rawDataCopy)
 
 
     for t in returnTypes:
         assertUnmodified(autoData, 'automatic')
         assertUnmodified(trueData, True)
         assertUnmodified(autoArray, 'automatic')
-        assertUnmodified(numpy.array(trueData), True)
-        assertUnmodified(numpy.matrix(autoArray), 'automatic')
-        assertUnmodified(numpy.matrix(trueData), True)
+        assertUnmodified(np.array(trueData), True)
+        assertUnmodified(np.matrix(autoArray), 'automatic')
+        assertUnmodified(np.matrix(trueData), True)
         assertUnmodified(scipy.sparse.coo_matrix(autoArray), 'automatic')
         assertUnmodified(scipy.sparse.coo_matrix(trueData), True)
         assertUnmodified(pd.DataFrame([[1, -1, -3]], index=['pt'],
@@ -1953,7 +1953,7 @@ def mocked_requests_get(url, *args, **kwargs):
         data = [[[[1, 2], [3, 4]]], [[[-1, -2], [-3, -4]]]]
         with tempfile.NamedTemporaryFile(suffix=".data") as tmpHDF:
             hdfFile = h5py.File(tmpHDF, 'w')
-            ds1 = hdfFile.create_dataset('data', data=numpy.array(data))
+            ds1 = hdfFile.create_dataset('data', data=np.array(data))
             hdfFile.flush()
             hdfFile.close()
             tmpHDF.seek(0)
@@ -3141,7 +3141,7 @@ def test_data_keepPF_pythonList_simple():
 def test_data_keepPF_npArray_simple():
     wanted = nimble.data("Matrix", source=[[22, 33], [222, 333]])
     rawList = [[1, 2, 3], [11, 22, 33], [111, 222, 333]]
-    raw = numpy.array(rawList)
+    raw = np.array(rawList)
 
     fromNPArr = nimble.data(
         "Matrix", source=raw, keepPoints=[1, 2], keepFeatures=[1, 2])
@@ -3156,7 +3156,7 @@ def test_data_keepPF_npArray_simple():
 def test_data_keepPF_npMatrix_simple():
     wanted = nimble.data("Matrix", source=[[22, 33], [222, 333]])
     rawList = [[1, 2, 3], [11, 22, 33], [111, 222, 333]]
-    raw = numpy.matrix(rawList)
+    raw = np.matrix(rawList)
 
     fromList = nimble.data(
         "Matrix", source=raw, keepPoints=[1, 2], keepFeatures=[1, 2])
@@ -3645,8 +3645,8 @@ def test_data_csv_inputSeparatorNot1Character():
 
 def test_missingDefaults():
     for t in returnTypes:
-        nan = numpy.nan
-        data = [[1, 2, float('nan')], [numpy.nan, 5, 6], [7, None, 9], ["", "nan", "None"]]
+        nan = np.nan
+        data = [[1, 2, float('nan')], [np.nan, 5, 6], [7, None, 9], ["", "nan", "None"]]
         toTest = nimble.data(t, data)
         expData = [[1, 2, nan], [nan, 5, 6], [7, nan, 9], [nan, nan, nan]]
         expRet = nimble.data(t, expData)
@@ -3654,7 +3654,7 @@ def test_missingDefaults():
 
 def test_handmadeReplaceMissingWith():
     for t in returnTypes:
-        data = [[1, 2, float('nan')], [numpy.nan, 5, 6], [7, None, 9], ["", "nan", "None"]]
+        data = [[1, 2, float('nan')], [np.nan, 5, 6], [7, None, 9], ["", "nan", "None"]]
         toTest = nimble.data(t, data, replaceMissingWith=0)
         expData = [[1, 2, 0], [0, 5, 6], [7, 0, 9], [0, 0, 0]]
         expRet = nimble.data(t, expData)
@@ -3669,10 +3669,10 @@ def test_numericalReplaceMissingWithNonNumeric():
         assert toTest == expRet
 
 def test_handmadeTreatAsMissing():
-    nan = numpy.nan
+    nan = np.nan
     data = [[1, 2, ""], [nan, 5, 6], [7, "", 9], [nan, "nan", "None"]]
     missingList = [nan, "", 5]
-    assert numpy.array(missingList).dtype != numpy.object_
+    assert np.array(missingList).dtype != np.object_
     for t in returnTypes:
         toTest = nimble.data(t, data, treatAsMissing=missingList)
         expData = [[1, 2, nan], [nan, nan, 6], [7, nan, 9], [nan, "nan", "None"]]
@@ -3697,8 +3697,8 @@ def test_replaceDataTypeMismatch():
 
 def test_keepNanAndReplaceAlternateMissing():
     for t in returnTypes:
-        nan = numpy.nan
-        data = [[1, 2, "NA"], [numpy.nan, 5, 6], [7, "NA", 9], ["NA", numpy.nan, "NA"]]
+        nan = np.nan
+        data = [[1, 2, "NA"], [np.nan, 5, 6], [7, "NA", 9], ["NA", np.nan, "NA"]]
         toTest = nimble.data(t, data, treatAsMissing=["NA"], replaceMissingWith=-1)
         expData = [[1, 2, -1], [nan, 5, 6], [7, -1, 9], [-1, nan, -1]]
         expRet = nimble.data(t, expData, treatAsMissing=None)
@@ -3706,8 +3706,8 @@ def test_keepNanAndReplaceAlternateMissing():
 
 def test_treatAsMissingIsNone():
     for t in returnTypes:
-        nan = numpy.nan
-        data = [[1, 2, None], [None, 5, 6], [7, None, 9], ["", numpy.nan, ""]]
+        nan = np.nan
+        data = [[1, 2, None], [None, 5, 6], [7, None, 9], ["", np.nan, ""]]
         toTest = nimble.data(t, data, treatAsMissing=None)
         notExpData = [[1,2, nan], [nan, 5, 6], [7, nan, 9], [nan, nan, nan]]
         notExpRet = nimble.data(t, notExpData, treatAsMissing=None)
@@ -3715,9 +3715,9 @@ def test_treatAsMissingIsNone():
 
 def test_DataOutputWithMissingDataTypes1D():
     for t in returnTypes:
-        nan = numpy.nan
+        nan = np.nan
         expListOutput = [[1.0, 2.0, nan]]
-        expMatrixOutput = numpy.array(expListOutput)
+        expMatrixOutput = np.array(expListOutput)
         expDataFrameOutput = pd.DataFrame(expListOutput)
         expSparseOutput = scipy.sparse.coo_matrix(expListOutput)
 
@@ -3727,13 +3727,13 @@ def test_DataOutputWithMissingDataTypes1D():
         orig3.features.sort()
         orig4 = nimble.data(t, [{'a':1, 'b':2, 'c':"None"}])
         orig4.features.sort()
-        orig5 = nimble.data(t, numpy.array([1,2,"None"], dtype=object))
-        orig6 = nimble.data(t, numpy.matrix([1,2,"None"], dtype=object))
+        orig5 = nimble.data(t, np.array([1,2,"None"], dtype=object))
+        orig6 = nimble.data(t, np.matrix([1,2,"None"], dtype=object))
         orig7 = nimble.data(t, pd.DataFrame([[1,2,"None"]]))
         orig8 = nimble.data(t, pd.Series([1,2,"None"]))
-        orig9 = nimble.data(t, scipy.sparse.coo_matrix(numpy.array([1,2,"None"], dtype=object)))
-        orig10 = nimble.data(t, scipy.sparse.csc_matrix(numpy.array([1,2,float('nan')])))
-        orig11 = nimble.data(t, scipy.sparse.csr_matrix(numpy.array([1,2,float('nan')])))
+        orig9 = nimble.data(t, scipy.sparse.coo_matrix(np.array([1,2,"None"], dtype=object)))
+        orig10 = nimble.data(t, scipy.sparse.csc_matrix(np.array([1,2,float('nan')])))
+        orig11 = nimble.data(t, scipy.sparse.csr_matrix(np.array([1,2,float('nan')])))
         try:
             orig12 = nimble.data(t, pd.DataFrame([[1,2,"None"]], dtype='Sparse[object]'))
         except TypeError:
@@ -3745,23 +3745,23 @@ def test_DataOutputWithMissingDataTypes1D():
             if orig.getTypeString() == "List":
                 assert orig._data[0][0] == expListOutput[0][0]
                 assert orig._data[0][1] == expListOutput[0][1]
-                assert numpy.isnan(orig._data[0][2])
+                assert np.isnan(orig._data[0][2])
             elif orig.getTypeString() == "Matrix":
-                assert numpy.array_equal(orig._data[0, :2], expMatrixOutput[0, :2])
-                assert numpy.isnan(orig._data[0, 2])
+                assert np.array_equal(orig._data[0, :2], expMatrixOutput[0, :2])
+                assert np.isnan(orig._data[0, 2])
             elif orig.getTypeString() == "DataFrame":
-                assert numpy.array_equal(orig._data.values[0, :2], expDataFrameOutput.values[0, :2])
-                assert numpy.isnan(orig._data.values[0, 2])
+                assert np.array_equal(orig._data.values[0, :2], expDataFrameOutput.values[0, :2])
+                assert np.isnan(orig._data.values[0, 2])
             else:
                 orig._sortInternal('point')
-                assert numpy.array_equal(orig._data.data[:2], expSparseOutput.data[:2])
-                assert numpy.isnan(orig._data.data[2])
+                assert np.array_equal(orig._data.data[:2], expSparseOutput.data[:2])
+                assert np.isnan(orig._data.data[2])
 
 def test_DataOutputWithMissingDataTypes2D():
     for t in returnTypes:
-        nan = numpy.nan
+        nan = np.nan
         expListOutput = [[1, 2, nan], [3,4,'b']]
-        expMatrixOutput = numpy.array(expListOutput, dtype=object)
+        expMatrixOutput = np.array(expListOutput, dtype=object)
         expDataFrameOutput = pd.DataFrame(expMatrixOutput)
         expSparseOutput = scipy.sparse.coo_matrix(expMatrixOutput)
 
@@ -3771,10 +3771,10 @@ def test_DataOutputWithMissingDataTypes2D():
         orig3.features.sort()
         orig4 = nimble.data(t, [{'a':1, 'b':2, 'c':'None'}, {'a':3, 'b':4, 'c':'b'}])
         orig4.features.sort()
-        orig5 = nimble.data(t, numpy.array([[1,2,'None'], [3,4,'b']], dtype=object))
-        orig6 = nimble.data(t, numpy.matrix([[1,2,'None'], [3,4,'b']], dtype=object))
+        orig5 = nimble.data(t, np.array([[1,2,'None'], [3,4,'b']], dtype=object))
+        orig6 = nimble.data(t, np.matrix([[1,2,'None'], [3,4,'b']], dtype=object))
         orig7 = nimble.data(t, pd.DataFrame([[1,2,'None'], [3,4,'b']]))
-        orig8 = nimble.data(t, scipy.sparse.coo_matrix(numpy.array([[1,2,'None'], [3,4,'b']], dtype=object)))
+        orig8 = nimble.data(t, scipy.sparse.coo_matrix(np.array([[1,2,'None'], [3,4,'b']], dtype=object)))
         try:
             orig9 = nimble.data(t, pd.DataFrame([[1,2,'None'], [3,4,'b']], dtype='Sparse[object]'))
         except TypeError:
@@ -3786,25 +3786,25 @@ def test_DataOutputWithMissingDataTypes2D():
             if orig.getTypeString() == "List":
                 assert orig._data[0][0] == expListOutput[0][0]
                 assert orig._data[0][1] == expListOutput[0][1]
-                assert numpy.isnan(orig._data[0][2])
+                assert np.isnan(orig._data[0][2])
                 assert orig._data[1] == expListOutput[1]
             elif orig.getTypeString() == "Matrix":
-                assert numpy.array_equal(orig._data[0, :2], expMatrixOutput[0, :2])
-                assert numpy.isnan(orig._data[0, 2])
-                assert numpy.array_equal(orig._data[1,:], expMatrixOutput[1,:])
+                assert np.array_equal(orig._data[0, :2], expMatrixOutput[0, :2])
+                assert np.isnan(orig._data[0, 2])
+                assert np.array_equal(orig._data[1,:], expMatrixOutput[1,:])
             elif orig.getTypeString() == "DataFrame":
-                assert numpy.array_equal(orig._data.values[0, :2], expDataFrameOutput.values[0, :2])
-                assert numpy.isnan(orig._data.values[0, 2])
-                assert numpy.array_equal(orig._data.values[1,:], expDataFrameOutput.values[1,:])
+                assert np.array_equal(orig._data.values[0, :2], expDataFrameOutput.values[0, :2])
+                assert np.isnan(orig._data.values[0, 2])
+                assert np.array_equal(orig._data.values[1,:], expDataFrameOutput.values[1,:])
             else:
                 orig._sortInternal('point')
-                assert numpy.array_equal(orig._data.data[:2], expSparseOutput.data[:2])
-                assert numpy.isnan(orig._data.data[2])
-                assert numpy.array_equal(orig._data.data[3:], expSparseOutput.data[3:])
+                assert np.array_equal(orig._data.data[:2], expSparseOutput.data[:2])
+                assert np.isnan(orig._data.data[2])
+                assert np.array_equal(orig._data.data[3:], expSparseOutput.data[3:])
 
 def test_replaceNumpyValues_dtypePreservation():
     for t in returnTypes:
-        data = numpy.array([[True, False, True], [False, True, False]])
+        data = np.array([[True, False, True], [False, True, False]])
         toTest = nimble.data(t, data, replaceMissingWith=2,
                              treatAsMissing=[False])
         # should upcast to int, since replaceMissingWith is int
@@ -3813,29 +3813,29 @@ def test_replaceNumpyValues_dtypePreservation():
         assert toTest[0, 0] == True # could be 1 or True depending on type
         assert toTest[0, 1] == 2
 
-        data = numpy.array([[1, 0, 1], [0, 1, 0]])
-        toTest = nimble.data(t, data, replaceMissingWith=numpy.nan,
+        data = np.array([[1, 0, 1], [0, 1, 0]])
+        toTest = nimble.data(t, data, replaceMissingWith=np.nan,
                              treatAsMissing=[None])
         # should skip attempted replacement because no treatAsMissing values
         if hasattr(toTest._data, 'dtype'):
             assert toTest._data.dtype == int
-        ints = (int, numpy.integer)
+        ints = (int, np.integer)
         assert all(isinstance(val, ints) for val in toTest.iterateElements())
 
-        toTest = nimble.data(t, data, replaceMissingWith=numpy.nan,
+        toTest = nimble.data(t, data, replaceMissingWith=np.nan,
                              treatAsMissing=[0])
         # should upcast to float, since replaceMissingWith is float
         if hasattr(toTest._data, 'dtype'):
             assert toTest._data.dtype == float
         assert toTest[0, 0] == True # could be 1.0 or True depending on type
-        assert numpy.isnan(toTest[0, 1])
+        assert np.isnan(toTest[0, 1])
 
 
         toTest = nimble.data(t, data, replaceMissingWith='x',
                              treatAsMissing=[0])
         # should upcast to object, since replaceMissingWith is a string
         if hasattr(toTest._data, 'dtype'):
-            assert toTest._data.dtype == numpy.object_
+            assert toTest._data.dtype == np.object_
         assert toTest[0, 0] == True
         assert toTest[0, 1] == 'x'
 
@@ -3856,16 +3856,16 @@ def makeTensorData(matrix):
     rank3List = [matrix, matrix, matrix]
     rank4List = [rank3List, rank3List, rank3List]
     rank5List = [rank4List, rank4List, rank4List]
-    rank3Array = numpy.array(rank3List)
-    rank4Array = numpy.array(rank4List)
-    rank5Array = numpy.array(rank5List)
-    rank3Array2D = numpy.empty((3, 3), dtype='O')
+    rank3Array = np.array(rank3List)
+    rank4Array = np.array(rank4List)
+    rank5Array = np.array(rank5List)
+    rank3Array2D = np.empty((3, 3), dtype='O')
     for i, lst in enumerate(rank3List):
         rank3Array2D[i] = lst
-    rank4Array2D = numpy.empty((3, 3), dtype='O')
+    rank4Array2D = np.empty((3, 3), dtype='O')
     for i, lst in enumerate(rank4List):
         rank4Array2D[i] = lst
-    rank5Array2D = numpy.empty((3, 3), dtype='O')
+    rank5Array2D = np.empty((3, 3), dtype='O')
     for i, lst in enumerate(rank5List):
         rank5Array2D[i] = lst
     rank3DF = pd.DataFrame(rank3Array2D)
@@ -3901,7 +3901,7 @@ def test_data_multidimensionalData():
             expShape = [3, 3, 5]
             for i in range(idx % 3):
                 expShape.insert(0, 3)
-            expFeatures = numpy.prod(expShape[1:])
+            expFeatures = np.prod(expShape[1:])
             assert toTest._shape == expShape
             assert toTest._pointCount == expPoints
             assert toTest._featureCount == expFeatures
@@ -3911,7 +3911,7 @@ def test_data_multidimensionalData():
             expShape = [3, 3, 0]
             for i in range(idx % 3):
                 expShape.insert(0, 3)
-            expFeatures = numpy.prod(expShape[1:])
+            expFeatures = np.prod(expShape[1:])
             assert toTest._shape == expShape
             assert toTest._pointCount == expPoints
             assert toTest._featureCount == expFeatures
@@ -3949,7 +3949,7 @@ def test_data_multidimensionalData_featureNames():
 
 def test_data_multidimensionalData_listsOfMultiDimensionalObjects():
     for (rType1, rType2) in itertools.product(returnTypes, returnTypes):
-        arr1D = numpy.array([1, 2, 3, 0])
+        arr1D = np.array([1, 2, 3, 0])
         nim1D = nimble.data(rType1, [1, 2, 3, 0])
 
         fromListArr1D = nimble.data(rType2, [arr1D, arr1D, arr1D])
@@ -3979,7 +3979,7 @@ def test_data_multidimensionalData_listsOfMultiDimensionalObjects():
 # Tests when input data matches the backend data type
 
 nimbleRawMap = {'List': list,
-                'Matrix': numpy.array,
+                'Matrix': np.array,
                 'Sparse': scipy.sparse.coo_matrix,
                 'DataFrame': pd.DataFrame}
 
@@ -4031,19 +4031,19 @@ def test_data_copyData_False_copyMadeWhenNamesExtracted():
 
             nim = nimble.data(rType, raw, pointNames=True, copyData=False)
             rawArr = getArray[rType](raw)
-            assert not numpy.array_equal(rawArr, getArray[rType](nim._data))
-            assert numpy.array_equal(rawArr, rawArrCopy)
+            assert not np.array_equal(rawArr, getArray[rType](nim._data))
+            assert np.array_equal(rawArr, rawArrCopy)
 
             nim = nimble.data(rType, raw, featureNames=True, copyData=False)
             rawArr = getArray[rType](raw)
-            assert not numpy.array_equal(rawArr, getArray[rType](nim._data))
-            assert numpy.array_equal(rawArr, rawArrCopy)
+            assert not np.array_equal(rawArr, getArray[rType](nim._data))
+            assert np.array_equal(rawArr, rawArrCopy)
 
             nim = nimble.data(rType, raw, pointNames=True, featureNames=True,
                               copyData=False)
             rawArr = getArray[rType](raw)
-            assert not numpy.array_equal(rawArr, getArray[rType](nim._data))
-            assert numpy.array_equal(rawArr, rawArrCopy)
+            assert not np.array_equal(rawArr, getArray[rType](nim._data))
+            assert np.array_equal(rawArr, rawArrCopy)
         else:
             # DataFrame extracts from columns & index attributes, not data
             # copy was made if backend data has different id

--- a/tests/testGeneratedData.py
+++ b/tests/testGeneratedData.py
@@ -6,7 +6,7 @@ nimble.random.data, nimble.ones, nimble.zeros, nimble.identity
 
 import copy
 
-import numpy
+import numpy as np
 from nose.tools import *
 
 import nimble
@@ -41,7 +41,7 @@ def back_constant_sizeChecking(toTest):
 
 
 def back_constant_emptyCreation(toTest):
-    fEmpty = numpy.array([[], []])
+    fEmpty = np.array([[], []])
     pEmpty = fEmpty.T
 
     for t in returnTypes:

--- a/tests/testLearnHelpers.py
+++ b/tests/testLearnHelpers.py
@@ -1,7 +1,7 @@
 import math
 from math import fabs
 
-import numpy
+import numpy as np
 from nose.tools import *
 from nose.plugins.attrib import attr
 
@@ -33,7 +33,7 @@ class FoldIteratorTester(object):
     def test_FoldIterator_exceptionPEmpty(self):
         """ Test FoldIterator() for InvalidArgumentValueCombination when object is point empty """
         data = [[], []]
-        data = numpy.array(data).T
+        data = np.array(data).T
         toTest = self.constructor(data)
         FoldIterator([toTest], 2)
 
@@ -41,7 +41,7 @@ class FoldIteratorTester(object):
     #	def test_FoldIterator_exceptionFEmpty(self):
     #		""" Test FoldIterator() for ImproperActionException when object is feature empty """
     #		data = [[],[]]
-    #		data = numpy.array(data)
+    #		data = np.array(data)
     #		toTest = self.constructor(data)
     #		FoldIterator([toTest],2)
 
@@ -160,8 +160,8 @@ class FoldIteratorTester(object):
 
     def test_FoldIterator_foldSizes(self):
         """ Test that the size of each fold created by FoldIterator matches expectations """
-        data1 = self.constructor(numpy.random.random((98, 10)))
-        data2 = self.constructor(numpy.ones((98, 1)))
+        data1 = self.constructor(np.random.random((98, 10)))
+        data2 = self.constructor(np.ones((98, 1)))
         folds = FoldIterator([data1, data2], 10)
 
         # first 8 folds should have 10, last 2 folds should have 9
@@ -388,8 +388,8 @@ def testSumDifferenceFunction():
 
 
 def test_computeMetrics_1d_2arg():
-    knownLabels = numpy.array([[1.0], [2.0], [3.0]])
-    predictedLabels = numpy.array([[1.0], [2.0], [3.0]])
+    knownLabels = np.array([[1.0], [2.0], [3.0]])
+    predictedLabels = np.array([[1.0], [2.0], [3.0]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -398,8 +398,8 @@ def test_computeMetrics_1d_2arg():
     result = computeMetrics(knownLabelsMatrix, None, predictedLabelsMatrix, metricFunctions)
     assert result == 0.0
 
-    knownLabels = numpy.array([[1.5], [2.5], [3.5]])
-    predictedLabels = numpy.array([[1.0], [2.0], [3.0]])
+    knownLabels = np.array([[1.5], [2.5], [3.5]])
+    predictedLabels = np.array([[1.0], [2.0], [3.0]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -411,8 +411,8 @@ def test_computeMetrics_1d_2arg():
 
 
 def test_computeMetrics_1d_labelsInData():
-    training = numpy.array([[1.0, 5], [2.0, 27], [3.0, 42]])
-    predictedLabels = numpy.array([[1.0], [2.0], [3.0]])
+    training = np.array([[1.0, 5], [2.0, 27], [3.0, 42]])
+    predictedLabels = np.array([[1.0], [2.0], [3.0]])
 
     trainingObj = nimble.data('Matrix', source=training)
     predictedObj = nimble.data('Matrix', source=predictedLabels)
@@ -427,8 +427,8 @@ def test_computeMetrics_1d_labelsInData():
 
 # multi val, two arg metric
 def test_computeMetrics_2d_2arg():
-    knownLabels = numpy.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])
-    predictedLabels = numpy.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])
+    knownLabels = np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])
+    predictedLabels = np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])
 
     knownLabelsMatrix = nimble.data('Matrix', source=knownLabels)
     predictedLabelsMatrix = nimble.data('Matrix', source=predictedLabels)
@@ -440,8 +440,8 @@ def test_computeMetrics_2d_2arg():
 
 
 def test_computeMetrics_2d_labelsInData():
-    training = numpy.array([[1.0, 5, 1.0], [2.0, 27, 2.0], [3.0, 42, 3.0]])
-    predictedLabels = numpy.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])
+    training = np.array([[1.0, 5, 1.0], [2.0, 27, 2.0], [3.0, 42, 3.0]])
+    predictedLabels = np.array([[1.0, 1.0], [2.0, 2.0], [3.0, 3.0]])
 
     trainingObj = nimble.data('Matrix', source=training)
     predictedObj = nimble.data('Matrix', source=predictedLabels)
@@ -455,8 +455,8 @@ def test_computeMetrics_2d_labelsInData():
 
 # single val, symetric two arg metric (similarity)
 def test_computeMetrics_1d_2d_symmetric():
-    origData = numpy.array([[1.0], [2.0], [3.0]])
-    outputData = numpy.array([[1.0], [2.0], [3.0]])
+    origData = np.array([[1.0], [2.0], [3.0]])
+    outputData = np.array([[1.0], [2.0], [3.0]])
 
     origObj = nimble.data('Matrix', source=origData)
     outObj = nimble.data('Matrix', source=outputData)
@@ -468,8 +468,8 @@ def test_computeMetrics_1d_2d_symmetric():
 # multi metrics should not be allowed
 @raises(TypeError)
 def test_computeMetrics_multiple_metrics_disallowed():
-    origData = numpy.array([[1.0], [2.0], [3.0]])
-    outputData = numpy.array([[1.0], [2.0], [3.0]])
+    origData = np.array([[1.0], [2.0], [3.0]])
+    outputData = np.array([[1.0], [2.0], [3.0]])
 
     origObj = nimble.data('Matrix', source=origData)
     outObj = nimble.data('Matrix', source=outputData)

--- a/tests/testRandom.py
+++ b/tests/testRandom.py
@@ -5,7 +5,7 @@ Tests for the nimble.random submodule
 import random
 import copy
 
-import numpy
+import numpy as np
 import nose
 
 import nimble
@@ -18,7 +18,7 @@ from tests.helpers import oneLogEntryExpected, logCountAssertionFactory
 def testSetRandomSeedExplicit():
     """ Test nimble.random.setSeed yields Nimble accessible random objects with the correct random behavior """
     expPy = random.Random(1333)
-    expNp = numpy.random.RandomState(1333)
+    expNp = np.random.RandomState(1333)
     nimble.random.setSeed(1333)
 
     for i in range(50):
@@ -35,7 +35,7 @@ def testSetRandomSeedNone():
 
     origPy = random.Random()
     origPy.setstate(pyState)
-    origNp = numpy.random.RandomState()
+    origNp = np.random.RandomState()
     origNp.set_state(npState)
 
     nimble.random.setSeed(None)
@@ -152,7 +152,7 @@ def testSparsityReturnedPlausible():
 
                     assert (difference < .01)
                 else:
-                    nonZerosCount = numpy.count_nonzero(returned.copy(to='numpyarray'))
+                    nonZerosCount = np.count_nonzero(returned.copy(to='numpyarray'))
                     actualSparsity = 1.0 - nonZerosCount / float(nPoints * nFeatures)
                     difference = abs(actualSparsity - curSparsity)
 

--- a/tests/testUtility.py
+++ b/tests/testUtility.py
@@ -3,7 +3,7 @@ Tests for nimble._utility submodule
 """
 
 from nose.tools import raises
-import numpy
+import numpy as np
 
 from nimble.exceptions import InvalidArgumentValue
 from nimble.exceptions import InvalidArgumentValueCombination
@@ -35,10 +35,10 @@ def test_DeferredModuleImport_numpy():
     assert numpy == np
     assert numpy != optNumpy
 
-    numpy_arr = numpy.array(arr_data)
-    assert numpy.array_equal(numpy_arr, opt_arr)
+    numpy_arr = np.array(arr_data)
+    assert np.array_equal(numpy_arr, opt_arr)
     assert type(numpy_arr) == type(opt_arr)
-    assert numpy.array_equal(inverse, opt_arr)
+    assert np.array_equal(inverse, opt_arr)
 
 
 def test_DeferredModuleImport_numpy_nimbleAccessibleSuccess():
@@ -49,10 +49,10 @@ def test_DeferredModuleImport_numpy_nimbleAccessibleSuccess():
 
 @raises(AttributeError)
 def test_DeferredModuleImport_numpy_noAccessibleCheck():
-    numpy = DeferredModuleImport('numpy')
+    np = DeferredModuleImport('numpy')
     # random is a valid numpy module but will get an AttributeError since
-    # we never verified numpy is accessible using numpy.nimbleAccessible()
-    numpy.random
+    # we never verified numpy is accessible using np.nimbleAccessible()
+    np.random
 
 
 @raises(AttributeError)
@@ -142,9 +142,9 @@ def test_inspectArguments():
 def test_numpy2DArray_converts1D():
     raw = [1, 2, 3, 4]
     ret = numpy2DArray(raw)
-    fromNumpy = numpy.array(raw)
+    fromNumpy = np.array(raw)
     assert len(ret.shape) == 2
-    assert not numpy.array_equal(ret,fromNumpy)
+    assert not np.array_equal(ret,fromNumpy)
 
 @raises(InvalidArgumentValue)
 def test_numpy2DArray_dimensionException():
@@ -153,17 +153,17 @@ def test_numpy2DArray_dimensionException():
 
 def test_is2DArray():
     raw1D = [1, 2, 3]
-    arr1D = numpy.array(raw1D)
-    mat1D = numpy.matrix(raw1D)
+    arr1D = np.array(raw1D)
+    mat1D = np.matrix(raw1D)
     assert not is2DArray(arr1D)
     assert is2DArray(mat1D)
     raw2D = [[1, 2, 3]]
-    arr2D = numpy.array(raw2D)
-    mat2D = numpy.matrix(raw2D)
+    arr2D = np.array(raw2D)
+    mat2D = np.matrix(raw2D)
     assert is2DArray(arr2D)
     assert is2DArray(mat2D)
     raw3D = [[[1, 2, 3]]]
-    arr3D = numpy.array(raw3D)
+    arr3D = np.array(raw3D)
     assert not is2DArray(arr3D)
 
 def test_setAll():


### PR DESCRIPTION
Changed from `import numpy` to `import numpy as np`.

This change was incentivized by issues related to upgrading `pylint`. Importing as `np` appears to allow `pylint` not to misidentify `numpy` objects. This upgrade identified a few other small fixes that have been addressed in this PR, see below.
```
nimble.core._createHelpers:1717: Comparing against a callable, did you omit the parenthesis? (comparison-with-callable)
nimble.core.data.axis:985: Boolean condition 'not None and not isinstance(name, str)' may be simplified to 'not isinstance(name, str)' (simplifiable-condition)
nimble.core.data.base:1172: Consider using a generator instead 'tuple(point[i] for i in by)' (consider-using-generator)
nimble.match.match:1355: Use a generator instead 'all(val == val for val in matchList)' (use-a-generator)
```

The last small change was to define `DEFAULT_MISSING` in `_createHelpers` to use as the default argument for the `treatAsMissing` parameter. This parameter with the same defaults is present in more than one function so this prevents the need to change the argument default in multiple locations, if the tuple of missing values changes. The tuple, not the variable value, will still show in the documentation as well as in help(nimble.data) and other signature support in IDE's. This also highlighted a bug in certain Sphinx versions where default arguments that are tuples are not wrapped in parenthesis in the documentation signature (this is currently the case in our github pages, see [nimble.data](https://willfind.github.io/nimble/docs/nimble.html#nimble.data). So, `conf.py` was edited to require 3.3 or above. 