### PR TITLE
Style modifications following axis name rework

### DIFF
--- a/nimble/core/data/axis.py
+++ b/nimble/core/data/axis.py
@@ -155,13 +155,6 @@ class Axis(ABC):
 
 
     def _setNames(self, assignments, useLog=None):
-        self._setNamesBackend(assignments)
-
-        handleLogging(useLog, 'prep', '{ax}s.setNames'.format(ax=self._axis),
-                      self._base.getTypeString(), self._sigFunc('setNames'),
-                      assignments)
-
-    def _setNamesBackend(self, assignments):
         if assignments is None:
             self.names = None
             self.namesInverse = None
@@ -210,6 +203,10 @@ class Axis(ABC):
 
         self.names = names
         self.namesInverse = reverseMap
+
+        handleLogging(useLog, 'prep', '{ax}s.setNames'.format(ax=self._axis),
+                      self._base.getTypeString(), self._sigFunc('setNames'),
+                      assignments)
 
     def _getIndex(self, identifier, allowFloats=False):
         num = len(self)

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -254,8 +254,6 @@ class QueryBackend(DataTestObject):
                     setter = exclude.features.setNames
                 count = len(exclude.features)
 
-            # increase the index of the default point name so that it will be
-            # recognizable when we read in from the file.
             axisExclude = getattr(exclude, axis + 's')
 
             with tempfile.NamedTemporaryFile(suffix=".csv") as tmpFile:


### PR DESCRIPTION
Removes now outdated comment, and collapses an unnecessary extra method layer for setNames.