### PR TITLE
add __str__ to SessionConfiguration

### DIFF
--- a/nimble/core/configuration.py
+++ b/nimble/core/configuration.py
@@ -72,6 +72,20 @@ class SessionConfiguration(object):
         self.changes = {}
         self.hooks = {}
 
+    def __str__(self):
+        """
+        String of configuration settings.
+
+        Output uses the same INI syntax used for configuration files.
+        """
+        ret = ''
+        for section, options in self.get().items():
+            ret += '[{}]\n'.format(section)
+            for option, value in options.items():
+                ret += '{} = {}\n'.format(option, value)
+            ret += '\n'
+        return ret.rstrip()
+
     def get(self, section=None, option=None):
         """
         Query the current settings.

--- a/tests/testConfig.py
+++ b/tests/testConfig.py
@@ -445,6 +445,20 @@ def test_settings_setDefault():
 
     assert nimble.settings.get("tempSectionName", 'temp.Option.Name2') == '2'
 
+def test_settings_str():
+    """ Test nimble.settings string has expected sections and options """
+
+    s = str(nimble.settings)
+    # check that string is valid for configparser and use configparser to test
+    # that it contains the expected sections and options for logger and fetch
+    cp = configparser.ConfigParser()
+    cp.read_string(s)
+    assert 'logger' in cp
+    assert 'location' in cp['logger']
+    assert 'enabledByDefault' in cp['logger']
+    assert 'enableCrossValidationDeepLogging' in cp['logger']
+    assert 'fetch' in cp
+    assert 'location' in cp['fetch']
 
 @patch(nimble.core.interfaces, 'predefined', [FailedPredefined])
 def testSetLocationForFailedPredefinedInterface():


### PR DESCRIPTION
The `__str__` of a `SessionConfiguration`, will match the contents of reading a configuration file with those same settings. In addition to clearly displaying the sections and options, the INI syntax allows for the string to be written to a configuration file and be read by `configparser.ConfigParser`.