### PR TITLE
Efficiency improvement in _genericStructuralFrontend

### DIFF
--- a/nimble/core/data/axis.py
+++ b/nimble/core/data/axis.py
@@ -1128,8 +1128,9 @@ class Axis(ABC):
                 targetSet = set(targetList)
                 reindexedInverse = []
                 for idx, value in enumerate(self.namesInverse):
-                    if value is not None and idx not in targetSet:
-                        self.names[value] = len(reindexedInverse)
+                    if idx not in targetSet:
+                        if value is not None:
+                            self.names[value] = len(reindexedInverse)
                         reindexedInverse.append(value)
                 self.namesInverse = reindexedInverse
 


### PR DESCRIPTION
Trades a sort, a loop, and n list deletes (each O(n) because of recopying) for a set create, n set look ups, and n list appends.

This ought to be a flat out efficiency increase, but it was not empirically verified. If you have less confidence in this change, we can run the experiment to verify.