### PR TITLE
Correct publish_gh-pages to use the correct branch + related safety checks

### DIFF
--- a/documentation/publish_gh-pages.py
+++ b/documentation/publish_gh-pages.py
@@ -81,6 +81,17 @@ def checkTargetUpToDate(target):
     return localSHA == remoteSHA
 
 
+def checkTargetScriptUpToDate(target):
+    # get diff of HEAD vs target branch's publish script
+    cmd = "git diff {} -- publish_gh-pages.py".format(target)
+    if not SUPPRESSOUTPUT:
+        print(cmd)
+    currP = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE)
+    diffOutput = currP.stdout.read().decode("utf-8")
+    if not SUPPRESSOUTPUT:
+        print(diffOutput)
+    return len(diffOutput) == 0
+
 def argIsSuppress(toCheck):
     check = toCheck.lower()
     # TODO trim down to two (one abreviation, one long)
@@ -126,8 +137,15 @@ if __name__ == '__main__':
         print("We require the target branch to be up to date before publishing docs to gh-pages")
         sys.exit(1)
 
+    if not checkTargetScriptUpToDate(targetBranch):
+        msg = "We require the {} branch's publish script to ".format(targetBranch)
+        msg += "match that of the calling branch's script."
+        print(msg)
+        sys.exit(1)
+
     committed = False
     try:
+        printAndCall("git checkout " + targetBranch)
         printAndCall("git checkout --orphan gh-pages")
         printAndCall("git rm -rf --cached ../.")
 


### PR DESCRIPTION
Previously, the current branch was used to source the documentation, regardless of the provided argument. The script will now switch to the target branch (or master by default).

Also added was a check to confirm that the current branch's script matched the target branches script. This is meant to ensure consistency of execution and error messages around any of the times where local branches might have different change sets relating to the publishing process.