### PR TITLE
add randomSeed to retrain and incrementalTrain

### DIFF
--- a/nimble/core/interfaces/custom_learner.py
+++ b/nimble/core/interfaces/custom_learner.py
@@ -144,13 +144,15 @@ class CustomLearnerInterface(UniversalInterface):
         return ret
 
     def _incrementalTrainer(self, learnerName, learner, trainX, trainY,
-                            arguments, customDict):
+                            arguments, randomSeed, customDict):
         if learner.__class__.learnerType == 'classification':
             flattenedY = dtypeConvert(trainY.copy(to='numpyarray').flatten())
             if learner.labelList is None: # no previous training
                 learner.labelList = []
             learner.labelList = np.union1d(learner.labelList, flattenedY)
-        learner.incrementalTrain(trainX, trainY, **arguments)
+
+        with nimble.random.alternateControl(randomSeed, useLog=False):
+            learner.incrementalTrain(trainX, trainY, **arguments)
 
         return learner
 

--- a/nimble/core/interfaces/keras_interface.py
+++ b/nimble/core/interfaces/keras_interface.py
@@ -323,15 +323,19 @@ To install keras
         return nimble.data(outputType, outputValue, useLog=False)
 
 
+    def _setRandomness(self, arguments, randomSeed):
+        if self._tfVersion2:
+            checkArgsForRandomParam(arguments, 'seed')
+            self.tensorflow.random.set_seed(randomSeed)
+
+
     def _trainer(self, learnerName, trainX, trainY, arguments, randomSeed,
                  customDict):
         initNames = self._paramQuery('__init__', learnerName, ['self'])[0]
         compileNames = self._paramQuery('compile', learnerName, ['self'])[0]
         isSparse = isinstance(trainX, nimble.core.data.Sparse)
 
-        if self._tfVersion2:
-            checkArgsForRandomParam(arguments, 'seed')
-            self.tensorflow.random.set_seed(randomSeed)
+        self._setRandomness(arguments, randomSeed)
         # keras 2.2.5+ fit_generator functionality merged into fit.
         # fit_generator may be removed, but will be used when possible
         # to support earlier versions.
@@ -397,7 +401,8 @@ To install keras
 
 
     def _incrementalTrainer(self, learnerName, learner, trainX, trainY,
-                            arguments, customDict):
+                            arguments, randomSeed, customDict):
+        self._setRandomness(arguments, randomSeed)
         param = 'train_on_batch'
         trainOnBatchNames = self._paramQuery(param, learnerName, ['self'])[0]
         trainOnBatchParams = {}

--- a/nimble/core/interfaces/mlpy_interface.py
+++ b/nimble/core/interfaces/mlpy_interface.py
@@ -301,7 +301,7 @@ To install mlpy
 
 
     def _incrementalTrainer(self, learnerName, learner, trainX, trainY,
-                            arguments, customDict):
+                            arguments, randomSeed, customDict):
         raise NotImplementedError
 
 

--- a/nimble/core/interfaces/scikit_learn_interface.py
+++ b/nimble/core/interfaces/scikit_learn_interface.py
@@ -161,7 +161,7 @@ class _SciKitLearnAPI(PredefinedInterfaceMixin):
         return learner
 
     def _incrementalTrainer(self, learnerName, learner, trainX, trainY,
-                            arguments, customDict):
+                            arguments, randomSeed, customDict):
         # see partial_fit(X, y[, classes, sample_weight])
         msg = 'this interface does not implement incremental training'
         raise ImproperObjectAction(msg)

--- a/nimble/core/interfaces/shogun_interface.py
+++ b/nimble/core/interfaces/shogun_interface.py
@@ -393,7 +393,7 @@ To install shogun
 
 
     def _incrementalTrainer(self, learnerName, learner, trainX, trainY,
-                            arguments, customDict):
+                            arguments, randomSeed, customDict):
         # StreamingDotFeatures?
         raise NotImplementedError
 

--- a/tests/customLearners/custom_learner_test.py
+++ b/tests/customLearners/custom_learner_test.py
@@ -465,3 +465,56 @@ def testMeanConstantSimple():
 
         customLearners = nimble.listLearners('custom')
         assert 'MeanConstant' in customLearners
+
+
+class RandomControl(CustomLearner):
+    learnerType = 'unknown'
+
+    def train(self, trainX, trainY):
+        self.rand = nimble.random.pythonRandom.randint(0, 1e15)
+
+    def incrementalTrain(self, trainX, trainY):
+        self.rand = nimble.random.pythonRandom.randint(0, 1e15)
+
+    def apply(self, testX):
+        return [v * self.rand for v in testX]
+
+def test_customLearnerRandomControl():
+    trainX = nimble.data('Matrix', [[1], [2], [3]])
+    trainY = trainX.copy()
+    testX = trainX.copy()
+    a = nimble.trainAndApply(RandomControl, trainX, trainY, testX, randomSeed=1)
+    b = nimble.trainAndApply('custom.RandomControl', trainX, trainY, testX,
+                             randomSeed=1)
+    c = nimble.trainAndApply('custom.RandomControl', trainX, trainY, testX,
+                             randomSeed=2)
+    d = nimble.trainAndApply('custom.RandomControl', trainX, trainY, testX,
+                             randomSeed=3)
+
+    assert a == b
+    assert a != c
+    assert a != d
+    assert c != d
+
+    model = nimble.train(RandomControl, trainX, trainY)
+    model.incrementalTrain(trainX, trainY, randomSeed=2)
+    e = model.apply(testX)
+    model.incrementalTrain(trainX, trainY, randomSeed=3)
+    f = model.apply(testX)
+    model.incrementalTrain(trainX, trainY, randomSeed=2)
+    g = model.apply(testX)
+
+    assert e == g
+    assert e != f
+
+    model = nimble.train(RandomControl, trainX, trainY)
+    assert a != model.apply(testX)
+    model.retrain(trainX, trainY, randomSeed=1)
+    h = model.apply(testX)
+    assert a == h
+    model.retrain(trainX, trainY, randomSeed=2)
+    i = model.apply(testX)
+    assert c == i
+    model.retrain(trainX, trainY, randomSeed=3)
+    j = model.apply(testX)
+    assert d == j

--- a/tests/interfaces/universal_test.py
+++ b/tests/interfaces/universal_test.py
@@ -139,7 +139,7 @@ class TestPredefinedInterface(PredefinedInterfaceMixin):
         pass
 
     def _incrementalTrainer(self, learnerName, learner, trainX, trainY,
-                            arguments, customDict):
+                            arguments, randomSeed, customDict):
         pass
 
     def _checkVersion(self):
@@ -319,7 +319,7 @@ class AlwaysWarnInterface(UniversalInterface):
         return (learnerName, trainX, trainY, arguments)
 
     def _incrementalTrainer(self, learnerName, learner, trainX, trainY,
-                            arguments, customDict):
+                            arguments, randomSeed, customDict):
         self.issueWarnings()
         pass
 


### PR DESCRIPTION
Added `randomSeed` parameter for `retrain` and `incrementalTrain` in `TrainedLearner`. Updated interface `_incrementalTrainer` to include `randomSeed` and tested that `randomSeed` yields reproducible results for a `CustomLearner`.