### PR TITLE
add __all__ to exceptions.py

### DIFF
--- a/nimble/exceptions.py
+++ b/nimble/exceptions.py
@@ -81,3 +81,6 @@ class FileFormatException(NimbleException, ValueError):
 
     This is a subclass of Python's ValueError.
     """
+
+# can't use _utility._setAll here due to circular import
+__all__ = sorted(var for var in vars() if not var.startswith('_'))

--- a/tests/organizationTests.py
+++ b/tests/organizationTests.py
@@ -1,0 +1,23 @@
+"""
+Test that the nimble package is organized as expected.
+"""
+from types import ModuleType
+
+import nimble
+
+def test__all__():
+    assert hasattr(nimble, '__all__')
+    nimbleAll = nimble.__all__
+    # update this list if a new submodule is added or existing one is removed
+    expectedSubmodules = ['calculate', 'exceptions', 'fill', 'learners',
+                          'match', 'random']
+    submodules = [attr for attr in nimbleAll
+                  if isinstance(getattr(nimble, attr), ModuleType)]
+    assert sorted(expectedSubmodules) == sorted(submodules)
+
+    # core should not be included in __all__
+    assert 'core' not in nimbleAll
+
+    for name in submodules:
+        mod = getattr(nimble, name)
+        assert hasattr(mod, '__all__')


### PR DESCRIPTION
When exceptions was moved to the top level, exceptions/__init__.py included `__all__`  and was removed so `__all__` was not transferred to the top level file. I have added `__all__` to exceptions.py and added test to check that nimble `__all__` includes all expected submodules and that each submodule includes `__all__`. 