### PR TITLE
sklearn all_estimators new location

### DIFF
--- a/nimble/core/interfaces/scikit_learn_interface.py
+++ b/nimble/core/interfaces/scikit_learn_interface.py
@@ -10,6 +10,7 @@ import warnings
 from unittest import mock
 import pkgutil
 import abc
+import importlib
 
 import numpy as np
 
@@ -337,8 +338,6 @@ class SciKitLearn(_SciKitLearnAPI):
 
     def __init__(self):
         self.skl = modifyImportPathAndImport('sklearn', 'sklearn')
-        testUtils = modifyImportPathAndImport('sklearn',
-                                              'sklearn.utils.testing')
 
         version = self.version()
         epoch, release = version.split('.')[:2]
@@ -348,19 +347,18 @@ class SciKitLearn(_SciKitLearnAPI):
             warnings.warn(msg)
 
         walkPackages = pkgutil.walk_packages
+
         def mockWalkPackages(*args, **kwargs):
             packages = walkPackages(*args, **kwargs)
-            sklAll = self.skl.__all__
             ret = []
+            # ignore anything that imports libraries that are not installed
             # each pkg is a tuple (importer, moduleName, isPackage)
-            # we want to ignore anything not in __all__ and any private
-            # modules to prevent trying to import libraries outside of
-            # scikit-learn dependencies
             for pkg in packages:
-                nameSplit = pkg[1].split('.')
-                allPublic = all(not n.startswith('_') for n in nameSplit)
-                if nameSplit[1] in sklAll and allPublic:
+                try:
+                    _ = importlib.import_module(pkg[1])
                     ret.append(pkg)
+                except ImportError:
+                    pass
 
             return ret
 
@@ -369,11 +367,14 @@ class SciKitLearn(_SciKitLearnAPI):
                                              FutureWarning))
             with mock.patch('pkgutil.walk_packages', mockWalkPackages):
                 try:
-                    kwargs = {'include_dont_test': True}
-                    estimatorDict = testUtils.all_estimators(**kwargs)
-                except TypeError:
-                    # include_dont_test will be removed in later versions
-                    estimatorDict = testUtils.all_estimators()
+                    utils = modifyImportPathAndImport('sklearn',
+                                                      'sklearn.utils')
+                    estimatorDict = utils.all_estimators()
+                except AttributeError: # version < 0.22
+                    utils = modifyImportPathAndImport('sklearn',
+                                                      'sklearn.utils.testing')
+                    estimatorDict = utils.all_estimators(
+                        include_dont_test=True)
 
             self.allEstimators = {}
             for name, obj in estimatorDict:


### PR DESCRIPTION
The `all_estimators` function in `sklearn` was moved from `sklearn.utils.testing` to `sklearn.utils` in version 0.22. The code has been adjusted to search `sklearn.utils` first and fallback on `sklearn.utils.testing` when `all_estimators` is not found. The `include_dont_test` parameter was deprecated in 0.21 and removed in 0.23 so it is not necessary for higher versions.

When the above change was made, `mockWalkPackages` was not able to filter some of the modules that import packages that are not `sklearn` dependencies. This issue arises in `all_estimators` after the call to `walk_packages` while attempting the import. So, a change was made to instead attempt the import of the module within `mockWalkPackages` and ignore it anytime the import fails rather than trying to determine if it is a private module.