### PR TITLE
File containing dependency requirements

### DIFF
--- a/documentation/source/install.rst
+++ b/documentation/source/install.rst
@@ -2,12 +2,13 @@ Installation
 ============
 
 Nimble can be installed in a variety of ways and strives for flexibility
-during the install process. The only install dependency is `NumPy`_  but much
-of Nimble's functionality is provided through third-party
-:ref:`optional-packages`. This ensures that Nimble does not install additional
-packages that will not be used, but Nimble's functionality is very limited with
-only NumPy installed. For this reason, we offer many ways to install optional
-packages while installing Nimble. We recommend the :ref:`quickstart-install`
+during the install process. To avoid requiring packages that may never be used,
+Nimble only has only two required dependencies, `Numpy`_ and `packaging`_.
+`NumPy`, provides access to a limited portion of the API and additional
+functionality is accessed by installing third-party :ref:`optional-packages`.
+The `packaging` dependency is used to validate the installed versions of any
+optional packages. For convenience, installing optional packages can also be
+triggered while installing Nimble. We recommend the :ref:`quickstart-install`
 to make much of Nimble's functionality available with a single install.
 
 Install Methods
@@ -64,20 +65,20 @@ Machine-Learning Interfaces
    :align: left
    :widths: auto
 
-   +------------------------+--------------------------------------------------+------+----------------------------+
-   | Package                | Provides                                         | pip  | conda                      |
-   +========================+==================================================+======+============================+
-   | `scikit-learn`_        | Machine Learning.                                | |cm| | |cm|                       |
-   +------------------------+--------------------------------------------------+------+----------------------------+
-   | `tensorflow`_/         | Neural Networks.                                 | |cm| | |cm|                       |
-   | `keras`_               | See :ref:`install note <tensorflow-note>` below. |      |                            |
-   +------------------------+--------------------------------------------------+------+----------------------------+
-   | `autoimpute`_          | Imputation. Machine Learning with missing data.  | |cm| |                            |
-   +------------------------+--------------------------------------------------+------+----------------------------+
-   | `shogun`_              | Machine Learning.                                |      | |cm| (conda-forge channel) |
-   +------------------------+--------------------------------------------------+------+----------------------------+
-   | `machine-learning-py`_ | Machine Learning.                                | |cm| | |cm| (conda-forge channel) |
-   +------------------------+--------------------------------------------------+------+----------------------------+
+   +----------------+--------------------------------------------------+------+----------------------------+
+   | Package        | Provides                                         | pip  | conda                      |
+   +================+==================================================+======+============================+
+   | `sklearn`_     | Machine Learning.                                | |cm| | |cm|                       |
+   +----------------+--------------------------------------------------+------+----------------------------+
+   | `tensorflow`_/ | Neural Networks.                                 | |cm| | |cm|                       |
+   | `keras`_       | See :ref:`install note <tensorflow-note>` below. |      |                            |
+   +----------------+--------------------------------------------------+------+----------------------------+
+   | `autoimpute`_  | Imputation. Machine Learning with missing data.  | |cm| |                            |
+   +----------------+--------------------------------------------------+------+----------------------------+
+   | `shogun`_      | Machine Learning.                                |      | |cm| (conda-forge channel) |
+   +----------------+--------------------------------------------------+------+----------------------------+
+   | `mlpy`_        | Machine Learning.                                | |cm| | |cm| (conda-forge channel) |
+   +----------------+--------------------------------------------------+------+----------------------------+
 
 .. _tensorflow-note:
 
@@ -145,13 +146,16 @@ install.
 
 .. code-block::
 
-  pip install nimble[dateutil]                         # single extra
+  pip install nimble[dateutil]                    # single extra
     or
-  pip install nimble[requests,matplotlib,scikit-learn] # multiple extras
+  pip install nimble[requests,matplotlib,sklearn] # multiple extras
     or
-  pip install nimble[data]                             # shortcut (scipy and pandas)
+  pip install nimble[data]                        # shortcut (scipy and pandas)
 
 .. note::
+   - The names of the extras match the names displayed in the "Package" columns
+     in :ref:`optional-packages`.
+
    - The brackets may need to be escaped in some shells.
 
 **With conda:**
@@ -164,6 +168,12 @@ available channels.
 .. code-block::
 
   conda install -c nimble-data nimble matplotlib scikit-learn
+
+.. note::
+   - The package names used for the installation do not always match the
+     names displayed in the "Package" columns in :ref:`optional-packages`,
+     for example, "scikit-learn" is used to install the ``sklearn`` package and
+     "python-dateutil" is used to install the ``dateutil`` package.
 
 .. _basic-install:
 
@@ -191,6 +201,7 @@ operations requiring an optional package that is not installed.
 .. |cm| unicode:: U+02713 .. check mark
 
 .. _NumPy: https://numpy.org/
+.. _packaging: https://packaging.pypa.io/
 .. _datetime: https://docs.python.org/3/library/datetime.html
 .. _scipy: https://www.scipy.org/install.html
 .. _pandas: https://pandas.pydata.org/pandas-docs/stable/getting_started/install.html
@@ -199,9 +210,9 @@ operations requiring an optional package that is not installed.
 .. _cloudpickle: https://github.com/cloudpipe/cloudpickle
 .. _dateutil: https://dateutil.readthedocs.io/en/stable/
 .. _h5py: https://docs.h5py.org/en/stable/build.html
-.. _scikit-learn: https://scikit-learn.org/stable/install.html
+.. _sklearn: https://scikit-learn.org/stable/install.html
 .. _tensorflow: https://www.tensorflow.org/install
 .. _autoimpute: https://autoimpute.readthedocs.io/en/latest/user_guide/getting_started.html
 .. _shogun: https://www.shogun.ml/install
 .. _keras: https://keras.io/getting_started/
-.. _machine-learning-py: https://github.com/richardARPANET/mlpy
+.. _mlpy: https://github.com/richardARPANET/mlpy

--- a/nimble/_dependencies.py
+++ b/nimble/_dependencies.py
@@ -1,0 +1,77 @@
+"""
+Store dependency versions requirements.
+
+Also includes helpers for validating optional dependency versions at
+runtime.
+"""
+from packaging.requirements import Requirement
+from packaging.version import Version, LegacyVersion, InvalidVersion
+from packaging.specifiers import LegacySpecifier
+
+from nimble.exceptions import PackageException
+
+DEPENDENCIES = {
+    'required': {
+        'numpy': 'numpy>=1.14',
+        'packaging': 'packaging>=20.0'
+    },
+    'data': {
+        'pandas': 'pandas>=0.24',
+        'scipy': 'scipy>=1.1'
+    },
+    'operation': {
+        'matplotlib': 'matplotlib>=3.1',
+        'cloudpickle': 'cloudpickle>=1.0',
+        'requests': 'requests>2.12',
+        'h5py': 'h5py>=2.10',
+        'dateutil': 'python-dateutil>=2.6'
+    },
+    'interfaces': {
+        'sklearn': 'scikit-learn>=0.19',
+        'tensorflow': 'tensorflow>=1.14',
+        'keras': 'keras>=2.0',
+        'autoimpute': 'autoimpute>=0.12',
+        'shogun': 'shogun>=3',
+        'mlpy': 'machine-learning-py>=3.5;python_version<"3.7"'
+    },
+    'development': {
+        'pytest': 'pytest>=2.7.4',
+        'pylint': 'pylint>=6.2',
+        'cython': 'cython>=0.29',
+        'sphinx': 'sphinx>=3.3'
+    }
+}
+
+_LOCATIONS = {}
+for key1, value in DEPENDENCIES.items():
+    for key2 in value:
+        _LOCATIONS[key2] = key1
+
+def checkVersion(package):
+    """
+    Compare the package requirements to the available version.
+
+    Generally, the package name and version and can be extracted from
+    the package, but when that is not the case or the extracted value
+    does not align with DEPENDENCIES, then alternate values can be
+    provided.
+    """
+    version = package.__version__
+    try:
+        vers = Version(version)
+        legacy = False
+    except InvalidVersion:
+        vers = LegacyVersion(version)
+        legacy = True
+    name = package.__name__
+    location = _LOCATIONS[name]
+    requirement = DEPENDENCIES[location][name]
+    req = Requirement(requirement)
+    for specifier in req.specifier:
+        # when vers is a LegacyVersion, need specifiers to be LegacySpecifier
+        if legacy and not isinstance(specifier, LegacySpecifier):
+            specifier = LegacySpecifier(str(specifier))
+        if not specifier.contains(vers):
+            msg = 'The installed version of {0} ({1}) does not meet the '
+            msg += 'version requirements: {2}'
+            raise PackageException(msg.format(req.name, vers, requirement))

--- a/nimble/core/_learnHelpers.py
+++ b/nimble/core/_learnHelpers.py
@@ -13,6 +13,7 @@ import numpy as np
 import nimble
 from nimble.exceptions import InvalidArgumentValue, InvalidArgumentType
 from nimble.exceptions import InvalidArgumentValueCombination
+from nimble.exceptions import PackageException
 from nimble.core.data import Base
 from nimble.random import pythonRandom
 from nimble.random import numpyRandom
@@ -38,7 +39,9 @@ def findBestInterface(package):
         if interface.isAlias(package):
             try:
                 interfaceObj = interface()
-            except Exception: # pylint: disable=broad-except
+            except Exception as e: # pylint: disable=broad-except
+                if isinstance(e, PackageException):
+                    raise # interface version does not meet requirements
                 # interface is a predefined one, but instantiation failed
                 return interface.provideInitExceptionInfo()
             # add successful instantiations to interfaces.available and

--- a/nimble/core/interfaces/_collect_interfaces.py
+++ b/nimble/core/interfaces/_collect_interfaces.py
@@ -6,7 +6,7 @@ import os
 import importlib
 
 import nimble
-from .universal_interface import PredefinedInterface
+from .universal_interface import PredefinedInterfaceMixin
 from .custom_learner import CustomLearnerInterface
 
 
@@ -28,17 +28,17 @@ def initInterfaceSetup():
         if extension == 'py' and not name.startswith('_'):
             pythonModules.append(name)
     # setup seen with the interfaces we know we don't want to load/try to load
-    seen = set(["PredefinedInterface"])
+    seen = set(["PredefinedInterfaceMixin"])
     for toImport in pythonModules:
         importedModule = importlib.import_module('.' + toImport, __package__)
         contents = dir(importedModule)
 
         # for each attribute of the module, we will check to see if it is a
-        # subclass of the PredefinedInterface
+        # subclass of the PredefinedInterfaceMixin
         for valueName in contents:
             value = getattr(importedModule, valueName)
             try:
-                if (issubclass(value, PredefinedInterface)
+                if (issubclass(value, PredefinedInterfaceMixin)
                         and not valueName in seen
                         and not valueName.startswith('_')):
                     seen.add(valueName)

--- a/nimble/core/interfaces/autoimpute_interface.py
+++ b/nimble/core/interfaces/autoimpute_interface.py
@@ -31,7 +31,7 @@ class Autoimpute(_SciKitLearnAPI):
         """
 
         """
-        self.autoimpute = modifyImportPathAndImport('autoimpute', 'autoimpute')
+        self.package = modifyImportPathAndImport('autoimpute', 'autoimpute')
 
         def isLearner(obj):
             try:
@@ -49,7 +49,7 @@ class Autoimpute(_SciKitLearnAPI):
 
             return hasPred or hasTrans or hasFitPred or hasFitTrans
 
-        self._searcher = PythonSearcher(self.autoimpute, isLearner, 1)
+        self._searcher = PythonSearcher(self.package, isLearner, 1)
 
         super().__init__('seed')
 
@@ -86,9 +86,9 @@ To install autoimpute
 
     def learnerType(self, name):
         obj = self.findCallable(name)
-        if issubclass(obj, self.autoimpute.imputations.BaseImputer):
+        if issubclass(obj, self.package.imputations.BaseImputer):
             return 'transformation'
-        if issubclass(obj, self.autoimpute.analysis.MiBaseRegressor):
+        if issubclass(obj, self.package.analysis.MiBaseRegressor):
             if 'LogisticRegression' in name:
                 return 'classification'
             return 'regression'
@@ -169,7 +169,7 @@ To install autoimpute
         learner = self.findCallable(learnerName)(**initParams)
 
         # need to enforce strategy as a required parameter for the imputer
-        if (isinstance(learner, self.autoimpute.imputations.BaseImputer)
+        if (isinstance(learner, self.package.imputations.BaseImputer)
                 and 'strategy' not in initParams):
             strategies = list(learner.strategies.keys())
             msg = "Due to the level of complexity of {learnerName}'s default "
@@ -179,7 +179,7 @@ To install autoimpute
             raise InvalidArgumentValue(msg)
         # for regressors, also need to check that MultipleImputer strategy is
         # defined if the user did not provide a MultipleImputer directly
-        if (isinstance(learner, self.autoimpute.analysis.MiBaseRegressor)
+        if (isinstance(learner, self.package.analysis.MiBaseRegressor)
                 and ('mi' not in initParams or initParams['mi'] is None)
                 and ('mi_kwgs' not in initParams
                      or 'strategy' not in initParams['mi_kwgs'])):
@@ -222,9 +222,6 @@ To install autoimpute
             learner.fit(*fitArgs, **fitKwargs)
         except ValueError as e:
             raise InvalidArgumentValue(str(e)) from e
-
-    def version(self):
-        return self.autoimpute.__version__
 
     def _argumentInit(self, toInit):
         # override universal method to require strategy param for imputers

--- a/nimble/core/interfaces/mlpy_interface.py
+++ b/nimble/core/interfaces/mlpy_interface.py
@@ -13,7 +13,7 @@ import nimble
 from nimble.exceptions import InvalidArgumentValue
 from nimble._utility import inspectArguments
 from nimble._utility import inheritDocstringsFactory, dtypeConvert
-from .universal_interface import PredefinedInterface
+from .universal_interface import PredefinedInterfaceMixin
 from ._interface_helpers import PythonSearcher
 from ._interface_helpers import modifyImportPathAndImport
 from ._interface_helpers import removeFromTailMatchedLists
@@ -21,8 +21,8 @@ from ._interface_helpers import validInitParams
 from . import _mlpy_patches
 
 
-@inheritDocstringsFactory(PredefinedInterface)
-class Mlpy(PredefinedInterface):
+@inheritDocstringsFactory(PredefinedInterfaceMixin)
+class Mlpy(PredefinedInterfaceMixin):
     """
     This class is an interface to mlpy.
     """
@@ -33,8 +33,7 @@ class Mlpy(PredefinedInterface):
 
     def __init__(self):
         # modify path if another directory provided
-
-        self.mlpy = modifyImportPathAndImport('mlpy', 'mlpy')
+        self.package = modifyImportPathAndImport('mlpy', 'mlpy')
 
         def isLearner(obj):
             hasLearn = hasattr(obj, 'learn')
@@ -45,7 +44,7 @@ class Mlpy(PredefinedInterface):
                 return True
             return False
 
-        self._searcher = PythonSearcher(self.mlpy, isLearner, 1)
+        self._searcher = PythonSearcher(self.package, isLearner, 1)
 
         super().__init__()
 
@@ -229,7 +228,7 @@ To install mlpy
             if arg == 'kernel':
                 validate = val is None
 
-                if isinstance(val, self.mlpy.KernelExponential):
+                if isinstance(val, self.package.KernelExponential):
                     msg = "This interface disallows KernelExponential; "
                     msg = "it is bugged in some versions of mlpy"
                     raise InvalidArgumentValue(msg)
@@ -338,10 +337,6 @@ To install mlpy
 
     def _configurableOptionNames(self):
         return ['location']
-
-
-    def version(self):
-        return self.mlpy.__version__
 
 
     def _pred(self, learner, testX, arguments, customDict):

--- a/nimble/core/interfaces/scikit_learn_interface.py
+++ b/nimble/core/interfaces/scikit_learn_interface.py
@@ -18,7 +18,7 @@ import nimble
 from nimble.exceptions import InvalidArgumentValue, ImproperObjectAction
 from nimble._utility import inspectArguments
 from nimble._utility import inheritDocstringsFactory, dtypeConvert
-from .universal_interface import PredefinedInterface
+from .universal_interface import PredefinedInterfaceMixin
 from ._interface_helpers import modifyImportPathAndImport
 from ._interface_helpers import collectAttributes
 from ._interface_helpers import removeFromTailMatchedLists
@@ -26,8 +26,8 @@ from ._interface_helpers import noLeading__, notCallable, notABCAssociated
 from ._interface_helpers import validInitParams
 
 
-@inheritDocstringsFactory(PredefinedInterface)
-class _SciKitLearnAPI(PredefinedInterface):
+@inheritDocstringsFactory(PredefinedInterfaceMixin)
+class _SciKitLearnAPI(PredefinedInterfaceMixin):
     """
     Base class for interfaces following the scikit-learn api.
     """
@@ -326,10 +326,6 @@ class _SciKitLearnAPI(PredefinedInterface):
     def _fitLearner(self, learner, learnerName, trainX, trainY, arguments):
         pass
 
-    @abc.abstractmethod
-    def version(self):
-        pass
-
 @inheritDocstringsFactory(_SciKitLearnAPI)
 class SciKitLearn(_SciKitLearnAPI):
     """
@@ -337,14 +333,7 @@ class SciKitLearn(_SciKitLearnAPI):
     """
 
     def __init__(self):
-        self.skl = modifyImportPathAndImport('sklearn', 'sklearn')
-
-        version = self.version()
-        epoch, release = version.split('.')[:2]
-        if int(epoch) == 0 and int(release) < 19:
-            msg = "nimble was tested using sklearn 0.19 and above, we cannot "
-            msg += "be sure of success for version {0}".format(version)
-            warnings.warn(msg)
+        self.package = modifyImportPathAndImport('sklearn', 'sklearn')
 
         walkPackages = pkgutil.walk_packages
 
@@ -452,13 +441,13 @@ To install scikit-learn
 
     def learnerType(self, name):
         obj = self.findCallable(name)
-        if issubclass(obj, self.skl.base.ClassifierMixin):
+        if issubclass(obj, self.package.base.ClassifierMixin):
             return 'classification'
-        if issubclass(obj, self.skl.base.RegressorMixin):
+        if issubclass(obj, self.package.base.RegressorMixin):
             return 'regression'
-        if issubclass(obj, self.skl.base.ClusterMixin):
+        if issubclass(obj, self.package.base.ClusterMixin):
             return 'cluster'
-        if issubclass(obj, self.skl.base.TransformerMixin):
+        if issubclass(obj, self.package.base.TransformerMixin):
             return 'transformation'
         # if (hasattr(obj, 'classes_') or hasattr(obj, 'label_')
         #         or hasattr(obj, 'labels_')):
@@ -574,4 +563,4 @@ To install scikit-learn
             raise InvalidArgumentValue(str(e)) from e
 
     def version(self):
-        return self.skl.__version__
+        return self.package.__version__

--- a/nimble/core/interfaces/universal_interface.py
+++ b/nimble/core/interfaces/universal_interface.py
@@ -24,6 +24,7 @@ from nimble._utility import cloudpickle
 from nimble._utility import mergeArguments
 from nimble._utility import prettyListString
 from nimble._utility import prettyDictString
+from nimble._dependencies import checkVersion
 from nimble.core.logger import handleLogging
 from nimble.core.configuration import configErrors
 from nimble.core._learnHelpers import computeMetrics
@@ -1770,9 +1771,9 @@ class TrainedLearners(TrainedLearner):
         raise ImproperObjectAction('Wrong multiclassification method.')
 
 
-#######################
-# PredefinedInterface #
-#######################
+############################
+# PredefinedInterfaceMixin #
+############################
 
 pathMessage = """
 If {name} installed
@@ -1789,7 +1790,7 @@ def _formatPathMessage(name):
     return pathMessage.format(name=name, underline=underline)
 
 @inheritDocstringsFactory(UniversalInterface)
-class PredefinedInterface(UniversalInterface):
+class PredefinedInterfaceMixin(UniversalInterface):
     """
     Interfaces to third party packages.
 
@@ -1814,6 +1815,8 @@ class PredefinedInterface(UniversalInterface):
             # call _optionDefaults to make sure it doesn't throw an exception
             self._optionDefaults(optionName)
 
+        self._checkVersion()
+
     @classmethod
     @abc.abstractmethod
     def getCanonicalName(cls):
@@ -1822,6 +1825,12 @@ class PredefinedInterface(UniversalInterface):
     @classmethod
     def isAlias(cls, name):
         return name.lower() == cls.getCanonicalName().lower()
+
+    def _checkVersion(self):
+        checkVersion(self.package)
+
+    def version(self):
+        return self.package.__version__
 
     @classmethod
     def provideInitExceptionInfo(cls):

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,8 @@ try:
 except ImportError:
     CYTHON_AVAILABLE = False
 
+from nimble._dependencies import DEPENDENCIES
+
 def getCFiles():
     return glob.glob(os.path.join('nimble', '**', '*.c'), recursive=True)
 
@@ -162,51 +164,43 @@ def run_setup():
     setupKwargs['description'] = "Interfaces and tools for data science."
     setupKwargs['url'] = "https://nimbledata.org"
     setupKwargs['packages'] = find_packages(exclude=('tests', 'tests.*'))
-    setupKwargs['python_requires'] = '>=3.4'
+    setupKwargs['python_requires'] = '>=3.6'
     setupKwargs['classifiers'] = [
         'Development Status :: 3 - Alpha',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Operating System :: OS Independent',
         ]
 
     setupKwargs['include_package_data'] = True
     setupKwargs['convert_2to3_doctests'] = []
-    setupKwargs['install_requires'] = ['numpy>=1.14']
+
+    setupKwargs['install_requires'] = list(DEPENDENCIES['required'].values())
     # extras
-    pandas = 'pandas>=0.24'
-    scipy = 'scipy>=1.1'
-    matplotlib = 'matplotlib>=3.1'
-    cloudpickle = 'cloudpickle>=1.0'
-    requests = 'requests>2.12'
-    h5py = 'h5py>=2.10'
-    dateutil = 'python-dateutil>=2.6'
-    scikitlearn = 'scikit-learn>=0.19'
-    tensorflow = 'tensorflow>=1.14'
-    keras = 'keras>=2.0'
-    autoimpute = 'autoimpute>=0.12'
-    mlpy = 'machine-learning-py>=3.5;python_version<"3.7"'
-    pylint = 'pylint>=2.7.4'
-    pytest = 'pytest>=6.2'
-    cython = 'cython>=0.29'
-    sphinx = 'sphinx>=3.3'
-    data = [pandas, scipy]
-    operation = [matplotlib, cloudpickle, requests, h5py, dateutil]
-    interfaces = [scikitlearn, tensorflow, autoimpute, mlpy]
-    quickstart = data + operation + [scikitlearn]
-    userAll = data + operation + interfaces
-    development = [pytest, pylint, cython, sphinx]
+    data = DEPENDENCIES['data']
+    operation = DEPENDENCIES['operation']
+    interfaces = DEPENDENCIES['interfaces']
+    development = DEPENDENCIES['development']
+
     setupKwargs['extras_require'] = {
-        'quickstart': quickstart, 'all': userAll, 'data': data,
-        'pandas': pandas, 'scipy': scipy, 'matplotlib': matplotlib,
-        'cloudpickle': cloudpickle, 'requests': requests, 'h5py': h5py,
-        'dateutil': dateutil, 'machine-learning-py': mlpy,
-        'scikit-learn': scikitlearn, 'keras': keras, 'tensorflow': tensorflow,
-        'autoimpute': autoimpute, 'development': development, 'pylint': pylint,
-        'pylint': pylint, 'cython': cython, 'sphinx': sphinx,
+        'data': list(data.values()), 'development': list(development.values()),
         }
+    setupKwargs['extras_require'].update(data)
+    setupKwargs['extras_require'].update(operation)
+    setupKwargs['extras_require'].update(interfaces)
+    setupKwargs['extras_require'].update(development)
+
+    quickstart = list(data.values()) + list(operation.values())
+    userAll = quickstart.copy()
+    quickstart.append(interfaces['sklearn'])
+    del interfaces['keras'] # tensorflow includes keras
+    userAll.extend(interfaces.values())
+
+    setupKwargs['extras_require']['quickstart'] = quickstart
+    setupKwargs['extras_require']['all'] = userAll
 
     # TODO
     # determine best version requirements for install_requires, extras_require


### PR DESCRIPTION
The file, _dependencies.py, is accessible to setup.py and for validation of optional dependency versions.

The file contains a dictionary, `DEPENDENCIES` storing version requirements for each dependency. `DEPENDENCIES` is designed to support the extras in setup.py, so there is also a helper dictionary `_LOCATIONS` to identify the key in `DEPENDENCIES` that contains the package. This helper is used by the `checkVersion` function, that verifies that the user installed version of any optional dependencies meet our tested requirements. This check is applied to all optional packages and a `PackageException` is raised if an invalid version is found. 

The individually named attributes (`self.skl`, `self.keras`, etc.) storing the module object in each interface was changed to an attribute named 'package'. This allows for `PredefinedInterfaceMixin` (renamed from `PredefinedInterface` to trigger `pylint` not to issue certain warnings) to better abstract methods, like `version`, from the individual interfaces.