### PR TITLE
Custom learner api refactoring and training randomness

### DIFF
--- a/nimble/core/interfaces/custom_learner.py
+++ b/nimble/core/interfaces/custom_learner.py
@@ -138,7 +138,8 @@ class CustomLearnerInterface(UniversalInterface):
             labels = dtypeConvert(trainY.copy(to='numpyarray'))
             ret.labelList = np.unique(labels)
 
-        ret.train(trainX, trainY, **arguments)
+        with nimble.random.alternateControl(randomSeed, useLog=False):
+            ret.train(trainX, trainY, **arguments)
 
         return ret
 


### PR DESCRIPTION
Refactored the `*ForInterface` methods from the `CustomLearner` object into the `CustomLearnerInterface` - as a consequence, these will no longer be visible to the user.

Also added a `random.alternateControl` context manager so that the `randomSeed` parameter for train is actually used.