### PR TITLE
More hyperlinks in examples

### DIFF
--- a/documentation/source/examples/additional_functionality.py
+++ b/documentation/source/examples/additional_functionality.py
@@ -44,9 +44,9 @@ tempDir = tempfile.TemporaryDirectory('nimble-logs')
 ## Nimble allows for user configuration of certain aspects of our library
 ## through `nimble.settings`. The default settings are written to a file and
 ## loaded each time Nimble is imported. To see the current configuration
-## settings, we can use `nimble.settings.get()`. We can also change the
-## default settings using `nimble.settings.setDefault()` or use
-## `nimble.settings.set()` to make changes for only the current session.
+## settings, we can use `nimble.settings.get`. We can also change the
+## default settings using `nimble.settings.setDefault` or use
+## `nimble.settings.set` to make changes for only the current session.
 
 ## Next, we will be exploring Nimble's logging feature. We want to start with
 ## an empty log file and make sure that our logger behavior is the same. Let's
@@ -103,7 +103,7 @@ wifi.show('wifi signal strengths', maxHeight=9)
 ## local control of logging, which can override the global settings. A value of
 ## `True` will always add a log entry, `False` will never add a log entry and
 ## `None` (the default) will use the global "enabledByDefault" setting . Thus
-## far, our calls to `nimble.data` and `wifi.features.setNames` contained
+## far, our previous calls to `nimble.data` and `features.setNames` contained
 ## `useLog` parameters. Since we set `enabledByDefault` to "True", these two
 ## calls were logged.
 
@@ -120,11 +120,11 @@ nimble.showLog()
 ## regardless of the global setting. When "enabledByDefault" is set to "False",
 ## using `useLog=True` is perfect for logging only things we explicitly want to
 ## log. We set "enabledByDefault" to "True" earlier, but we still may want to
-## avoid logging certain things. For example, below we decide to check the mean
-## and median signal strength for each source because large differences would
-## indicate outliers. Remembering that we ran this check is not overly helpful
-## so we can skip logging it, but if we find outliers we will want to log any
-## actions we take.
+## avoid logging certain things. For example, below we decide to check the
+## `mean` and `median` signal strength for each source because large
+## differences would indicate outliers. Remembering that we ran this check is
+## not overly helpful so we can skip logging it, but if we find outliers we
+## will want to log any actions we take.
 sourceData = wifi[:, 'source0':'source6']
 print(sourceData.features.calculate(nimble.calculate.mean, useLog=False))
 print(sourceData.features.calculate(nimble.calculate.median, useLog=False))
@@ -139,12 +139,11 @@ nimble.showLog()
 
 ## If you revisit our data above, we can see that the points appear to be
 ## sorted by room. For our machine learning, we will want to randomize the
-## order. When we call `wifi.points.permute()` with no arguments, a random
-## permutation is used to reorder our points. However, Nimble wants each run of
-## a script to produce consistent results, so the random seed is controlled by
-## default. This means that the points in our randomly permuted object shown
-## below are always in the same order every time for everyone running this
-## script.
+## order. When we call `points.permute` with no arguments, a random permutation
+## is used to reorder our points. However, Nimble wants each run of a script to
+## produce consistent results, so the random seed is controlled by default.
+## This means that the points in our randomly permuted object shown below are
+## always in the same order every time for everyone running this script.
 wifi.points.permute()
 wifi.show('randomly permuted', maxHeight=9)
 
@@ -182,7 +181,7 @@ uncontrolled.show('uncontrolled randomness sample')
 
 ## Now it is time to perform our machine learning. For this example, we will
 ## first design our own custom machine learning algorithm for use with Nimble
-## rather than using one of Nimble's built-in `CustomLearners` or an algorithm
+## rather than using one of Nimble's built-in `CustomLearner`s or an algorithm
 ## from another package supported by Nimble (like `sklearn` or `keras`). One
 ## theory is that we could identify the center of each room by calculating the
 ## mean signal strengths of all known observations in that room. Once we have

--- a/documentation/source/examples/cleaning_data.py
+++ b/documentation/source/examples/cleaning_data.py
@@ -167,9 +167,8 @@ traffic.show('Cleaned traffic data', **keywordsForShow)
 
 ## Writing to a file ##
 
-## We'd like to be able to load the cleaned data for our
-## [Supervised Learning example](supervised_learning.ipynb) any time we want,
-## so we will write it to a new csv file.
+## We'd like to be able to load the cleaned data for our Supervised Learning
+## example any time we want, so we will write it to a new csv file.
 traffic.writeFile('Metro_Interstate_Traffic_Volume_Cleaned.csv')
 
 ## **References:**

--- a/documentation/source/examples/exploring_data.py
+++ b/documentation/source/examples/exploring_data.py
@@ -58,8 +58,8 @@ visits[:, visitDetailFts].show('Visit detail features', **settingsForShow)
 ## Reaching product-related pages is important for maximizing the chance that
 ## a purchase is made. This site categorizes their pages into three types
 ## ("Administrative", "Informational", and "ProductRelated"). Let's calculate
-## the mean and median counts for each page type and find out if most visitors
-## are reaching a product-related page.
+## the `mean` and `median` counts for each page type and find out if most
+## visitors are reaching a product-related page.
 for ft in ['Administrative', 'Informational', 'ProductRelated']:
     mean = nimble.calculate.mean(visits[:, ft])
     print('Mean', ft, 'hits per visit', mean)
@@ -124,7 +124,7 @@ visits.plotFeatureDistribution('Region')
 ## the Region feature, the regions on the x-axis will be in order of appearance
 ## in the data. To keep them in ascending numeric order, we will first sort our
 ## data by Region. Once sorted, `plotFeatureGroupStatistics` will find the
-## count of values in the purchase column for each Region. Then, it will
+## `count` of values in the purchase column for each Region. Then, it will
 ## further subdivide each count bar based on the values in Purchase (True or
 ## False). Now we can see if any regions are particularly better or worse at
 ## providing visits with a purchase.
@@ -136,8 +136,8 @@ visits.plotFeatureGroupStatistics(nimble.calculate.count, 'Purchase', 'Region',
 ## It does not appear that any region is making disproportionately more or less
 ## purchases than the others. We have learned a lot about our website data
 ## through this exploration. Next, see how we can use Nimble to extract more
-## insight from this dataset using machine learning in our
-## [Unsupervised Learning example](unsupervised_learning.ipynb).
+## insight from this dataset using machine learning in our Unsupervised
+## Learning example.
 
 ## **References:**
 

--- a/documentation/source/examples/neural_networks.py
+++ b/documentation/source/examples/neural_networks.py
@@ -34,9 +34,9 @@ images = nimble.data('Matrix', path)
 ## Preparing the data ##
 
 ## We need to separate the features identifying the labels (the last 10
-## features) from the features containing our image data. Using `extract`
-## performs this separation. New labels are placed in the `labels` object and
-## our `images` object now only contains our image data.
+## features) from the features containing our image data. Using
+## `features.extract` performs this separation. New labels are placed in the
+## `labels` object and our `images` object now only contains our image data.
 labels = images.features.extract(range(256, len(images.features)))
 labels.show('one-hot encoded labels', maxHeight=9)
 

--- a/documentation/source/examples/supervised_learning.py
+++ b/documentation/source/examples/supervised_learning.py
@@ -6,8 +6,8 @@
 In this example, we will use two datasets that contain data on
 interstate traffic volumes and features that may contribute to changes
 in traffic volume. `Metro_Interstate_Traffic_Volume_Cleaned.csv`, was
-generated in our [Data Cleaning example](cleaning_data.ipynb) and is the
-cleaned data we will use to build our supervised learning models.
+generated in our Cleaning Data example and is the cleaned data we will
+use to build our supervised learning models.
 `Metro_Interstate_Traffic_Volume_Predict.csv`, contains fictional
 "forecast" data that we will use to simulate making traffic volume
 predictions using our supervised machine learning model.

--- a/documentation/source/examples/unsupervised_learning.py
+++ b/documentation/source/examples/unsupervised_learning.py
@@ -3,13 +3,12 @@
 
 ### Classifying online shoppers
 
-In our [Exploring Data example](exploring_data.ipynb), we began
-exploring visitor behavior data from an ecommerce website. We will use
-that same data for this example, but a version that has been prepared
-for machine learning, `online_shoppers_intention_clean.csv`. Our goal
-will be to use an unsupervised machine learning algorithm to gain a
-better understanding of visitors that made a purchase during their
-visit.
+In our Exploring Data example, we began exploring visitor behavior data
+from an ecommerce website. We will use that same data for this example,
+but a version that has been prepared for machine learning,
+`online_shoppers_intention_clean.csv`. Our goal will be to use an
+unsupervised machine learning algorithm to gain a better understanding
+of visitors that made a purchase during their visit.
 
 [Open this example in Google Colab][colab]
 
@@ -127,7 +126,7 @@ for i in range(numClusters):
 ## cluster. For this plot, values will be marked with a black "X" so the
 ## centers are clearly visible and we will add it to our same
 ## 'clusterAndCenters' figure. Now that all of our plots have been added to our
-## figure, the default `show` setting (`show=True`) will display the figure
+## figure, the default `show=True` will display the figure.
 centers = nimble.data('Matrix', kmeans.getAttributes()['cluster_centers_'],
                       featureNames=['component_1', 'component_2'])
 centers.points.setNames(['cluster' + str(i) for i in range(numClusters)])


### PR DESCRIPTION
- Hyperlink inline code blocks in the markdown blocks of the examples
  - The markdown has additional options for hyperlinks. For example, `nimble.calculate.mean` is used in code blocks, but if the markdown says only `mean` this will now be linked as well
  - This generated a need to introduce a system for handling hyperlinks for objects with conflicting names (nimble.train/CustomLearner.train and TrainedLearner.apply/CustomLearner.apply). The solution is that no path is defined when duplicate names are found and these instead will need to be defined separately in `nimble_mapping` which should be modified on a file-by-file basis. For now the defaults are set to the most common use and only Additional Functionality requires different values.
- Automatically add hyperlinks to other examples instead of manually linking in .py file
  - Any time the example name followed by "example" is used (i.e. "Supervised Learning example") a hyperlink is added.
  - This prevents broken links in downloaded notebook and colab notebook (will need update when this is accepted)
- Regular expressions updates
  - Modified method calls regex to allow for indexing. Calls in Exploring Data and Unsupervised Learning were not linked if the method was called after indexing an object (i.e. `clusterMeans[:, pageTypes].features.plot()`)
  - Modified the regex expression to capture the entire call. For example, nimble.settings.set was capturing (and hyperlinking) only nimble.settings
    - This prompted an additional change for SessionConfiguration methods to link to any references to the method called by nimble.settings.
- Other changes
  - Added some additional inline code elements in the markdown when it was something that could by hyperlinked.
  - Separated various hyperlinking actions into their own functions for clarity