### PR TITLE
fix logs showing as default when above level of detail

### DIFF
--- a/nimble/core/data/axis.py
+++ b/nimble/core/data/axis.py
@@ -1127,6 +1127,7 @@ class Axis(ABC):
             if self._namesCreated():
                 targetSet = set(targetList)
                 reindexedInverse = []
+                self.names = {}
                 for idx, value in enumerate(self.namesInverse):
                     if idx not in targetSet:
                         if value is not None:

--- a/tests/logger/testLoggingIO.py
+++ b/tests/logger/testLoggingIO.py
@@ -954,7 +954,7 @@ def testShowLogSearchFilters():
     pathToFile = os.path.join(location, name)
     nimble.showLog(levelOfDetail=3, leastSessionsAgo=0, mostSessionsAgo=5, maximumEntries=100, saveToFileName=pathToFile)
     fullShowLogSize = os.path.getsize(pathToFile)
-    # nimble.showLog(levelOfDetail=3, leastSessionsAgo=0, mostSessionsAgo=5, maximumEntries=100)
+
     # level of detail
     nimble.showLog(levelOfDetail=3, saveToFileName=pathToFile)
     mostDetailedSize = os.path.getsize(pathToFile)
@@ -962,10 +962,26 @@ def testShowLogSearchFilters():
     nimble.showLog(levelOfDetail=2, saveToFileName=pathToFile)
     lessDetailedSize = os.path.getsize(pathToFile)
     assert lessDetailedSize < mostDetailedSize
+    # logs above level 2 should not be present in formatted or default form
+    with open(pathToFile) as f:
+        output = f.read()
+        assert 'runCV' not in output
+        assert 'KFoldCrossValidation' not in output
 
     nimble.showLog(levelOfDetail=1, saveToFileName=pathToFile)
     leastDetailedSize = os.path.getsize(pathToFile)
     assert leastDetailedSize < lessDetailedSize
+    # logs above level 1 should not be present in formatted or default form
+    with open(pathToFile) as f:
+        output = f.read()
+        assert 'prep' not in output
+        assert 'features.extract ' not in output
+        assert 'runCV' not in output
+        assert 'KFoldCrossValidation' not in output
+        assert 'crossVal' not in output
+        assert 'Cross Validating' not in output
+        assert 'run' not in output
+        assert 'trainAndTest' not in output
 
     # sessionNumber
     nimble.showLog(levelOfDetail=3, mostSessionsAgo=4, saveToFileName=pathToFile)


### PR DESCRIPTION
Log entries that were above the specified `levelOfDetail` were being added to the `showLog` output using the default formatting. This was occurring because the logic would not apply the formatting if the level of detail was not met, but always added each log to the entry. Instead, the logs should not be added when the `levelOfDetail` is too low.

Simplified the code by using a dictionary to store the string building function and the level of detail necessary base of the `logType`. Now, the only time the default formatting will be used is for an unidentified `logType` or if an error occurs when trying to log an identified `logType`.

There was also a bug from PR #360 where the axis `names` attribute was not being reset before adding the appropriate names after a structural change.