### PR TITLE
merge bug fixes

### DIFF
--- a/nimble/core/data/dataframe.py
+++ b/nimble/core/data/dataframe.py
@@ -346,6 +346,7 @@ class DataFrame(Base):
                                           right_index=True)
         else:
             onIdxL = self._data.columns.get_loc(onFeature)
+            onIdxR = tmpDfR.columns.get_loc(onFeature) + numColsL
             self._data = self._data.merge(tmpDfR, how=point, on=onFeature)
 
         # return labels to default after we've executed the merge
@@ -357,16 +358,15 @@ class DataFrame(Base):
             if onFeature is not None and left == onIdxL:
                 # onFeature column has already been merged
                 continue
-            if onFeature is not None and left > onIdxL:
+            right += numColsL
+            if onFeature is not None and right > onIdxR:
                 # one less to account for merged onFeature
-                right = right + numColsL - 1
-            else:
-                right = right + numColsL
-            matches = self._data.iloc[:, left] == self._data.iloc[:, right]
+                right -= 1
 
+            matches = self._data.iloc[:, left] == self._data.iloc[:, right]
             nansL = np.array([x != x for x in self._data.iloc[:, left]])
             nansR = np.array([x != x for x in self._data.iloc[:, right]])
-            acceptableValues = matches + nansL + nansR
+            acceptableValues = matches | nansL | nansR
             if not all(acceptableValues):
                 msg = "The objects contain different values for the same "
                 msg += "feature"

--- a/tests/data/structure_backend.py
+++ b/tests/data/structure_backend.py
@@ -8682,14 +8682,14 @@ class StructureModifying(StructureShared):
             leftObj.merge(rightObj, point='intersection', feature='union',
                           onFeature=0)
 
-    def test_merge_onFeatureIndex_ftStrictNoFtNames(self):
-        dataL = [['a', 1, 2], ['b', 5, 6], ['c', -1, -2]]
-        dataR = [['a', 3, 4], ['b', 5, 6], ['c', -3, -4]]
+    def test_merge_onPtNames_ftStrictNoFtNames(self):
+        dataL = [['a', 1, 2], ['b', 5, 6], ['c', 0, -2]]
+        dataR = [['b', 5, 6], ['a', 3, 0], ['c', -3, -4]]
         leftObj = self.constructor(dataL, pointNames=['a', 'b', 'c'])
-        rightObj = self.constructor(dataR, pointNames=['d', 'b', 'e'])
+        rightObj = self.constructor(dataR, pointNames=['b', 'd', 'e'])
 
-        expData = [['a', 1, 2], ['b', 5, 6], ['c', -1, -2],
-                   ['a', 3, 4], ['c', -3, -4]]
+        expData = [['a', 1, 2], ['b', 5, 6], ['c', 0, -2],
+                   ['a', 3, 0], ['c', -3, -4]]
         exp = self.constructor(expData, pointNames=['a', 'b', 'c', 'd', 'e'])
 
         leftObj.merge(rightObj, point='union', feature='strict', force=True)
@@ -9422,7 +9422,7 @@ class StructureModifying(StructureShared):
         self.merge_backend(left, right, expected, on="id")
 
     def test_merge_onFeature_sharedIds_newFeatures_nonDuplicate(self):
-        dataL = [["id1", "a", 1], ["id2", "b", 2], ["id3", "c", 3]]
+        dataL = [["id1", "a", 0], ["id2", "b", 0], ["id3", "c", 0]]
         fNamesL = ["id", "f1", "f2"]
         pNamesL = ["p1", "p2", "p3"]
         left = self.constructor(dataL, pointNames=pNamesL, featureNames=fNamesL)
@@ -9430,7 +9430,7 @@ class StructureModifying(StructureShared):
         fNamesR = ["id", "f3", "f4"]
         right = self.constructor(dataR, featureNames=fNamesR)
 
-        mData = [["id1", "a", 1, None, None], ["id2", "b", 2, "x", 9], ["id3", "c", 3, "y", 8],
+        mData = [["id1", "a", 0, None, None], ["id2", "b", 0, "x", 9], ["id3", "c", 0, "y", 8],
                  ["id4", None, None, "z", 7]]
         mFtNames = ["id", "f1", "f2", "f3", "f4"]
         mLargest = self.constructor(mData, featureNames=mFtNames)
@@ -9457,8 +9457,8 @@ class StructureModifying(StructureShared):
         fNamesL = ["id", "f1", "f2"]
         pNamesL = ["p1", "p2", "p3"]
         left = self.constructor(dataL, pointNames=pNamesL, featureNames=fNamesL)
-        dataR = [["id4", 4, "x"], ["id5", 5, "y"], ["id6", 6, "z"]]
-        fNamesR = ["id", "f2", "f3"]
+        dataR = [[4, "id4", "x"], [5, "id5", "y"], [6, "id6", "z"]]
+        fNamesR = ["f2","id", "f3"]
         right = self.constructor(dataR, featureNames=fNamesR)
 
         mData = [["id1", "a", 1, None], ["id2", "b", 2, None], ["id3", "c", 3, None],


### PR DESCRIPTION
Identified bugs in `merge` for `DataFrame` and `Sparse` implementations.

`DataFrame`, was not properly adjusting the location of the matching feature in the right-hand side object unless the onFeature was at index 0. The tests always placed the onFeature at index 0, so one of the tests was adjusted.

`Sparse` was not accounting for when the object contained 0s. When any 0 values are present, the indexing of the coo_matrix data would have less values than the corresponding `matchingFtIdx` list, so an `IndexError` would occur. This was not caught because none of the tests included 0 values, so some tests were adjusted.