### PR TITLE
remove double line feature name trigger for csv

### DIFF
--- a/nimble/core/data/sparse.py
+++ b/nimble/core/data/sparse.py
@@ -284,6 +284,8 @@ class Sparse(Base):
 
             pointer = 0
             pmax = len(self._data.data)
+            # write zero to file as same type as this data
+            zero = self._data.data.dtype.type(0)
             for i in range(len(self.points)):
                 if includePointNames:
                     currPname = csvCommaFormat(self.points.getName(i))
@@ -295,7 +297,7 @@ class Sparse(Base):
                         value = csvCommaFormat(self._data.data[pointer])
                         pointer = pointer + 1
                     else:
-                        value = 0
+                        value = zero
 
                     if j != 0:
                         outFile.write(',')

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -206,6 +206,22 @@ class QueryBackend(DataTestObject):
 
         assert toWrite == orig
 
+    def test_writeFile_CSVhandmade_output(self):
+        # instantiate object
+        data = [[1., 2., 3.], [0., 2., 4.], [0., 0., 0.]]
+        pointNames = ['one', '2', '0']
+        featureNames = ['one', 'two', 'three']
+        toWrite = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
+        orig = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
+
+        # should be no leading blank lines and data values should be floats
+        exp = "pointNames,one,two,three\none,1.0,2.0,3.0\n2,0.0,2.0,4.0\n0,0.0,0.0,0.0\n"
+        with tempfile.NamedTemporaryFile(mode='w+', suffix=".csv") as tmpFile:
+            toWrite.writeFile(tmpFile.name, fileFormat='csv', includeNames=True)
+            tmpFile.seek(0)
+            assert tmpFile.read() == exp
+
+
     def test_writeFile_CSVhandmade_lazyNameGeneration(self):
         # instantiate object
         data = [[1, 2, 3], [1, 2, 3], [2, 4, 6], [0, 0, 0]]


### PR DESCRIPTION
Remove code triggering featureName extraction when a csv file starts with two blank lines. The `writeFile` methods for the concrete types did not make use of this trigger.  `Sparse` could write output differently than other types because it always wrote an integer `0`, but this has been changed to write zero as the same type as the nonzero data.

A new test for `writeFile` tests that the double line trigger is not used and that `0.0` is written to files for float type data.

This also removes a section of code for MTX files that is not necessary. Recent refactors ensure that any `ioStream` object used for MTX files is a bytes object, so it is not possible for any line to be an instance of `str`.