### PR TITLE
change saved object extension to .pickle

### DIFF
--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -1679,10 +1679,9 @@ class Base(ABC):
         Parameters
         ----------
         outputPath : str
-            The location (including file name and extension) where
-            we want to write the output file. If filename extension
-            .nimd is not included in file name it would be added to the
-            output file.
+            The location (including file name and extension) where we
+            want to write the output file. If a filename extension is
+            not included, the ".pickle" extension will be added.
 
         Keywords
         --------
@@ -1692,16 +1691,12 @@ class Base(ABC):
             msg = "To save nimble objects, cloudpickle must be installed"
             raise PackageException(msg)
 
-        extension = '.nimd'
-        if not outputPath.endswith(extension):
-            outputPath = outputPath + extension
+        extension = os.path.splitext(outputPath)[1]
+        if not extension:
+            outputPath += '.pickle'
 
         with open(outputPath, 'wb') as file:
             cloudpickle.dump(self, file)
-        # TODO: save session
-        # print('session_' + outputFilename)
-        # print(globals())
-        # dill.dump_session('session_' + outputFilename)
 
     def getTypeString(self):
         """

--- a/nimble/core/interfaces/universal_interface.py
+++ b/nimble/core/interfaces/universal_interface.py
@@ -12,6 +12,7 @@ import sys
 import numbers
 import time
 import warnings
+import os
 
 import numpy as np
 
@@ -1178,17 +1179,17 @@ class TrainedLearner(object):
         Parameters
         ----------
         outputPath : str
-            The location (including file name and extension) where
-            we want to write the output file. If filename extension
-            .nimm is not included in file name it would be added to the
-            output file.
+            The location (including file name and extension) where we
+            want to write the output file. If a filename extension is
+            not included, the ".pickle" extension will be added.
         """
         if not cloudpickle.nimbleAccessible():
             msg = "To save nimble models, cloudpickle must be installed"
             raise PackageException(msg)
-        extension = '.nimm'
-        if not outputPath.endswith(extension):
-            outputPath = outputPath + extension
+
+        extension = os.path.splitext(outputPath)[-1]
+        if not extension:
+            outputPath = outputPath + '.pickle'
 
         with open(outputPath, 'wb') as file:
             cloudpickle.dump(self, file)

--- a/tests/data/high_dimension_backend.py
+++ b/tests/data/high_dimension_backend.py
@@ -183,7 +183,7 @@ class HighDimensionSafe(DataTestObject):
             toSaveShape = toSave._shape
             assert len(toSave._shape) > 2
 
-            with tempfile.NamedTemporaryFile(suffix=".nimd") as tmpFile:
+            with tempfile.NamedTemporaryFile(suffix=".pickle") as tmpFile:
                 toSave.save(tmpFile.name)
                 loadObj = nimble.data(None, tmpFile.name)
 

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -352,20 +352,35 @@ class QueryBackend(DataTestObject):
         data = [[1, 2, 3], [1, 2, 3], [2, 4, 6], [0, 0, 0]]
         featureNames = ['one', 'two', 'three']
         pointNames = ['1', 'one', '2', '0']
-        toSave = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
+        toSave = self.constructor(data, pointNames=pointNames,
+                                  featureNames=featureNames)
 
-        with tempfile.NamedTemporaryFile(suffix=".nimd") as tmpFile:
+        with tempfile.NamedTemporaryFile(suffix=".pickle") as tmpFile:
             toSave.save(tmpFile.name)
-            LoadObj = nimble.data(None, tmpFile.name)
+            load1 = nimble.data(None, tmpFile.name)
 
-        assert toSave.isIdentical(LoadObj)
-        assert LoadObj.isIdentical(toSave)
+        assert toSave.isIdentical(load1)
+        assert load1.isIdentical(toSave)
+
+        with tempfile.NamedTemporaryFile(suffix=".p") as tmpFile:
+            toSave.save(tmpFile.name)
+            load2 = nimble.data(None, tmpFile.name)
+
+        assert toSave.isIdentical(load2)
+        assert load2.isIdentical(toSave)
+
+        with tempfile.NamedTemporaryFile() as tmpFile:
+            toSave.save(tmpFile.name)
+            load3 = nimble.data(None, tmpFile.name + ".pickle")
+
+        assert toSave.isIdentical(load3)
+        assert load3.isIdentical(toSave)
 
     def test_save_lazyNameGeneration(self):
         data = [[1, 2, 3], [1, 2, 3], [2, 4, 6], [0, 0, 0]]
         toSave = self.constructor(data)
 
-        with tempfile.NamedTemporaryFile(suffix=".nimd") as tmpFile:
+        with tempfile.NamedTemporaryFile(suffix=".pickle") as tmpFile:
             toSave.save(tmpFile.name)
 
         assertNoNamesGenerated(toSave)
@@ -376,13 +391,13 @@ class QueryBackend(DataTestObject):
         pointNames = ['1', 'one', '2', '0']
         toSave = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
 
-        with tempfile.NamedTemporaryFile(suffix=".nimd") as tmpFile:
-            # save without extension to ensure the .nimd extension is added
-            fileNameWithoutExtension = tmpFile.name[:-5]
+        with tempfile.NamedTemporaryFile(suffix=".pickle") as tmpFile:
+            # save without extension to ensure the .pickle extension is added
+            fileNameWithoutExtension = tmpFile.name[:-7]
             # it is important that the saved object has the same name as the
             # tmpFile otherwise a new file will be created and saved which will
             # not be cleaned up by tempfile.
-            assert fileNameWithoutExtension + '.nimd' == tmpFile.name
+            assert fileNameWithoutExtension + '.pickle' == tmpFile.name
 
             toSave.save(fileNameWithoutExtension)
             LoadObj = nimble.data(None, tmpFile.name)
@@ -398,7 +413,7 @@ class QueryBackend(DataTestObject):
         pointNames = ['1', 'one', '2', '0']
         toSave = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
 
-        with tempfile.NamedTemporaryFile(suffix=".nimd") as tmpFile:
+        with tempfile.NamedTemporaryFile(suffix=".pickle") as tmpFile:
             toSave.save(tmpFile.name)
             LoadObj = nimble.data(None, tmpFile.name)
 

--- a/tests/interfaces/scikit_learn_interface_test.py
+++ b/tests/interfaces/scikit_learn_interface_test.py
@@ -816,7 +816,7 @@ def _apply_saveLoad(trainerLearnerObj, givenTestX):
     Given a TrainedLearner object, return the results of apply after having
     saved then loaded the learner from a file.
     """
-    with tempfile.NamedTemporaryFile(suffix=".nimm") as tmpFile:
+    with tempfile.NamedTemporaryFile(suffix=".pickle") as tmpFile:
         trainerLearnerObj.save(tmpFile.name)
         trainer_ret_l = loadTrainedLearner(tmpFile.name)
         return trainer_ret_l.apply(givenTestX, useLog=False)
@@ -830,7 +830,7 @@ def test_saveLoadTrainedLearner_logCount():
     trainObj = nimble.data('Matrix', train, useLog=False)
 
     tl = nimble.train('SciKitLearn.LogisticRegression', trainObj, 0, useLog=False)
-    with tempfile.NamedTemporaryFile(suffix=".nimm") as tmpFile:
+    with tempfile.NamedTemporaryFile(suffix=".pickle") as tmpFile:
         tl.save(tmpFile.name)
         load = loadTrainedLearner(tmpFile.name)
 

--- a/tests/logger/testLoggingFlags.py
+++ b/tests/logger/testLoggingFlags.py
@@ -60,10 +60,10 @@ def loadAndCheck(toCall, useLog, *args):
 def test_data():
     for rType in nimble.core.data.available:
         back_load(nimble.data, rType, [[1, 2, 3], [4, 5, 6]])
-    
+
     for constructor in constructors:
         obj = constructor([[1, 2, 3], [4, 5, 6]], useLog=False)
-        with tempfile.NamedTemporaryFile(suffix='.nimd') as tmpFile:
+        with tempfile.NamedTemporaryFile(suffix='.pickle') as tmpFile:
             obj.save(tmpFile.name)
             back_load(nimble.data, None, tmpFile.name)
 
@@ -78,7 +78,7 @@ def test_loadTrainedLearner():
         trainX = constructor([[0, 0, 1], [0, 1, 0], [1, 0, 0]], useLog=False)
         trainY = constructor([[3], [2], [1]], useLog=False)
         tl = nimble.train('nimble.KNNClassifier', trainX, trainY)
-        with tempfile.NamedTemporaryFile(suffix='.nimm') as tmpFile:
+        with tempfile.NamedTemporaryFile(suffix='.pickle') as tmpFile:
             tl.save(tmpFile.name)
             back_load(nimble.loadTrainedLearner, tmpFile.name)
 

--- a/tests/logger/testLoggingIO.py
+++ b/tests/logger/testLoggingIO.py
@@ -199,7 +199,7 @@ def testLoadTypeFunctionsUseLog():
     assert "'numPoints': 4" in logInfo
     assert "'numFeatures': 1" in logInfo
 
-    with tempfile.NamedTemporaryFile(suffix=".nimd") as tmpFile:
+    with tempfile.NamedTemporaryFile(suffix=".pickle") as tmpFile:
         trainXObj.save(tmpFile.name)
         load = nimble.data(None, tmpFile.name)
     logInfo = getLastLogData()
@@ -216,7 +216,7 @@ def testLoadTypeFunctionsUseLog():
 
     # loadTrainedLearner
     tl = nimble.train('nimble.KNNClassifier', trainXObj, trainYObj, arguments={'k': 1})
-    with tempfile.NamedTemporaryFile(suffix=".nimm") as tmpFile:
+    with tempfile.NamedTemporaryFile(suffix=".pickle") as tmpFile:
         tl.save(tmpFile.name)
         load = nimble.loadTrainedLearner(tmpFile.name)
     logInfo = getLastLogData()


### PR DESCRIPTION
To better indicates the saved file type, change to using the '.pickle' extension instead of '.nimd' and '.nimm' for saving Base and TrainedLearner objects. The extension is only added if the user provides a path without an extension.