### PR TITLE
typo fixes in examples

### DIFF
--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -8,6 +8,7 @@ PAPER         =
 BUILDDIR      = ./
 PUBLISHDIR    = ../
 EXAMPLESDIR   = ./source/examples/
+SOURCEDIR     = ./source/
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
@@ -89,6 +90,7 @@ clean:
 	rm -fr $(PUBLISHDIR)/_images
 	rm -fr $(PUBLISHDIR)/examples
 	rm -fr $(PUBLISHDIR)/docs
+	rm -fr $(SOURCEDIR)/docs/generated
 	rm -fr $(EXAMPLESDIR)/logs-nimble
 	rm -fr $(EXAMPLESDIR)/*.ipynb
 	rm -f $(EXAMPLESDIR)/Metro_Interstate_Traffic_Volume_Cleaned.csv

--- a/documentation/source/examples/additional_functionality.py
+++ b/documentation/source/examples/additional_functionality.py
@@ -192,7 +192,7 @@ uncontrolled.show('uncontrolled randomness sample')
 ## will be the room that we predict.
 
 ## We will be creating a learner named `LeastFeatureMeanDistance` that
-## classifies points by measuring the euclidean distance to the feature means
+## classifies points by measuring the Euclidean distance to the feature means
 ## for each label and selecting the label where the distance is minimized. To
 ## create our own custom machine learning algorithm for Nimble, we inherit from
 ## `nimble.CustomLearner`. Every `CustomLearner` must minimally define a
@@ -202,12 +202,12 @@ uncontrolled.show('uncontrolled randomness sample')
 ## data to learn a relationship that can be applied to other data. For our
 ## learner, the `train` method groups our data based on label and calculates
 ## the feature means for data with the same label. It uses a dictionary to
-## store the feature means that we "learn" from our training data so that they
-## can be used for `apply`. The `apply` method uses the information learned
-## from training to make predictions on new (unseen) data. For `apply` in our
-## learner, we compare the euclidean distance between a point and each label's
-## feature means (learned in `train`) and predict the label with the shortest
-## distance.
+## store the mean of each feature that we "learn" from our training data so
+## that they can be used for `apply`. The `apply` method uses the information
+## learned from training to make predictions on new (unseen) data. For `apply`
+## in our learner, we compare the Euclidean distance between a point and each
+## label's feature means (learned in `train`) and predict the label with the
+## shortest distance.
 class LeastFeatureMeanDistance(nimble.CustomLearner):
     learnerType = 'classification'
 
@@ -294,13 +294,13 @@ def roomIdentifier(pt):
     return (actualRoom, closestCenter)
 
 rTrainY = rTrainX.points.calculate(roomIdentifier, useLog=False)
-# extract 25% of our raondom data (first 500 points) for testing.
+# extract 25% of our random data (first 500 points) for testing.
 rTestX = rTrainX.points.extract(number=500, useLog=False)
 rTestY = rTrainY.points.extract(number=500, useLog=False)
 
 # Expected accuracy is the number of points in the test labels where the
 # actual room (index 0) is the same as the closest center room (index 1)
-# divided by total number of test labels.
+# divided by the total number of test labels.
 expAcc = rTestY.points.count(lambda pt: pt[0] == pt[1]) / len(rTestY.points)
 print('LeastFeatureMeanDistance test expected accuracy', expAcc)
 
@@ -343,7 +343,7 @@ print('LeastFeatureMeanDistance accuracy:', performance)
 ## multiple points of comparison which could help improve prediction accuracy
 ## for points near other rooms. However, we usually do not know the best value
 ## for `k` (the number of nearest neighbors) so we will cross validate for
-## three different values of `k`. Logging has another configurable option name
+## three different values of `k`. Logging has another configurable option named
 ## "enableCrossValidationDeepLogging". By default it is set to "False" because
 ## logging cross validation can increase the size of the log file much more
 ## quickly. However, we can learn a lot of useful information from these cross
@@ -352,7 +352,7 @@ print('LeastFeatureMeanDistance accuracy:', performance)
 nimble.settings.set('logger', 'enableCrossValidationDeepLogging', 'True')
 
 ## Enabling deep logging for cross-validation, will generate log entries for
-## each fold during our k-fold cross validation. Below `trainAndTest` with
+## each fold during our k-fold cross validation. Below, `trainAndTest` with
 ## `folds=3` and `k=nimble.CV([3, 5, 7])` will perform 3-fold cross validation
 ## on each of our 3 `k` values and use the `k` value that performed the best
 ## during cross validation.
@@ -399,7 +399,7 @@ nimble.showLog(searchForText='wifiData')
 ## logging, randomness and custom learners add a lot of helpful functionality.
 ## We expect you’ll find yourself using some or all of it to support your data
 ## science work. That wraps it up for this example, so now is a good time to
-## cleanup the temporary directory containing our log file.
+## clean up the temporary directory containing our log file.
 tempDir.cleanup()
 
 ## **References:**

--- a/documentation/source/examples/merging_and_tidying_data.py
+++ b/documentation/source/examples/merging_and_tidying_data.py
@@ -78,8 +78,8 @@ dwtnMinAM.show('Downtown data merged on date', maxWidth=120, maxHeight=9)
 ## objects with different extremes (min vs. max) for the same location.
 ## Before combining, we will want to add an “extreme” feature to each object
 ## based on whether it contains min vs. max data. Without this step, we would
-## not be able to different between minimum and maximum temperature points in
-## the combined objects. Once our new feature is added, we can `append` our
+## not be able to differentiate between minimum and maximum temperature points
+## in the combined objects. Once our new feature is added, we can `append` our
 ## objects from the same weather station.
 for obj in [dwtnMinAM, dwtnMaxAM, airptMinAM, airptMaxAM]:
     extreme = 'min' if 'min' in obj.name else 'max'
@@ -183,7 +183,7 @@ tempData.show('Date and hour sorted', maxWidth=120, maxHeight=11)
 ## We see above that `hr0` on `2011-01-01` for the `downtown` station, for
 ## example, is still represented by two points. This is because each point
 ## identifies either the minimum or maximum temperature. Our second step is to
-## combine these two point pairss by expanding the features to include features
+## combine these two point pairs by expanding the features to include features
 ## for the minimum and maximum temperatures. Our `extreme` feature contains the
 ## values (min and max) that will become our new feature names and the `temp`
 ## feature contains the values that fill the new `min` and `max` features.

--- a/documentation/source/examples/neural_networks.py
+++ b/documentation/source/examples/neural_networks.py
@@ -52,7 +52,7 @@ labels.show('one-hot encoded labels', maxHeight=9)
 intLabels = labels @ nimble.data('Matrix', list(range(10))).T
 intLabels.show('integer labels', maxHeight=9)
 
-## Now that we have a single feature of labels. We can randomly partion our
+## Now that we have a single feature of labels. We can randomly partition our
 ## data into training and testing sets.
 trainX, trainY, testX, testY = images.trainAndTestSets(testFraction=0.25,
                                                        labels=intLabels)
@@ -124,10 +124,10 @@ testX = testX.points.calculate(reshapePoint)
 print('trainX.shape', trainX.shape, 'trainX.dimensions', trainX.dimensions)
 print('testX.shape', testX.shape, 'testX.dimensions', testX.dimensions)
 
-## For our 2D convolutional neural network, we wil need five different types of
-## Keras `Layers` objects. Just as we did with our simple neural network above,
-## we can use `nimble.Init` to instantiate these objects without directly
-## importing them from Keras.
+## For our 2D convolutional neural network, we will need five different types
+## of Keras `Layers` objects. Just as we did with our simple neural network
+## above, we can use `nimble.Init` to instantiate these objects without
+## directly importing them from Keras.
 layersCNN = []
 layersCNN.append(nimble.Init('Conv2D', filters=64, kernel_size=3,
                              activation='relu', input_shape=(16, 16, 1)))

--- a/documentation/source/examples/unsupervised_learning.py
+++ b/documentation/source/examples/unsupervised_learning.py
@@ -45,7 +45,7 @@ purchaseOnly = visits.points.copy(lambda pt: pt['Purchase'])
 purchaseOnly.features.delete(lambda ft: len(ft.countUniqueElements()) == 1)
 purchaseOnlyFtNames = purchaseOnly.features.getNames()
 
-## For both the PCA (Principle Component Analysis) and k-means algorithms that
+## For both the PCA (Principal Component Analysis) and k-means algorithms that
 ## we will be using, we want to normalize our data. We will make a copy of our
 ## data (we will still need our original data later), and then standardize each
 ## feature to have a mean of 0 and standard deviation of 1.
@@ -139,7 +139,7 @@ centers.plotFeatureAgainstFeature(0, 1, figureName='clusterAndCenters',
 ## Cluster Analysis ##
 
 ## We used PCA and k-means clustering to identify cluster numbers for each
-## point in our data. Now can group our original data, `purchaseOnly`, by
+## point in our data. Now we can group our original data, `purchaseOnly`, by
 ## cluster number to analyze the data in each cluster. As we iterate through
 ## each cluster group, we will analyze how many data points fall into each
 ## cluster and calculate the feature means in each cluster for further


### PR DESCRIPTION
Typo fixes from feedback on examples. Changes to the scripts will carry over to the jupyter notebooks used for the documentation but not the Colab notebooks, so I edited those manually as well.

Also added the generated/ directory to `clean` in the Makefile, so unused stub files do not remain there when changes are made to the codebase.