### PR TITLE
predetermine dtype for conversion to numpy array

### DIFF
--- a/nimble/core/_createHelpers.py
+++ b/nimble/core/_createHelpers.py
@@ -761,7 +761,9 @@ def convertData(returnType, rawData, pointNames, featureNames, copied):
                         rawData = rawData.copy()
                     for i, iterator in enumerate(rawData):
                         rawData[i] = list(iterator)
-        elif returnType == 'Matrix' and len(rawData.shape) == 1:
+        elif (returnType == 'Matrix' and
+              (len(rawData.shape) == 1 or
+              not allowedNumpyDType(rawData.dtype))):
             rawData = numpy2DArray(rawData)
         return rawData
     ret = convertToBest(rawData, pointNames, featureNames)

--- a/nimble/core/data/_dataHelpers.py
+++ b/nimble/core/data/_dataHelpers.py
@@ -15,7 +15,7 @@ from nimble import match
 from nimble._utility import pd, plt, scipy
 from nimble._utility import inspectArguments
 from nimble._utility import isAllowedSingleElement
-from nimble._utility import is2DArray, numpy2DArray
+from nimble._utility import is2DArray
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
 from nimble.exceptions import InvalidArgumentValueCombination
 from nimble.exceptions import ImproperObjectAction, PackageException
@@ -1181,19 +1181,6 @@ def isValid2DObject(data):
     Determine validity of object for nimble data object instantiation.
     """
     return is2DArray(data) or is2DList(data)
-
-def numpyArrayFromList(data):
-    """
-    Use object dtype when all data is not int or float.
-    """
-    ret = numpy2DArray(data)
-    if ret.dtype not in (bool, np.bool_, np.object_):
-        # numpy will autoconvert bool values, we want to keep them as bools
-        for point in data:
-            if any(isinstance(val, bool) for val in point):
-                return numpy2DArray(data, dtype=np.object_)
-
-    return ret
 
 def modifyNumpyArrayValue(arr, index, newVal):
     """

--- a/nimble/core/data/matrix.py
+++ b/nimble/core/data/matrix.py
@@ -22,7 +22,7 @@ from ._dataHelpers import csvCommaFormat
 from ._dataHelpers import denseCountUnique
 from ._dataHelpers import NimbleElementIterator
 from ._dataHelpers import convertToNumpyOrder, modifyNumpyArrayValue
-from ._dataHelpers import isValid2DObject, numpyArrayFromList
+from ._dataHelpers import isValid2DObject
 
 @inheritDocstringsFactory(Base)
 class Matrix(Base):
@@ -46,10 +46,8 @@ class Matrix(Base):
             msg += "or python list."
             raise InvalidArgumentType(msg)
 
-        if isinstance(data, np.matrix):
+        if isinstance(data, (np.matrix, list)):
             data = numpy2DArray(data)
-        elif isinstance(data, list):
-            data = numpyArrayFromList(data)
         if reuseData:
             self._data = data
         else:

--- a/nimble/core/data/sparse.py
+++ b/nimble/core/data/sparse.py
@@ -13,6 +13,7 @@ from nimble.exceptions import PackageException
 from nimble._utility import inheritDocstringsFactory
 from nimble._utility import scipy, pd
 from nimble._utility import sparseMatrixToArray, removeDuplicatesNative
+from nimble._utility import numpy2DArray
 from .base import Base
 from .views import BaseView
 from .sparseAxis import SparsePoints, SparsePointsView
@@ -24,7 +25,7 @@ from ._dataHelpers import csvCommaFormat
 from ._dataHelpers import denseCountUnique
 from ._dataHelpers import NimbleElementIterator
 from ._dataHelpers import convertToNumpyOrder, modifyNumpyArrayValue
-from ._dataHelpers import isValid2DObject, numpyArrayFromList
+from ._dataHelpers import isValid2DObject
 from ._dataHelpers import validateAxis
 
 @inheritDocstringsFactory(Base)
@@ -64,7 +65,7 @@ class Sparse(Base):
             self._data = data.tocoo()
         else: # data is np.array or python list
             if isinstance(data, list):
-                data = numpyArrayFromList(data)
+                data = numpy2DArray(data)
             # Sparse will convert None to 0 so we need to use np.nan instead
             # pylint: disable=singleton-comparison
             if data[data == None].size:


### PR DESCRIPTION
Modified `numpy2DArray` to determine the best dtype for the array whenever the object passed to the function is not already a numpy array. This is necessary because long strings in the data will lead numpy to select a unicode dtype and allocate the amount of memory needed to store the longest string to each item in the object. 

To determine the best dtype, the array is first created with the object dtype. Then the types of objects within the array are identified and the unique types are analyzed to determine whether a numeric dtype can be applied. The `bool`, `int`, and `float` types in python and numpy are subclasses of `numbers.Number`. However, if there are `bool` values mixed with other numeric values in the data, we will continue to use the object dtype so the boolean types are not converted. 

This change allowed for `numpyArrayFromList` in _dataHelpers to be removed.