### PR TITLE
No infinite loop when reading file with no data

### DIFF
--- a/nimble/core/_createHelpers.py
+++ b/nimble/core/_createHelpers.py
@@ -1870,8 +1870,10 @@ def _advancePastComments(ioStream):
     numSkipped = 0
     while True:
         startPosition = ioStream.tell()
-        row = ioStream.readline() # empty row indicates end of file
-        if not row or row[0] not in ['#', '\n']:
+        row = ioStream.readline()
+        if not row: # empty row indicates end of file
+            raise FileFormatException('No data found in file')
+        if row[0] not in ['#', '\n']:
             ioStream.seek(startPosition)
             break
 
@@ -1911,11 +1913,8 @@ def _detectDialectFromSeparator(ioStream, inputSeparator):
     # skip commented lines
     _ = _advancePastComments(ioStream)
     if inputSeparator == 'automatic':
-        firstLine = ioStream.readline()
-        if firstLine:
-            dialect = csv.Sniffer().sniff(firstLine)
-        else: # no data in file, use default dialect
-            dialect = None
+        # detect the delimiter from the first line of data
+        dialect = csv.Sniffer().sniff(ioStream.readline())
     elif len(inputSeparator) > 1:
         msg = "inputSeparator must be a single character"
         raise InvalidArgumentValue(msg)

--- a/tests/testData.py
+++ b/tests/testData.py
@@ -519,6 +519,30 @@ def test_data_CSV_data_ListOnly_noComment():
 
         assert fromList == fromCSV
 
+def test_data_CSV_emptyFile():
+    """ Test of data() loading a csv file, default params """
+    for t in returnTypes:
+        fromList = nimble.data(returnType=t, source=[[1, 2, 3]])
+
+        # instantiate from csv file
+        with tempfile.NamedTemporaryFile(suffix=".csv", mode='w') as tmpCSV:
+            tmpCSV.write("")
+            tmpCSV.flush()
+            objName = 'fromCSV'
+            with raises(FileFormatException, match='No data found in file'):
+                fromCSV = nimble.data(returnType=t, source=tmpCSV.name)
+
+def test_data_CSV_openToEndOfFile():
+    """ Test of data() loading a csv file, default params """
+    for t in returnTypes:
+        fromList = nimble.data(returnType=t, source=[[1, 2, 3]])
+
+        # instantiate from csv file
+        with tempfile.NamedTemporaryFile(suffix=".csv", mode='w+') as tmpCSV:
+            tmpCSV.write("1,2,3\n")
+            with raises(FileFormatException, match='No data found in file'):
+                fromCSV = nimble.data(returnType=t, source=tmpCSV)
+
 def test_data_CSV_data_unicodeCharacters():
     """ Test of data() loading a csv file with unicode characters """
     for t in returnTypes:


### PR DESCRIPTION
If an open file is empty or open to the end of the file, the `_advancePastComments` helper will get stuck in an infinite loop. This is because `readline()` will continue to output `''` when the end of a file is reached. So the loop should exit when an empty string is encountered. If the loop exits because there is no data, then a `FileFormatException` is raised.