### PR TITLE
elements with quotes and commas for csv write

### DIFF
--- a/nimble/core/data/_dataHelpers.py
+++ b/nimble/core/data/_dataHelpers.py
@@ -777,7 +777,9 @@ def csvCommaFormat(name):
     Prevent the name from being interpreted as two different csv values.
     """
     if isinstance(name, str) and ',' in name:
-        return '"{0}"'.format(name)
+        if '"' in name:
+            name = re.sub(r'"', '""', name)
+        name = '"{0}"'.format(name)
     return name
 
 operatorDict = {'!=': operator.ne, '==': operator.eq, '<=': operator.le,

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -297,6 +297,27 @@ class QueryBackend(DataTestObject):
         assert toWrite == orig
 
     @noLogEntryExpected
+    def test_writeFile_CSVhandmade_extraQuotes(self):
+        """ Test writeFile() when data and names contain commas """
+        # instantiate object
+        data = [[1, 2, 'with "quote"'], [1, 2, '"quotes","and", "commas"'],
+                [2, 4, 'includes"quote"'], [0, 0, 'd']]
+        pointNames = ['1', '1"quote"', '2', '0,zero']
+        featureNames = ['"quote",1', 'two', '3,three']
+        toWrite = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
+        orig = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
+
+        with tempfile.NamedTemporaryFile(suffix=".csv") as tmpFile:
+            toWrite.writeFile(tmpFile.name, fileFormat='csv', includeNames=True)
+            # read it back into a different object, then test equality
+            # must specify featureNames=True because 'automatic' will not detect
+            readObj = self.constructor(source=tmpFile.name, featureNames=True)
+        assert readObj.isIdentical(toWrite)
+        assert toWrite.isIdentical(readObj)
+
+        assert toWrite == orig
+
+    @noLogEntryExpected
     def test_writeFile_MTXhandmade(self):
         """ Test writeFile() for mtx extension with both data and featureNames """
         # instantiate object


### PR DESCRIPTION
When an element in the data contains double quotes and a comma(s), the value is divided into multiple values when writing to a csv. Each double quote in the element must be replaced with 2 double quotes to differentiate them from the double quotes used to wrap the entire element. The following element that identified this error: 
`[["Totally agree",3],["Agree",2],["Somewhat agree",1],["Neither agree nor disagree",0],["Somewhat disagree",-1],["Disagree",-2],["Totally disagree",-3]]`
It was being divided into 14 elements instead of being seen as a single element. For writing to a csv, this value needs to be changed to:
`[[""Totally agree"",3],[""Agree"",2],[""Somewhat agree"",1],[""Neither agree nor disagree"",0],[""Somewhat disagree"",-1],[""Disagree"",-2],[""Totally disagree"",-3]]`