### PR TITLE
Typo, links, highlighting, clarity, and consistency updates in example text

### DIFF
--- a/documentation/source/examples/additional_functionality.py
+++ b/documentation/source/examples/additional_functionality.py
@@ -84,7 +84,7 @@ wifi = nimble.data('Matrix', path, name='wifiData')
 ## and farther from others, changing the signal strength. This dataset is a
 ## matrix of integers collected from an experiment similar to our hypothetical
 ## situation above. Since our data does not contain a header row, it is a good
-## practice to add features names manually to clarify the contents of each
+## practice to add feature names manually to clarify the contents of each
 ## feature.
 headers = ['source' + str(i) for i in range(7)] + ['room']
 wifi.features.setNames(headers)

--- a/documentation/source/examples/cleaning_data.py
+++ b/documentation/source/examples/cleaning_data.py
@@ -42,9 +42,9 @@ path = nimble.fetchFile('uci::Metro Interstate Traffic Volume')
 traffic = nimble.data('Matrix', path, name='Metro Interstate Traffic Volume')
 
 ## The `show` method provides control over the printed output for an object.
-## It prints a description, the object name and shape and the object data
-## (truncating if necessary) given the parameters. To see a good selection of
-## our data throughout this example, we will want to adjust the ``maxWidth``
+## It prints a description, the `name` and `shape` of the object and the object
+## data (truncating if necessary) given the parameters. To see a good selection
+## of our data throughout this example, we will want to adjust the ``maxWidth``
 ## and ``maxHeight``. Since we will often want to use these same width and
 ## height settings in many of the calls to `show` in this example, it will be
 ## best to pack the values for these keyword arguments into a dictionary.

--- a/documentation/source/examples/merging_and_tidying_data.py
+++ b/documentation/source/examples/merging_and_tidying_data.py
@@ -53,8 +53,8 @@ dwtnMinAM.show('Example of data file structure', maxWidth=120, maxHeight=9)
 
 ## First, we can reduce our number of objects to 4 by combining AM and PM
 ## temperatures of objects at the same weather station (downtown or airport)
-## and with the same extreme (min or max). The featureNames for AM and PM are
-## currently the same, so we will need to modify the featureNames in the PM
+## and with the same extreme (min or max). The feature names for AM and PM are
+## currently the same, so we will need to modify the feature names in the PM
 ## objects so that they denote the hour according to a 24 hour clock.
 ftsPM = ['date', 'hr12', 'hr13', 'hr14', 'hr15', 'hr16', 'hr17',
          'hr18', 'hr19', 'hr20', 'hr21', 'hr22', 'hr23']
@@ -62,11 +62,11 @@ ftsPM = ['date', 'hr12', 'hr13', 'hr14', 'hr15', 'hr16', 'hr17',
 for obj in [dwtnMinPM, dwtnMaxPM, airptMinPM, airptMaxPM]:
     obj.features.setNames(ftsPM)
 
-## Now that we've differentiated our features, we can use a merge operation to
-## combine the data. We want to join these objects on the 'date' feature (i.e.,
-## we are combining data with the same date) and use point='union' (that is, we
-## want all the points from both files) so that we keep all possible dates,
-## even if a date is missing for the AM or PM data.
+## Now that we've differentiated our features, we can use a `merge` operation
+## to combine the data. We want to join these objects on the 'date' feature
+## (i.e., we are combining data with the same date) and use `point='union'`
+## (that is, we want all the points from both files) so that we keep all
+## possible dates, even if a date is missing for the AM or PM data.
 dwtnMinAM.merge(dwtnMinPM, onFeature='date', point='union')
 dwtnMaxAM.merge(dwtnMaxPM, onFeature='date', point='union')
 airptMinAM.merge(airptMinPM, onFeature='date', point='union')
@@ -79,8 +79,8 @@ dwtnMinAM.show('Downtown data merged on date', maxWidth=120, maxHeight=9)
 ## Before combining, we will want to add an “extreme” feature to each object
 ## based on whether it contains min vs. max data. Without this step, we would
 ## not be able to differentiate between minimum and maximum temperature points
-## in the combined objects. Once our new feature is added, we can `append` our
-## objects from the same weather station.
+## in the combined objects. Once our new feature is added, we can
+## `points.append` our objects from the same weather station.
 for obj in [dwtnMinAM, dwtnMaxAM, airptMinAM, airptMaxAM]:
     extreme = 'min' if 'min' in obj.name else 'max'
     ftData = [[extreme] for _ in range(len(obj.points))]
@@ -157,8 +157,8 @@ tempData.show('Fully merged (untidy) data', maxWidth=120, maxHeight=13)
 ## Tidying our data will take two steps. First, we need each point to represent
 ## a single hour of time. So we will take our 24 hour features (hr0, hr1, …,
 ## hr23) and collapse them to represent this same data using 24 points (one
-## point for each feature that is collapsed). The collapsed features become a
-## new feature named `hour` storing the featureName value and a new feature
+## point for each feature that is collapsed). The collapsed features become two
+## new features: one named `hour` storing each feature's name as a value and one
 ## named `temp` storing the temperature recorded during that hour.
 hourFts = ['hr' + str(i) for i in range(24)]
 tempData.points.splitByCollapsingFeatures(featuresToCollapse=hourFts,
@@ -172,8 +172,8 @@ tempData.show('Split points by collapsing the hour features', maxWidth=120,
 ## However, we still have separate points storing our maximum and minimum
 ## temperatures. This is not obvious in the output above, let's make a couple
 ## of modifications to see this more clearly. First, we can clean our `hour`
-## feature by transforming the former featureName strings into integers. Then,
-## we will `sort` our data so that `show()`` will clearly display point pairs
+## feature by transforming the former feature name strings into integers. Then,
+## we will sort our data so that `show` will clearly display point pairs
 ## that need to be combined for our data to be tidy.
 tempData.features.transform(lambda ft: [int(v[2:]) for v in ft],
                             features=['hour'])

--- a/documentation/source/examples/neural_networks.py
+++ b/documentation/source/examples/neural_networks.py
@@ -72,7 +72,7 @@ layer1 = nimble.Init('Dropout', rate=0.5)
 layer2 = nimble.Init('Dense', units=10, activation='softmax')
 layers = [layer0, layer1, layer2]
 
-## Now that we’ve taken advantage of nimble.Init to define our layers, we can
+## Now that we’ve taken advantage of `nimble.Init` to define our layers, we can
 ## train and apply our model in one step. `nimble.trainAndApply` will first
 ## train the model on our trainX data to predict our trainY data, then apply
 ## the resulting model to our testX data.

--- a/documentation/source/examples/unsupervised_learning.py
+++ b/documentation/source/examples/unsupervised_learning.py
@@ -161,9 +161,9 @@ for i in range(numClusters):
 
 ## We see some imbalance in cluster sizes, but each cluster contains at least
 ## 20% of our purchaser visits so we feel confident to continue. To analyze the
-## feature means in each cluster, we will make a new Nimble object. This object
-## has three points (one for each cluster) containing our calculated feature
-## means.
+## feature means in each cluster, we will make a new Nimble data object. This
+## object has three points (one for each cluster) containing our calculated
+## feature means.
 clusterMeans = nimble.data('Matrix', means, featureNames=purchaseOnlyFtNames,
                            pointNames=meanPtNames)
 


### PR DESCRIPTION
Improvements following up on #386. now that highlighted text may be a link to a page in the api docs, there were some inconsistencies with how linking and highlighting were applied.

Highlighting is used to indicate something is (or code be) code. As such, there were a couple of places where it seemed we forgot to highlight what felt like code snippets or method calls.

As much as possible, if something link-able is referred to, it is highlighted. There were a couple of easy additions like this: `name` and `shape` attributes for `Base` objects (in Cleaning Data), and some other places where it seemed like we just forgot we could highlight a method name.

Similarly, if something is highlighted and referring to something that's link-able, it *should* be link-able.  It seems as though points/features method names by themselves will not generate a link. For `append` it fit with the flow to change it to `points.append` while in the case of referring to `sort` I removed the highlighting since it could just be an action we're taking instead.

Lastly, the use of `featureName` (which looks like code, but wasn't highlighted) was rewritten to refer to a "feature name" as appropriate. While `featureName` / `featureNames` may refer to a specific parameter, here it felt confusing to use the camelcase style in an environment where all code was being highlighted.

There were a couple other simple typo fixes or what I felt were clarity improvements. Let me know if you disagree with anything or think we could take a different approach.