### PR TITLE
change figureName to figureID and can be any hashable

### DIFF
--- a/documentation/source/examples/unsupervised_learning.py
+++ b/documentation/source/examples/unsupervised_learning.py
@@ -108,12 +108,12 @@ clusters.features.setName(0, 'cluster')
 ## based on cluster number. In addition to the clusters, we are going to add
 ## the cluster centers to our figure (the canvas containing our plots), so we
 ## set `show` to `False` to prevent the figure from displaying after the
-## function call. We must also specify a `figureName` so our next plot can be
+## function call. We must also specify a `figureID` so our next plot can be
 ## added to this same figure.
 purchasePCA.features.append(clusters)
 purchasePCA.plotFeatureAgainstFeature(
     'component_1', 'component_2', groupByFeature='cluster', show=False,
-    figureName='clustersWithCenters')
+    figureID=1)
 
 ## Each cluster has a center that will help us see how close each data point
 ## lies to the center of the cluster in which it was placed. We use the cluster
@@ -128,8 +128,7 @@ centers = nimble.data('Matrix', kmeans.getAttributes()['cluster_centers_'],
 centers.points.setNames(['cluster' + str(i) for i in range(numClusters)])
 
 title = 'k-means clustering of principal components'
-centers.plotFeatureAgainstFeature('component_1', 'component_2',
-                                  figureName='clustersWithCenters',
+centers.plotFeatureAgainstFeature('component_1', 'component_2', figureID=1,
                                   title=title, marker='x', color='k')
 
 ## Cluster Analysis ##

--- a/nimble/core/data/_dataHelpers.py
+++ b/nimble/core/data/_dataHelpers.py
@@ -983,16 +983,16 @@ def pyplotRequired(func):
         return func(*args, **kwargs)
     return wrapped
 
-def plotFigureHandling(figureName):
+def plotFigureHandling(figureID):
     """
     Provide the figure and axis for the plot.
 
-    Use the stored figure and axis if the figureName exists, otherwise
+    Use the stored figure and axis if the figureID exists, otherwise
     generate a new figure and axis.
     """
     figures = nimble.core.data._plotFigures
-    if figureName and figureName in figures:
-        return figures[figureName]
+    if figureID is not None and figureID in figures:
+        return figures[figureID]
 
     fig, ax = plt.subplots()
     # tight_layout automatically adjusts margins to accommodate labels
@@ -1000,8 +1000,8 @@ def plotFigureHandling(figureName):
     # Setting a _nimbleAxisLimits attribute is a workaround for properly
     # setting figure axis limits. See plotUpdateAxisLimits docstring.
     ax._nimbleAxisLimits = [None, None, None, None]
-    if figureName is not None:
-        figures[figureName] = fig, ax
+    if figureID is not None:
+        figures[figureID] = fig, ax
     return fig, ax
 
 def plotOutput(outPath, show):

--- a/nimble/core/data/axis.py
+++ b/nimble/core/data/axis.py
@@ -893,9 +893,9 @@ class Axis(ABC):
     @pyplotRequired
     def _plotComparison(
             self, statistic, identifiers, confidenceIntervals, horizontal,
-            outPath, show, figureName, title, xAxisLabel, yAxisLabel,
+            outPath, show, figureID, title, xAxisLabel, yAxisLabel,
             legendTitle, **kwargs):
-        fig, ax = plotFigureHandling(figureName)
+        fig, ax = plotFigureHandling(figureID)
         if identifiers is None:
             identifiers = list(range(len(self)))
         axisRange = range(1, len(identifiers) + 1)

--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -2272,7 +2272,7 @@ class Base(ABC):
 
     @limitedTo2D
     def plotFeatureDistribution(self, feature, outPath=None, show=True,
-                                figureName=None, title=True, xAxisLabel=True,
+                                figureID=None, title=True, xAxisLabel=True,
                                 yAxisLabel=True, xMin=None, xMax=None,
                                 **kwargs):
         """
@@ -2296,11 +2296,11 @@ class Base(ABC):
             If True, display the plot. If False, the figure will not
             display until a plotting function with show=True is called.
             This allows for future plots to placed on the figure with
-            the same ``figureName`` before being shown.
-        figureName : str, None
-            A new figure will be generated when None or a new name,
-            otherwise the figure with that name will be activated to
-            draw the plot on an existing figure.
+            the same ``figureID`` before being shown.
+        figureID : hashable, None
+            A new figure will be generated for None or a new id,
+            otherwise the figure with that id will be activated to draw
+            the plot on the existing figure.
         title : str, None
             The title of the plot. If True, the title will identify the
             feature presented in the distribution.
@@ -2321,21 +2321,21 @@ class Base(ABC):
         --------
             matplotlib.pyplot.hist
         """
-        self._plotFeatureDistribution(feature, outPath, show, figureName,
+        self._plotFeatureDistribution(feature, outPath, show, figureID,
                                       title, xAxisLabel, yAxisLabel, xMin,
                                       xMax, **kwargs)
 
-    def _plotFeatureDistribution(self, feature, outPath, show, figureName,
+    def _plotFeatureDistribution(self, feature, outPath, show, figureID,
                                  title, xAxisLabel, yAxisLabel, xMin, xMax,
                                  **kwargs):
         return self._plotDistribution('feature', feature, outPath, show,
-                                      figureName, title, xAxisLabel,
+                                      figureID, title, xAxisLabel,
                                       yAxisLabel, xMin, xMax, **kwargs)
 
     @pyplotRequired
-    def _plotDistribution(self, axis, identifier, outPath, show, figureName,
+    def _plotDistribution(self, axis, identifier, outPath, show, figureID,
                           title, xAxisLabel, yAxisLabel, xMin, xMax, **kwargs):
-        _, ax = plotFigureHandling(figureName)
+        _, ax = plotFigureHandling(figureID)
         plotUpdateAxisLimits(ax, xMin, xMax, None, None)
 
         axisObj = self._getAxis(axis)
@@ -2390,7 +2390,7 @@ class Base(ABC):
     @limitedTo2D
     def plotFeatureAgainstFeatureRollingAverage(
             self, x, y, sampleSizeForAverage=20, groupByFeature=None,
-            trend=None, outPath=None, show=True, figureName=None, title=True,
+            trend=None, outPath=None, show=True, figureID=None, title=True,
             xAxisLabel=True, yAxisLabel=True, xMin=None, xMax=None, yMin=None,
             yMax=None, **kwargs):
         """
@@ -2431,11 +2431,11 @@ class Base(ABC):
             If True, display the plot. If False, the figure will not
             display until a plotting function with show=True is called.
             This allows for future plots to placed on the figure with
-            the same ``figureName`` before being shown.
-        figureName : str, None
-            A new figure will be generated when None or a new name,
-            otherwise the figure with that name will be activated to
-            draw the plot on an existing figure.
+            the same ``figureID`` before being shown.
+        figureID : hashable, None
+            A new figure will be generated for None or a new id,
+            otherwise the figure with that id will be activated to draw
+            the plot on the existing figure.
         title : str, None
             The title of the plot. If True, the title will identify the
             two features presented in the plot.
@@ -2462,13 +2462,13 @@ class Base(ABC):
         """
         self._plotFeatureAgainstFeature(
             x, y, groupByFeature, sampleSizeForAverage, trend, outPath, show,
-            figureName, title, xAxisLabel, yAxisLabel, xMin, xMax, yMin, yMax,
+            figureID, title, xAxisLabel, yAxisLabel, xMin, xMax, yMin, yMax,
             **kwargs)
 
     @limitedTo2D
     def plotFeatureAgainstFeature(
             self, x, y, groupByFeature=None, trend=None, outPath=None,
-            show=True, figureName=None, title=True, xAxisLabel=True,
+            show=True, figureID=None, title=True, xAxisLabel=True,
             yAxisLabel=True, xMin=None, xMax=None, yMin=None, yMax=None,
             **kwargs):
         """
@@ -2501,11 +2501,11 @@ class Base(ABC):
             If True, display the plot. If False, the figure will not
             display until a plotting function with show=True is called.
             This allows for future plots to placed on the figure with
-            the same ``figureName`` before being shown.
-        figureName : str, None
-            A new figure will be generated when None or a new name,
-            otherwise the figure with that name will be activated to
-            draw the plot on an existing figure.
+            the same ``figureID`` before being shown.
+        figureID : hashable, None
+            A new figure will be generated for None or a new id,
+            otherwise the figure with that id will be activated to draw
+            the plot on the existing figure.
         title : str, None
             The title of the plot. If True, the title will identify the
             two features presented in the plot.
@@ -2532,18 +2532,18 @@ class Base(ABC):
             matplotlib.pyplot.plot, matplotlib.colors, matplotlib.markers
         """
         self._plotFeatureAgainstFeature(
-            x, y, groupByFeature, None, trend, outPath, show, figureName,
+            x, y, groupByFeature, None, trend, outPath, show, figureID,
             title, xAxisLabel, yAxisLabel, xMin, xMax, yMin, yMax, **kwargs)
 
 
     def _plotFeatureAgainstFeature(
             self, x, y, groupByFeature, sampleSizeForAverage, trend, outPath,
-            show, figureName, title, xAxisLabel, yAxisLabel, xMin, xMax, yMin,
+            show, figureID, title, xAxisLabel, yAxisLabel, xMin, xMax, yMin,
             yMax, **kwargs):
         if groupByFeature is None:
             self._plotCross(
                 x, 'feature', y, 'feature', sampleSizeForAverage, trend,
-                outPath, show, figureName, title, xAxisLabel, yAxisLabel, xMin,
+                outPath, show, figureID, title, xAxisLabel, yAxisLabel, xMin,
                 xMax, yMin, yMax, **kwargs)
         else:
             grouped = self.groupByFeature(groupByFeature)
@@ -2559,9 +2559,9 @@ class Base(ABC):
             else:
                 colors = None
             del kwargs['color']
-            if show and not figureName:
+            if show and not figureID:
                 # need a figure name for plotting loop
-                figureName = 'Nimble Figure'
+                figureID = 'Nimble Figure'
             for label in labels:
                 showFig = show and label == lastLabel
                 if colors:
@@ -2572,7 +2572,7 @@ class Base(ABC):
                         raise KeyError(msg.format(label)) from e
                 grouped[label]._plotCross(
                     x, 'feature', y, 'feature', sampleSizeForAverage, trend,
-                    outPath, showFig, figureName, title, xAxisLabel,
+                    outPath, showFig, figureID, title, xAxisLabel,
                     yAxisLabel, xMin, xMax, yMin, yMax, label=label, **kwargs)
 
 
@@ -2592,9 +2592,9 @@ class Base(ABC):
 
     @pyplotRequired
     def _plotCross(self, x, xAxis, y, yAxis, sampleSizeForAverage, trend,
-                   outPath, show, figureName, title, xAxisLabel, yAxisLabel,
+                   outPath, show, figureID, title, xAxisLabel, yAxisLabel,
                    xMin, xMax, yMin, yMax, **kwargs):
-        _, ax = plotFigureHandling(figureName)
+        _, ax = plotFigureHandling(figureID)
         plotUpdateAxisLimits(ax, xMin, xMax, yMin, yMax)
 
         xAxisObj = self._getAxis(xAxis)
@@ -2674,7 +2674,7 @@ class Base(ABC):
     @limitedTo2D
     def plotFeatureGroupMeans(
             self, feature, groupFeature, horizontal=False, outPath=None,
-            show=True, figureName=None, title=True, xAxisLabel=True,
+            show=True, figureID=None, title=True, xAxisLabel=True,
             yAxisLabel=True, **kwargs):
         """
         Plot the means of a feature grouped by another feature.
@@ -2699,11 +2699,11 @@ class Base(ABC):
             If True, display the plot. If False, the figure will not
             display until a plotting function with show=True is called.
             This allows for future plots to placed on the figure with
-            the same ``figureName`` before being shown.
-        figureName : str, None
-            A new figure will be generated when None or a new name,
-            otherwise the figure with that name will be activated to
-            draw the plot on an existing figure.
+            the same ``figureID`` before being shown.
+        figureID : hashable, None
+            A new figure will be generated for None or a new id,
+            otherwise the figure with that id will be activated to draw
+            the plot on the existing figure.
         title : str, bool
             The title of the plot. If True, a title will automatically
             be generated.
@@ -2723,13 +2723,13 @@ class Base(ABC):
         """
         self._plotFeatureGroupStatistics(
             nimble.calculate.mean, feature, groupFeature, None, True,
-            horizontal, outPath, show, figureName, title, xAxisLabel,
+            horizontal, outPath, show, figureID, title, xAxisLabel,
             yAxisLabel, **kwargs)
 
     @limitedTo2D
     def plotFeatureGroupStatistics(
             self, statistic, feature, groupFeature, subgroupFeature=None,
-            horizontal=False, outPath=None, show=True, figureName=None,
+            horizontal=False, outPath=None, show=True, figureID=None,
             title=True, xAxisLabel=True, yAxisLabel=True, **kwargs):
         """
         Plot an aggregate statistic for each group of a feature.
@@ -2764,11 +2764,11 @@ class Base(ABC):
             If True, display the plot. If False, the figure will not
             display until a plotting function with show=True is called.
             This allows for future plots to placed on the figure with
-            the same ``figureName`` before being shown.
-        figureName : str, None
-            A new figure will be generated when None or a new name,
-            otherwise the figure with that name will be activated to
-            draw the plot on an existing figure.
+            the same ``figureID`` before being shown.
+        figureID : hashable, None
+            A new figure will be generated for None or a new id,
+            otherwise the figure with that id will be activated to draw
+            the plot on the existing figure.
         title : str, bool
             The title of the plot. If True, a title will automatically
             be generated.
@@ -2788,15 +2788,15 @@ class Base(ABC):
         """
         self._plotFeatureGroupStatistics(
             statistic, feature, groupFeature, subgroupFeature, False,
-            horizontal, outPath, show, figureName, title, xAxisLabel,
+            horizontal, outPath, show, figureID, title, xAxisLabel,
             yAxisLabel, **kwargs)
 
     @pyplotRequired
     def _plotFeatureGroupStatistics(
             self, statistic, feature, groupFeature, subgroupFeature,
-            confidenceIntervals, horizontal, outPath, show, figureName, title,
+            confidenceIntervals, horizontal, outPath, show, figureID, title,
             xAxisLabel, yAxisLabel, **kwargs):
-        fig, ax = plotFigureHandling(figureName)
+        fig, ax = plotFigureHandling(figureID)
         featureName = self._formattedStringID('feature', feature)
         if hasattr(statistic, '__name__') and statistic.__name__ != '<lambda>':
             statName = statistic.__name__

--- a/nimble/core/data/features.py
+++ b/nimble/core/data/features.py
@@ -2222,7 +2222,7 @@ class Features(ABC):
 
     @limitedTo2D
     def plot(self, features=None, horizontal=False, outPath=None,
-             show=True, figureName=None, title=True, xAxisLabel=True,
+             show=True, figureID=None, title=True, xAxisLabel=True,
              yAxisLabel=True, legendTitle=None, **kwargs):
         """
         Bar chart comparing features.
@@ -2247,11 +2247,11 @@ class Features(ABC):
             If True, display the plot. If False, the figure will not
             display until a plotting function with show=True is called.
             This allows for future plots to placed on the figure with
-            the same ``figureName`` before being shown.
-        figureName : str, None
-            A new figure will be generated when None or a new name,
-            otherwise the figure with that name will be activated to
-            draw the plot on an existing figure.
+            the same ``figureID`` before being shown.
+        figureID : hashable, None
+            A new figure will be generated for None or a new id,
+            otherwise the figure with that id will be activated to draw
+            the plot on the existing figure.
         title : str, bool
             The title of the plot. If True, a title will automatically
             be generated.
@@ -2274,12 +2274,12 @@ class Features(ABC):
             matplotlib.pyplot.bar
         """
         self._plotComparison(
-            None, features, None, horizontal, outPath, show, figureName, title,
+            None, features, None, horizontal, outPath, show, figureID, title,
             xAxisLabel, yAxisLabel, legendTitle, **kwargs)
 
     @limitedTo2D
     def plotMeans(self, features=None, horizontal=False, outPath=None,
-                  show=True, figureName=None, title=True, xAxisLabel=True,
+                  show=True, figureID=None, title=True, xAxisLabel=True,
                   yAxisLabel=True, **kwargs):
         """
         Plot feature means with 95% confidence interval bars.
@@ -2301,11 +2301,11 @@ class Features(ABC):
             If True, display the plot. If False, the figure will not
             display until a plotting function with show=True is called.
             This allows for future plots to placed on the figure with
-            the same ``figureName`` before being shown.
-        figureName : str, None
-            A new figure will be generated when None or a new name,
-            otherwise the figure with that name will be activated to
-            draw the plot on an existing figure.
+            the same ``figureID`` before being shown.
+        figureID : hashable, None
+            A new figure will be generated for None or a new id,
+            otherwise the figure with that id will be activated to draw
+            the plot on the existing figure.
         title : str, bool
             The title of the plot. If True, a title will automatically
             be generated.
@@ -2325,12 +2325,12 @@ class Features(ABC):
         """
         self._plotComparison(
             nimble.calculate.mean, features, True, horizontal, outPath,
-            show, figureName, title, xAxisLabel, yAxisLabel, None, **kwargs)
+            show, figureID, title, xAxisLabel, yAxisLabel, None, **kwargs)
 
     @limitedTo2D
     def plotStatistics(
             self, statistic, features=None, horizontal=False, outPath=None,
-            show=True, figureName=None, title=True, xAxisLabel=True,
+            show=True, figureID=None, title=True, xAxisLabel=True,
             yAxisLabel=True, legendTitle=None, **kwargs):
         """
         Bar chart comparing an aggregate statistic between features.
@@ -2362,11 +2362,11 @@ class Features(ABC):
             If True, display the plot. If False, the figure will not
             display until a plotting function with show=True is called.
             This allows for future plots to placed on the figure with
-            the same ``figureName`` before being shown.
-        figureName : str, None
-            A new figure will be generated when None or a new name,
-            otherwise the figure with that name will be activated to
-            draw the plot on an existing figure.
+            the same ``figureID`` before being shown.
+        figureID : hashable, None
+            A new figure will be generated for None or a new id,
+            otherwise the figure with that id will be activated to draw
+            the plot on the existing figure.
         title : str, bool
             The title of the plot. If True, a title will automatically
             be generated.
@@ -2389,7 +2389,7 @@ class Features(ABC):
             matplotlib.pyplot.bar
         """
         self._plotComparison(
-            statistic, features, False, horizontal, outPath, show, figureName,
+            statistic, features, False, horizontal, outPath, show, figureID,
             title, xAxisLabel, yAxisLabel, legendTitle, **kwargs)
 
     ####################
@@ -2511,7 +2511,7 @@ class Features(ABC):
 
     @abstractmethod
     def _plotComparison(self, statistic, identifiers, confidenceIntervals,
-                        horizontal, outPath, show, figureName, title,
+                        horizontal, outPath, show, figureID, title,
                         xAxisLabel, yAxisLabel, legendTitle, **kwargs):
         pass
 

--- a/nimble/core/data/points.py
+++ b/nimble/core/data/points.py
@@ -2114,7 +2114,7 @@ class Points(ABC):
 
     @limitedTo2D
     def plot(self, points=None, horizontal=False, outPath=None,
-             show=True, figureName=None, title=True, xAxisLabel=True,
+             show=True, figureID=None, title=True, xAxisLabel=True,
              yAxisLabel=True, legendTitle=None, **kwargs):
         """
         Bar chart comparing points.
@@ -2139,11 +2139,11 @@ class Points(ABC):
             If True, display the plot. If False, the figure will not
             display until a plotting function with show=True is called.
             This allows for future plots to placed on the figure with
-            the same ``figureName`` before being shown.
-        figureName : str, None
-            A new figure will be generated when None or a new name,
-            otherwise the figure with that name will be activated to
-            draw the plot on an existing figure.
+            the same ``figureID`` before being shown.
+        figureID : hashable, None
+            A new figure will be generated for None or a new id,
+            otherwise the figure with that id will be activated to draw
+            the plot on the existing figure.
         title : str, bool
             The title of the plot. If True, a title will automatically
             be generated.
@@ -2166,12 +2166,12 @@ class Points(ABC):
             matplotlib.pyplot.bar
         """
         self._plotComparison(
-            None, points, None, horizontal, outPath, show, figureName, title,
+            None, points, None, horizontal, outPath, show, figureID, title,
             xAxisLabel, yAxisLabel, legendTitle, **kwargs)
 
     @limitedTo2D
     def plotMeans(self, points=None, horizontal=False, outPath=None,
-                  show=True, figureName=None, title=True, xAxisLabel=True,
+                  show=True, figureID=None, title=True, xAxisLabel=True,
                   yAxisLabel=True, **kwargs):
         """
         Plot point means with 95% confidence interval bars.
@@ -2193,11 +2193,11 @@ class Points(ABC):
             If True, display the plot. If False, the figure will not
             display until a plotting function with show=True is called.
             This allows for future plots to placed on the figure with
-            the same ``figureName`` before being shown.
-        figureName : str, None
-            A new figure will be generated when None or a new name,
-            otherwise the figure with that name will be activated to
-            draw the plot on an existing figure.
+            the same ``figureID`` before being shown.
+        figureID : hashable, None
+            A new figure will be generated for None or a new id,
+            otherwise the figure with that id will be activated to draw
+            the plot on the existing figure.
         title : str, bool
             The title of the plot. If True, a title will automatically
             be generated.
@@ -2217,12 +2217,12 @@ class Points(ABC):
         """
         self._plotComparison(
             nimble.calculate.mean, points, True, horizontal, outPath,
-            show, figureName, title, xAxisLabel, yAxisLabel, None, **kwargs)
+            show, figureID, title, xAxisLabel, yAxisLabel, None, **kwargs)
 
     @limitedTo2D
     def plotStatistics(
             self, statistic, points=None, horizontal=False, outPath=None,
-            show=True, figureName=None, title=True, xAxisLabel=True,
+            show=True, figureID=None, title=True, xAxisLabel=True,
             yAxisLabel=True, legendTitle=None, **kwargs):
         """
         Bar chart comparing an aggregate statistic between points.
@@ -2254,11 +2254,11 @@ class Points(ABC):
             If True, display the plot. If False, the figure will not
             display until a plotting function with show=True is called.
             This allows for future plots to placed on the figure with
-            the same ``figureName`` before being shown.
-        figureName : str, None
-            A new figure will be generated when None or a new name,
-            otherwise the figure with that name will be activated to
-            draw the plot on an existing figure.
+            the same ``figureID`` before being shown.
+        figureID : hashable, None
+            A new figure will be generated for None or a new id,
+            otherwise the figure with that id will be activated to draw
+            the plot on the existing figure.
         title : str, bool
             The title of the plot. If True, a title will automatically
             be generated.
@@ -2281,7 +2281,7 @@ class Points(ABC):
             matplotlib.pyplot.bar
         """
         self._plotComparison(
-            statistic, points, False, horizontal, outPath, show, figureName,
+            statistic, points, False, horizontal, outPath, show, figureID,
             title, xAxisLabel, yAxisLabel, legendTitle, **kwargs)
 
     ####################
@@ -2409,6 +2409,6 @@ class Points(ABC):
 
     @abstractmethod
     def _plotComparison(self, statistic, identifiers, confidenceIntervals,
-                        horizontal, outPath, show, figureName, title,
+                        horizontal, outPath, show, figureID, title,
                         xAxisLabel, yAxisLabel, legendTitle, **kwargs):
         pass

--- a/tests/manualScripts/plottingExample.py
+++ b/tests/manualScripts/plottingExample.py
@@ -47,10 +47,10 @@ if __name__ == "__main__":
         alpha = 0.5
         shiftLeft = plotObj - 1
         shiftRight = plotObj + 1
-        shiftLeft.plotFeatureDistribution(0, show=False, figureName='dists',
+        shiftLeft.plotFeatureDistribution(0, show=False, figureID=0,
                                           alpha=alpha, label='shiftLeft')
         shiftRight.plotFeatureDistribution(0, outPath=outPath, title=title,
-                                           show=False, figureName='dists',
+                                           show=False, figureID=0,
                                            label='shiftRight', alpha=alpha,
                                            color='g')
 
@@ -87,12 +87,12 @@ if __name__ == "__main__":
         obj1 = nimble.data("Matrix", raw1)
 
         obj1.plotFeatureAgainstFeatureRollingAverage(
-            0, 1, 10, outPath=None, show=False, figureName='noise', label='1')
+            0, 1, 10, outPath=None, show=False, figureID='noise', label='1')
 
         title = 'Feature 0 Vs Feature 0 + Noises 1 and 2'
         outPath = getOutPath(outDir, "NoiseVsMultipleScaled")
         obj1.plotFeatureAgainstFeatureRollingAverage(
-            0, 2, 10, outPath=outPath, show=givenShow, figureName='noise',
+            0, 2, 10, outPath=outPath, show=givenShow, figureID='noise',
             label='2', title=title, yAxisLabel='')
 
         labels = nimble.data('List', ['ONE', 'TWO', 'THREE'] * 20).T
@@ -114,7 +114,7 @@ if __name__ == "__main__":
         # our helpers allow the yMax value to remain dynamic (expanding to
         # ~4) when adding the plots below while keeping our defined yMin.
         obj.plotFeatureAgainstFeature(0, 1, yMin=0.5, show=False,
-                                      figureName='fig', label=label)
+                                      figureID='fig', label=label)
 
         for i in range(1, 4):
             if i < 3:
@@ -129,7 +129,7 @@ if __name__ == "__main__":
 
             label = 'cluster' + str(i)
             scaled.plotFeatureAgainstFeature(0, 1, show=show, outPath=outPath,
-                                             figureName='fig', label=label)
+                                             figureID='fig', label=label)
 
     def makeCheckered(val, p, f):
         pParity = p % 2
@@ -186,27 +186,27 @@ if __name__ == "__main__":
 
         plotObj.plotFeatureGroupStatistics(
             nimble.calculate.sum, feature=2, groupFeature=0, show=False,
-            figureName='count', color='y', alpha=0.6)
+            figureID='count', color='y', alpha=0.6)
         plotObj.plotFeatureGroupStatistics(
             nimble.calculate.sum, feature=2, groupFeature=0,
             subgroupFeature=1, outPath=outPath, show=givenShow,
-            figureName='count', edgecolor='k')
+            figureID='count', edgecolor='k')
 
         plotObj.plotFeatureGroupStatistics(
             nimble.calculate.count, feature=1, groupFeature=0,
             subgroupFeature=1, outPath=outPath, show=givenShow,
-            figureName='count', color=['black', 'yellow'])
+            figureID='count', color=['black', 'yellow'])
         # Strange example with given data but used to highlight two things:
         # 1) Proper bar spacing when the subgroup does not contain all of the
         # unique values in the in the subgroup feature
         # 2) The color spectrum does not repeat with more than 10 subgroup bars
         plotObj.plotFeatureGroupStatistics(
             nimble.calculate.count, feature=2, groupFeature=0, show=False,
-            figureName='count', color='y', alpha=0.6)
+            figureID='count', color='y', alpha=0.6)
         plotObj.plotFeatureGroupStatistics(
             nimble.calculate.count, feature=2, groupFeature=0,
             subgroupFeature=2, outPath=outPath, show=givenShow,
-            figureName='count', edgecolor='k')
+            figureID='count', edgecolor='k')
 
     def plotFeatureSumsManual(plotObj, outDir, givenShow):
         outPath = getOutPath(outDir, "groupSumsManual")


### PR DESCRIPTION
`figureName` was already able to be any hashable, but there was one bug. `if figureName` would skip values like `''` or `0`, when `None` is the only value that indicates a `figureName` is not being supplied. With the change to any hashable, the name was changed to `figureID` and the docstrings were updated.