### PR TITLE
raise ZeroDivisionError for DataFrame with latest pandas versions

### DIFF
--- a/nimble/core/data/dataframe.py
+++ b/nimble/core/data/dataframe.py
@@ -487,9 +487,11 @@ class DataFrame(Base):
             else:
                 dtypes.append(useType)
 
-        # rhs may return array of sparse matrices so use default
-        if not (isinstance(other, nimble.core.data.Sparse)
-                and opName.startswith('__r')):
+        # pow operations for DataFrame do not raise expected ZeroDivisionErrors
+        # and rhs Sparse may return array of sparse matrices, so use default
+        if not ((isinstance(other, DataFrame) and 'pow' in opName)
+                or (isinstance(other, nimble.core.data.Sparse)
+                    and (opName.startswith('__r')))):
             try:
                 array = self._asNumpyArray(numericRequired=True)
                 values = getattr(array, opName)(other._data)


### PR DESCRIPTION
Pandas implements `np.errstate` and it appears that in the latest pandas versions its power operations are overriding any use of `np.errstate` in nimble. For the nimble `DataFrame`, it is necessary to bypass using pandas for power operations and instead use the default implementation that uses numpy so that the expected `ZeroDivisionError` will still be raised.