### PR TITLE
replace .values with .to_numpy() in pandas

### DIFF
--- a/nimble/core/_createHelpers.py
+++ b/nimble/core/_createHelpers.py
@@ -778,7 +778,7 @@ def convertToBest(rawData, pointNames, featureNames):
     """
     if _isPandasDataFrame(rawData):
         if rawData.empty:
-            return rawData.values
+            return rawData.to_numpy()
         return pandasDataFrameToList(rawData)
     if _isPandasSeries(rawData):
         if rawData.empty:
@@ -973,8 +973,8 @@ def _replaceMissingData(rawData, treatAsMissing, replaceMissingWith, copied):
                 copied = True
             rawData.data = replaceNumpyValues(rawData.data, replaceLocs)
     elif _isPandasDense(rawData):
-        if len(rawData.values) > 0:
-            replaceLocs = getNumpyReplaceLocations(rawData.values)
+        if len(rawData.to_numpy()) > 0:
+            replaceLocs = getNumpyReplaceLocations(rawData.to_numpy())
             if replaceLocs.any():
                 # .where keeps the True values, use ~ to replace instead
                 rawData = rawData.where(~replaceLocs, replaceMissingWith)
@@ -1036,7 +1036,7 @@ class GenericRowIterator:
         elif isinstance(data, dict):
             self.iterator = iter(data.values())
         elif _isPandasObject(data):
-            self.iterator = iter(data.values)
+            self.iterator = iter(data.to_numpy())
         elif _isScipySparse(data):
             self.iterator = SparseCOORowIterator(data.tocoo(False))
         else:

--- a/nimble/core/data/dataframe.py
+++ b/nimble/core/data/dataframe.py
@@ -568,11 +568,11 @@ class DataFrame(Base):
 
         if len(dtypes) > 0:
             if all(d in allowed and np.can_cast(d, float) for d in dtypes):
-                return self._data.values
+                return self._data.to_numpy()
         if numericRequired:
-            return self._data.values.astype(float)
+            return self._data.to_numpy(float)
 
-        return self._data.astype(np.object_).values
+        return self._data.astype(np.object_).to_numpy()
 
 
 class DataFrameView(BaseView, DataFrame):


### PR DESCRIPTION
Change from using `values` attribute to `to_numpy()` to get a `numpy` `array` from a `pandas` object. `to_numpy()` will always return a numpy array, there are cases where `values` returns a different object type.

The minimum dependency version for `pandas` was recently updated to 0.24, which is when `to_numpy` was introduced, so this did not require an update.