### PR TITLE
bug fixes and documentation typo fixes and clarification

### DIFF
--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -52,6 +52,10 @@ def process_signature(app, what, name, obj, options, signature,
     keepSignatures = ['nimble.CV', 'nimble.Init']
     if what == 'class' and name not in keepSignatures:
         signature = ''
+    # all nan values display as "nan", so we need to be more specific.
+    if what == 'function' and name == 'nimble.data':
+        signature = re.sub('nan, nan', 'float("nan"), numpy.nan', signature)
+        signature = re.sub('=nan', '=numpy.nan', signature)
 
     return signature, return_annotation
 
@@ -211,7 +215,8 @@ extensions = [
     #    'sphinx.ext.ifconfig',
 ]
 
-intersphinx_mapping = {'numpy': ('http://docs.scipy.org/doc/numpy/', None),}
+intersphinx_mapping = {'numpy': ('http://docs.scipy.org/doc/numpy/', None),
+                       'matplotlib': ('https://matplotlib.org/stable/', None)}
 
 autodoc_default_options = {
     'undoc-members': True,

--- a/documentation/source/docs/index.rst
+++ b/documentation/source/docs/index.rst
@@ -23,7 +23,7 @@ Creating Data Objects
 ---------------------
 Most functions for creating data objects are found at the top-level of
 ``nimble``. Nimble provides four data object types: List, Matrix, Sparse, and
-DataFrame. Each object has the same functionality, but differ on how data is
+DataFrame. Each object has the same functionality, but differ on how data are
 stored and manipulated on the backend. List uses a Python list, Matrix uses a
 numpy array, Sparse uses a scipy COO Matrix and DataFrame uses a pandas
 DataFrame. While the functionality is the same, choosing the best type may
@@ -153,13 +153,12 @@ Fetching Files
 --------------
 
 Nimble's ``fetchFile`` and ``fetchFiles`` provide efficient means for accessing
-online data sets. When a fetch function downloads a dataset, it stores it
-locally. Once downloaded, future calls to a fetch function for the same data
-will identify that the data is already available locally, avoiding a repeated
-download. The downloaded files are placed in a directory named "nimbleData" in
-a :ref:`configurable <configuration>` local location. The local storage
-location is identified by the "location" option in the "fetch" section and is
-set to the home directory by default.
+online datasets. When a new ``source`` is passed to a fetch function, it
+downloads and stores the files in a directory named "nimbleData" in a
+:ref:`configurable <configuration>` local location. When a repeated ``source``
+is passed to a fetch function, no downloading occurs because the data can be
+fetched locally. The local storage location is identified by the "location"
+option in the "fetch" section and is set to the home directory by default.
 
 .. autosummary::
    :toctree: generated/

--- a/documentation/source/examples/additional_functionality.py
+++ b/documentation/source/examples/additional_functionality.py
@@ -81,11 +81,11 @@ wifi = nimble.data('Matrix', path, name='wifiData')
 ## you live in an apartment with four rooms (kitchen, living room, bedroom, and
 ## bathroom) and your phone picks up 7 wifi signals from your neighbors. As you
 ## move your phone from room to room, it will be closer to certain wifi sources
-## and farther from others, changing the signal strength. This data is a matrix
-## of integers collected from an experiment similar to our hypothetical
+## and farther from others, changing the signal strength. This dataset is a
+## matrix of integers collected from an experiment similar to our hypothetical
 ## situation above. Since our data does not contain a header row, it is a good
-## practice to add features names manually so that the contents of our data is
-## more clear.
+## practice to add features names manually to clarify the contents of each
+## feature.
 headers = ['source' + str(i) for i in range(7)] + ['room']
 wifi.features.setNames(headers)
 wifi.show('wifi signal strengths', maxHeight=9)
@@ -97,7 +97,7 @@ wifi.show('wifi signal strengths', maxHeight=9)
 ## stored and can be queried later. This information is a great resource for
 ## reviewing sessions without needing to rerun the code. Depending on the
 ## settings, the log can also provide many additional details regarding a
-## machine learning algorithms performance. As we go through this example, we
+## machine learning algorithm's performance. As we go through this example, we
 ## will demonstrate how the logger is recording our actions. All logged
 ## functions and methods have a `useLog` parameter. This parameter provides
 ## local control of logging, which can override the global settings. A value of
@@ -211,7 +211,7 @@ uncontrolled.show('uncontrolled randomness sample')
 class LeastFeatureMeanDistance(nimble.CustomLearner):
     learnerType = 'classification'
 
-    def incrementalTrain(self, trainX, trainY):
+    def train(self, trainX, trainY):
         """
         Calculate the feature means by label group.
         """
@@ -388,8 +388,8 @@ nimble.showLog(levelOfDetail=3, maximumEntries=4)
 ## Now that we have completed our machine learning, let's dive a little deeper
 ## into how we can take advantage of the `showLog` to find certain information
 ## about our data. Right now our log is small, but as it grows we will not want
-## to look through the entire log. A log file can quickly contain data from
-## multiple sessions, multiple days and contain tons of different information
+## to look through the entire log. A log file can quickly contain tons of
+## very different textual information from various sessions on varying days.
 ## To make the log easy to query, `showLog` has parameters to filter the log by
 ## sessions, dates, and text. For now, let’s try a text search for our object’s
 ## name, ‘wifiData’, and see all log records containing that word.

--- a/documentation/source/examples/cleaning_data.py
+++ b/documentation/source/examples/cleaning_data.py
@@ -43,10 +43,13 @@ traffic = nimble.data('Matrix', path, name='Metro Interstate Traffic Volume')
 
 ## The `show` method provides control over the printed output for an object.
 ## It prints a description, the object name and shape and the object data
-## (truncating if necessary) given the parameters. The settings below allow us
-## to see a good selection of our data throughout this example.
-settingsForShow = {'maxWidth': 120, 'maxHeight': 9}
-traffic.show("Raw traffic data", **settingsForShow)
+## (truncating if necessary) given the parameters. To see a good selection of
+## our data throughout this example, we will want to adjust the ``maxWidth``
+## and ``maxHeight``. Since we will often want to use these same width and
+## height settings in many of the calls to `show` in this example, it will be
+## best to pack the values for these keyword arguments into a dictionary.
+keywordsForShow = {'maxWidth': 120, 'maxHeight': 9}
+traffic.show("Raw traffic data", **keywordsForShow)
 
 ## The machine learning algorithms we plan to use require numeric data and can
 ## be sensitive to outliers. Our data contains 48,204 points and 9 features,
@@ -97,7 +100,7 @@ traffic.features.splitByParsing('date_time', dateTimeSplitter,
 
 ## Now let's take a look at our data again after splitting a single feature
 ## of text into 5 numeric features.
-traffic.show('New parsed features in traffic data', **settingsForShow)
+traffic.show('New parsed features in traffic data', **keywordsForShow)
 
 ## Above, we also see that the `holiday` feature has many `nan` values. Let's
 ## take a look at a selection of points that include a holiday to get a better
@@ -105,7 +108,7 @@ traffic.show('New parsed features in traffic data', **settingsForShow)
 pointsWithHoliday = slice(1368, 1372)
 dateInfoFeatures = ['holiday', 'year', 'month', 'day', 'hour']
 sample = traffic[pointsWithHoliday, dateInfoFeatures]
-sample.show('Data sample with a holiday', **settingsForShow)
+sample.show('Data sample with a holiday', **keywordsForShow)
 
 ## Now we can see that this feature records the holiday name for the first data
 ## point recorded on a holiday, otherwise the value is `nan`. This means most
@@ -138,7 +141,7 @@ def holidayToBoolean(point):
 
 traffic.points.transform(holidayToBoolean)
 sample = traffic[pointsWithHoliday, dateInfoFeatures]
-sample.show('Data sample with converted holiday feature', **settingsForShow)
+sample.show('Data sample with converted holiday feature', **keywordsForShow)
 
 ## We have two features related to categorizing the weather conditions. We saw
 ## in our first look at the data that the `weather_description` feature is more
@@ -155,12 +158,12 @@ traffic.features.delete('weather_description')
 newCols = traffic.replaceFeatureWithBinaryFeatures('weather_main')
 sampleFts = ['weather_main=Clouds', 'weather_main=Clear', 'weather_main=Mist']
 traffic[pointsWithHoliday, sampleFts].show('Sample of binary weather features',
-                                           **settingsForShow)
+                                           **keywordsForShow)
 
 ## Now that we have removed any bad points and transformed all of our data to
-## numeric values, our data is ready for machine learning. We will be using
+## numeric values, our dataset is ready for machine learning. We will be using
 ## this data to predict the `traffic_volume` feature from the other features.
-traffic.show('Cleaned traffic data', **settingsForShow)
+traffic.show('Cleaned traffic data', **keywordsForShow)
 
 ## Writing to a file ##
 

--- a/documentation/source/examples/exploring_data.py
+++ b/documentation/source/examples/exploring_data.py
@@ -136,7 +136,7 @@ visits.plotFeatureGroupStatistics(nimble.calculate.count, 'Purchase', 'Region',
 ## It does not appear that any region is making disproportionately more or less
 ## purchases than the others. We have learned a lot about our website data
 ## through this exploration. Next, see how we can use Nimble to extract more
-## insight from this data set using machine learning in our
+## insight from this dataset using machine learning in our
 ## [Unsupervised Learning example](unsupervised_learning.ipynb).
 
 ## **References:**

--- a/documentation/source/examples/merging_and_tidying_data.py
+++ b/documentation/source/examples/merging_and_tidying_data.py
@@ -121,12 +121,12 @@ tempData.show('Fully merged (untidy) data', maxWidth=120, maxHeight=13)
 
 ## Tidying the data ##
 
-## Our data is combined, but not in the format we want. To structure our data
+## Our dataset is combined but not in the format we want. To structure our data
 ## for analysis, we would like each point to be a single observation of the
 ## variables in our data. According to [Hadley Wickham's Tidy Data][wickham]
-## principles, our data is not tidy for two reasons. First, 24 observations are
-## made every day (one each hour). Points should represent observations so each
-## day should be represented by 24 points. Second, our minimum and maximum
+## principles, our dataset is not tidy for two reasons. First, 24 observations
+## are made every day (one each hour). Points should represent observations so
+## each day should be represented by 24 points. Second, our minimum and maximum
 ## temperatures are variables for the same observation. Variables should be
 ## represented as features.
 

--- a/documentation/source/examples/neural_networks.py
+++ b/documentation/source/examples/neural_networks.py
@@ -3,7 +3,7 @@
 
 ### Using neural networks to identify handwritten digits.
 
-Our data set contains 1593 flattened 16x16 black and white images (each
+Our dataset contains 1593 flattened 16x16 black and white images (each
 pixel is represented by a 1 or 0) of handwritten digits (0-9).
 Approximately half of the digits were written neatly and the other half
 were written as quickly as possible. This provides some images that are
@@ -42,7 +42,7 @@ labels.show('one-hot encoded labels', maxHeight=9)
 
 ## Rather than 10 one-hot encoded features, we need our labels to be a single
 ## feature with the values 0-9 for our neural network. We can perform this
-## conversion by matrix multiplying (with the `@` matrix multiplication
+## conversion by matrix multiplying (with Python's `@` matrix multiplication
 ## operator) our `labels` object (1593 x 10) by a feature vector with the
 ## sequential values 0-9 (10 x 1). Since each label contains nine `0` values
 ## and a single `1`, the only non-zero product is between the `1` value in the
@@ -52,7 +52,7 @@ labels.show('one-hot encoded labels', maxHeight=9)
 intLabels = labels @ nimble.data('Matrix', list(range(10))).T
 intLabels.show('integer labels', maxHeight=9)
 
-## Now that we have a single feature of labels. We can randomly partition our
+## Now that we have a single feature of labels, we can randomly partition our
 ## data into training and testing sets.
 trainX, trainY, testX, testY = images.trainAndTestSets(testFraction=0.25,
                                                        labels=intLabels)
@@ -100,7 +100,7 @@ print('Accuracy of simple neural network:', accuracy)
 
 ## Convolutional Neural Network ##
 
-## Let's try to do better by increasing the complexity and create a 2D
+## Let's try to do better by increasing the complexity and creating a 2D
 ## convolutional neural network. This algorithm requires that our data be
 ## formatted so that it knows that each image is a 16 x 16 single channel
 ## (i.e., grayscale) image, so our flattened image data will not work. This

--- a/documentation/source/examples/outputs/supervised_learning_output.txt
+++ b/documentation/source/examples/outputs/supervised_learning_output.txt
@@ -8,7 +8,7 @@ REGEX: \{'n_neighbors': 5, 'rootMeanSquareError': 9[0-9]{2}\.[0-9]+\}
 REGEX: \{'n_neighbors': 7, 'rootMeanSquareError': 9[0-9]{2}\.[0-9]+\}
 REGEX: \{'learning_rate': 1\}
 REGEX: 4[0-9]{2}\.[0-9]+
-REGEX: sklearn.GradientBoostingRegressor learning_rate=1 error 3[567][0-9]\.[0-9]+
+REGEX: sklearn.GradientBoostingRegressor learning_rate=1 error 3[789][0-9]\.[0-9]+
 Traffic Volume Predictions
 24pt x 2ft
 

--- a/documentation/source/examples/supervised_learning.py
+++ b/documentation/source/examples/supervised_learning.py
@@ -102,14 +102,14 @@ print(gbTL.crossValidation.bestResult)
 ## as the default value so we already know how it performs on our testing data.
 ## However, `gbTL` found `learning_rate` of 1 outperformed the default, 0.1.
 ## Let's see how it performs on our testing (out-of-sample) data.
-gbPerf = gbTL.test(trainX, trainY, performanceFunction)
+gbPerf = gbTL.test(testX, testY, performanceFunction)
 print('sklearn.GradientBoostingRegressor', 'learning_rate=1', 'error', gbPerf)
 
 ## Applying our learner ##
 
 ## We see a further improvement in the performance so the
 ## GradientBoostingRegressor with a learning rate of 1 is our best model. Now
-## we will apply our `gbTL` trained learner to our `forecast` data set to
+## we will apply our `gbTL` trained learner to our `forecast` dataset to
 ## predict traffic volumes for a future day.
 predictedTraffic = gbTL.apply(forecast)
 predictedTraffic.features.setName(0, 'volume')

--- a/nimble/calculate/linalg.py
+++ b/nimble/calculate/linalg.py
@@ -264,7 +264,18 @@ def leastSquaresSolution(aObj, bObj):
 
     Examples
     --------
-    TODO: Example comparable with scipy counterpart.
+    >>> a = [[0, 1],
+    ...      [1, 1],
+    ...      [2, 1],
+    ...      [3, 1],
+    ...      [4, 1]]
+    >>> b = [6, 9, 12, 15, 18]
+    >>> aObj = nimble.data('Matrix', a)
+    >>> bObj = nimble.data('Matrix', b)
+    >>> nimble.calculate.leastSquaresSolution(aObj, bObj)
+    Matrix(
+        [[3.000 6.000]]
+        )
     """
     return _backendSolvers(aObj, bObj, leastSquaresSolution)
 

--- a/nimble/calculate/similarity.py
+++ b/nimble/calculate/similarity.py
@@ -34,8 +34,8 @@ cosineSimilarity.optimal = 'max'
 
 def correlation(X, X_T=None):
     """
-    Calculate the correlation between points in X. If X_T is not
-    provided, a copy of X will be made in this function.
+    Calculate the Pearson correlation coefficients between points in X.
+    If X_T is not provided, a copy of X will be made in this function.
     """
     # pylint: disable=invalid-name
     if X_T is None:

--- a/nimble/core/_createHelpers.py
+++ b/nimble/core/_createHelpers.py
@@ -2045,7 +2045,8 @@ def createDataFromFile(
         source.seek(saved)
 
         if not isinstance(content, bytes):
-            encoding = source.encoding
+            if source.encoding is not None:
+                encoding = source.encoding
             content = bytes(content, encoding=encoding)
 
         # try getting name attribute from file
@@ -2344,17 +2345,19 @@ def _namesDictToList(names, kind, paramName):
     return ret
 
 def _detectDialectFromSeparator(ioStream, inputSeparator):
-    "find the dialect to pass to csv.reader based on inputSeparator"
+    """
+    Find the dialect to pass to csv.reader based on inputSeparator.
+    """
     startPosition = ioStream.tell()
     # skip commented lines
     _ = _advancePastComments(ioStream)
     if inputSeparator == 'automatic':
         # detect the delimiter from the first line of data
-        dialect = csv.Sniffer().sniff(ioStream.readline())
+        inputSeparator = csv.Sniffer().sniff(ioStream.readline()).delimiter
     elif len(inputSeparator) > 1:
         msg = "inputSeparator must be a single character"
         raise InvalidArgumentValue(msg)
-    elif inputSeparator == '\t':
+    if inputSeparator == '\t':
         dialect = csv.excel_tab
     else:
         dialect = csv.excel

--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -2219,11 +2219,15 @@ class Base(ABC):
             A label for the x axis. If True, the label will be "Feature
             Values".
         yAxisLabel : str, bool
-            A label for the x axis. If True, the label will be "Point
+            A label for the y axis. If True, the label will be "Point
             Values".
         kwargs
             Any keyword arguments accepted by matplotlib.pyplot's
             ``matshow`` function.
+
+        See Also
+        --------
+            matplotlib.pyplot.matshow
         """
         self._plot(includeColorbar, outPath, show, title, xAxisLabel,
                    yAxisLabel, **kwargs)
@@ -2296,7 +2300,7 @@ class Base(ABC):
         xAxisLabel : str
             A label for the x axis. If True, the label will be "Values".
         yAxisLabel : str
-            A label for the x axis. If True, the label will be "Number
+            A label for the y axis. If True, the label will be "Number
             of Values".
         xMin : int, float
             The minimum value shown on the x axis of the resultant plot.
@@ -2305,6 +2309,10 @@ class Base(ABC):
         kwargs
             Any keyword arguments accepted by matplotlib.pyplot's
             ``hist`` function.
+
+        See Also
+        --------
+            matplotlib.pyplot.hist
         """
         self._plotFeatureDistribution(feature, outPath, show, figureName,
                                       title, xAxisLabel, yAxisLabel, xMin,
@@ -2421,7 +2429,7 @@ class Base(ABC):
         xAxisLabel : str
             A label for the x axis. If True, the label will be "Values".
         yAxisLabel : str
-            A label for the x axis. If True, the label will be "Number
+            A label for the y axis. If True, the label will be "Number
             of Values".
         xMin : int, float
             The minimum value shown on the x axis of the resultant plot.
@@ -2434,6 +2442,10 @@ class Base(ABC):
         kwargs
             Any keyword arguments accepted by matplotlib.pyplot's
             ``plot`` function.
+
+        See Also
+        --------
+            matplotlib.pyplot.plot, matplotlib.colors, matplotlib.markers
         """
         self._plotFeatureAgainstFeature(
             x, y, sampleSizeForAverage, trend, outPath, show, figureName,
@@ -2480,7 +2492,7 @@ class Base(ABC):
             A label for the x axis. If True, the label will be the x
             feature name or index.
         yAxisLabel : str
-            A label for the x axis. If True, the label will be the y
+            A label for the y axis. If True, the label will be the y
             feature name or index.
         xMin : int, float
             The minimum value shown on the x axis of the resultant plot.
@@ -2493,6 +2505,10 @@ class Base(ABC):
         kwargs
             Any keyword arguments accepted by matplotlib.pyplot's
             ``plot`` function.
+
+        See Also
+        --------
+            matplotlib.pyplot.plot, matplotlib.colors, matplotlib.markers
         """
         self._plotFeatureAgainstFeature(
             x, y, None, trend, outPath, show, figureName, title, xAxisLabel,
@@ -2641,11 +2657,15 @@ class Base(ABC):
             A label for the x axis. If True, a label will automatically
             be generated.
         yAxisLabel : str, bool
-            A label for the x axis. If True, a label will automatically
+            A label for the y axis. If True, a label will automatically
             be generated.
         kwargs
             Any keyword arguments accepted by matplotlib.pyplot's
             ``errorbar`` function.
+
+        See Also
+        --------
+            matplotlib.pyplot.errorbar
         """
         self._plotFeatureGroupStatistics(
             nimble.calculate.mean, feature, groupFeature, None, True,
@@ -2702,11 +2722,15 @@ class Base(ABC):
             A label for the x axis. If True, a label will automatically
             be generated.
         yAxisLabel : str, bool
-            A label for the x axis. If True, a label will automatically
+            A label for the y axis. If True, a label will automatically
             be generated.
         kwargs
             Any keyword arguments accepted by matplotlib.pyplot's
             ``bar`` function.
+
+        See Also
+        --------
+            matplotlib.pyplot.bar
         """
         self._plotFeatureGroupStatistics(
             statistic, feature, groupFeature, subgroupFeature, False,
@@ -2809,9 +2833,9 @@ class Base(ABC):
         """
         Invert the feature and point indices of the data.
 
-        Transpose the data in this object, inplace by inverting the
-        feature and point indices. This operations also includes
-        inverting the point and feature names.
+        Transpose the data in this object, inplace, by inverting the
+        feature and point indices. This includes inverting the point and
+        feature names, when available.
 
         Parameters
         ----------
@@ -2822,6 +2846,10 @@ class Base(ABC):
             send to the logger regardless of the global option. If
             False, do **NOT** send to the logger, regardless of the
             global option.
+
+        See Also
+        --------
+        T : Return the transposed object as a new object.
 
         Examples
         --------
@@ -2857,8 +2885,13 @@ class Base(ABC):
         """
         Invert the feature and point indices of the data.
 
-        Return this object with inverted feature and point indices,
-        including inverting point and feature names, if available.
+        Return a new object that is the transpose of the calling object.
+        The feature and point indices will be inverted, including
+        inverting point and feature names, if available.
+
+        See Also
+        --------
+        transpose : transpose the object inplace.
 
         Examples
         --------
@@ -3519,11 +3552,8 @@ class Base(ABC):
         objects. How the data will be merged is based upon the string
         arguments provided to ``point`` and ``feature``. If
         ``onFeature`` is None, the objects will be merged on the point
-        names. Otherwise, the objects will be merged on the feature
-        provided. ``onFeature`` allows for duplicate values to be
-        present in the provided feature, however, one of the objects
-        must contain only unique values for each point when
-        ``onFeature`` is provided.
+        names. Otherwise, ``onFeature`` must contain only unique values
+        in one or both objects.
 
         Parameters
         ----------

--- a/nimble/core/data/features.py
+++ b/nimble/core/data/features.py
@@ -2185,8 +2185,9 @@ class Features(ABC):
         ----------
         similarityFunction: str
             The name of the function. The accepted strings include:
-            'correlation', 'covariance', 'dot product',
-            'sample covariance', and 'population covariance'
+            'correlation', 'covariance', 'sample covariance',
+            'population covariance' and, 'dot product'. Pearson
+            correlation coefficients are used for 'correlation'.
 
         Returns
         -------
@@ -2258,7 +2259,7 @@ class Features(ABC):
             A label for the x axis. If True, a label will automatically
             be generated.
         yAxisLabel : str, bool
-            A label for the x axis. If True, a label will automatically
+            A label for the y axis. If True, a label will automatically
             be generated.
         legendTitle : str, None
             A title for the legend. A legend is only added when multiple
@@ -2267,6 +2268,10 @@ class Features(ABC):
         kwargs
             Any keyword arguments accepted by matplotlib.pyplot's
             ``bar`` function.
+
+        See Also
+        --------
+            matplotlib.pyplot.bar
         """
         self._plotComparison(
             None, features, None, horizontal, outPath, show, figureName, title,
@@ -2308,11 +2313,15 @@ class Features(ABC):
             A label for the x axis. If True, a label will automatically
             be generated.
         yAxisLabel : str, bool
-            A label for the x axis. If True, a label will automatically
+            A label for the y axis. If True, a label will automatically
             be generated.
         kwargs
             Any keyword arguments accepted by matplotlib.pyplot's
             ``errorbar`` function.
+
+        See Also
+        --------
+            matplotlib.pyplot.errorbar
         """
         self._plotComparison(
             nimble.calculate.mean, features, True, horizontal, outPath,
@@ -2365,7 +2374,7 @@ class Features(ABC):
             A label for the x axis. If True, a label will automatically
             be generated.
         yAxisLabel : str, bool
-            A label for the x axis. If True, a label will automatically
+            A label for the y axis. If True, a label will automatically
             be generated.
         legendTitle : str, None
             A title for the legend. A legend is only added when multiple
@@ -2374,6 +2383,10 @@ class Features(ABC):
         kwargs
             Any keyword arguments accepted by matplotlib.pyplot's
             ``bar`` function.
+
+        See Also
+        --------
+            matplotlib.pyplot.bar
         """
         self._plotComparison(
             statistic, features, False, horizontal, outPath, show, figureName,

--- a/nimble/core/data/points.py
+++ b/nimble/core/data/points.py
@@ -2078,8 +2078,9 @@ class Points(ABC):
         ----------
         similarityFunction: str
             The name of the function. The accepted strings include:
-            'correlation', 'covariance', 'dot product',
-            'sample covariance', and 'population covariance'
+            'correlation', 'covariance', 'sample covariance',
+            'population covariance' and, 'dot product'. Pearson
+            correlation coefficients are used for 'correlation'.
 
         Returns
         -------
@@ -2150,7 +2151,7 @@ class Points(ABC):
             A label for the x axis. If True, a label will automatically
             be generated.
         yAxisLabel : str, bool
-            A label for the x axis. If True, a label will automatically
+            A label for the y axis. If True, a label will automatically
             be generated.
         legendTitle : str, None
             A title for the legend. A legend is only added when multiple
@@ -2159,6 +2160,10 @@ class Points(ABC):
         kwargs
             Any keyword arguments accepted by matplotlib.pyplot's
             ``bar`` function.
+
+        See Also
+        --------
+            matplotlib.pyplot.bar
         """
         self._plotComparison(
             None, points, None, horizontal, outPath, show, figureName, title,
@@ -2200,11 +2205,15 @@ class Points(ABC):
             A label for the x axis. If True, a label will automatically
             be generated.
         yAxisLabel : str, bool
-            A label for the x axis. If True, a label will automatically
+            A label for the y axis. If True, a label will automatically
             be generated.
         kwargs
             Any keyword arguments accepted by matplotlib.pyplot's
             ``errorbar`` function.
+
+        See Also
+        --------
+            matplotlib.pyplot.errorbar
         """
         self._plotComparison(
             nimble.calculate.mean, points, True, horizontal, outPath,
@@ -2257,7 +2266,7 @@ class Points(ABC):
             A label for the x axis. If True, a label will automatically
             be generated.
         yAxisLabel : str, bool
-            A label for the x axis. If True, a label will automatically
+            A label for the y axis. If True, a label will automatically
             be generated.
         legendTitle : str, None
             A title for the legend. A legend is only added when multiple
@@ -2266,6 +2275,10 @@ class Points(ABC):
         kwargs
             Any keyword arguments accepted by matplotlib.pyplot's
             ``bar`` function.
+
+        See Also
+        --------
+            matplotlib.pyplot.bar
         """
         self._plotComparison(
             statistic, points, False, horizontal, outPath, show, figureName,

--- a/nimble/core/interfaces/universal_interface.py
+++ b/nimble/core/interfaces/universal_interface.py
@@ -953,7 +953,24 @@ class TrainedLearner(object):
 
         Examples
         --------
-        TODO
+        >>> from nimble.calculate import fractionIncorrect
+        >>> rawTrain = [[1, 0, 0, 1],
+        ...             [0, 1, 0, 2],
+        ...             [0, 0, 1, 3],
+        ...             [1, 0, 0, 1],
+        ...             [0, 1, 0, 2],
+        ...             [0, 0, 1, 3]]
+        >>> rawTest = [[1, 0, 0, 1], [0, 1, 0, 2], [0, 0, 1, 3]]
+        >>> ftNames = ['a', 'b', 'c', 'label']
+        >>> trainData = nimble.data('Matrix', rawTrain,
+        ...                         featureNames=ftNames)
+        >>> testData = nimble.data('Matrix', rawTest,
+        ...                        featureNames=ftNames)
+        >>> knn = nimble.train('nimble.KNNClassifier', trainX=trainData,
+        ...                    trainY='label')
+        >>> knn.test(testX=testData, testY='label',
+        ...          performanceFunction=fractionIncorrect)
+        0.0
         """
         startTime = time.process_time()
         if trackEntry.isEntryPoint:
@@ -1159,10 +1176,6 @@ class TrainedLearner(object):
             we want to write the output file. If filename extension
             .nimm is not included in file name it would be added to the
             output file.
-
-        Examples
-        --------
-        TODO
         """
         if not cloudpickle.nimbleAccessible():
             msg = "To save nimble models, cloudpickle must be installed"


### PR DESCRIPTION
Updates based on feedback regarding the examples.

- Fixed bug when loading a csv file that includes double quotes. Using `csv.Sniffer` to detect the dialect on only the first row will (usually) trigger `dialect.doublequotes` to be set to `False`. This will cause any subsequent rows with double quotes not to be divided correctly. Instead, it is safer to always set the dialect to `csv.excel` and set only the delimiter based on `csv.Sniffer`.
  - Additionally, while trying to debug this, I created a StringIO object that did not have a set encoding so it is necessary to check that `source.encoding` is not `None` before altering the `encoding` variable.
- Updated conf.py to modify the signature for `nimble.data` to clarify references to nan values.
  - Since str(float('nan') and str(numpy.nan) both return 'nan', the signature displays only nan so it was unclear which nan object was being used.
- Added `matplotlib` links to See Also in the plotting docstrings.
  - This is made possible by adding matplotlib to the intersphinx_mapping
- Added examples where there were still TODO or removed TODO if example section seemed unnecessary
- Made many typo fixes and clarifications in the landing page examples.