### PR TITLE
repr for points/features

### DIFF
--- a/tests/data/high_dimension_backend.py
+++ b/tests/data/high_dimension_backend.py
@@ -97,7 +97,7 @@ class HighDimensionSafe(DataTestObject):
             expRepr = repr(exp).split('\n')
             assert dims in testRepr[0] and shape in expRepr[0]
             assert testRepr[1:] == expRepr[1:]
-            
+
             try:
                 stdout1 = StringIO()
                 stdout2 = StringIO()
@@ -669,6 +669,18 @@ class HighDimensionModifying(DataTestObject):
         ftAxis = getattr(toTest, 'features')
         for method in ftDisallowed:
             assert isLimitedTo2D(ftAxis, method)
+
+    def test_highDimension_strings(self):
+        """Test that string representations work for high dimensions"""
+        for tensor in tensors:
+            toTest = self.constructor(tensor)
+            str(toTest)
+            repr(toTest)
+            toTest.show()
+            str(toTest.points)
+            repr(toTest.points)
+            str(toTest.features)
+            repr(toTest.features)
 
 class HighDimensionAll(HighDimensionSafe, HighDimensionModifying):
     pass

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -3,9 +3,10 @@ Methods tested in this file (none modify the data):
 
 pointCount, featureCount, isIdentical, writeFile, __getitem__,
 pointView, featureView, view, containsZero, __eq__, __ne__, toString,
-__repr__, points.similarities, features.similarities, points.statistics,
-features.statistics, points.__iter__, features.__iter__,
-iterateElements, inverse, solveLinearSystem, report, features.report
+__repr__, points.__repr__, features.__repr__, points.similarities,
+features.similarities, points.statistics, features.statistics,
+points.__iter__, features.__iter__, iterateElements, inverse,
+solveLinearSystem, report, features.report
 """
 
 import math
@@ -1357,9 +1358,9 @@ class QueryBackend(DataTestObject):
                             for colSep in ['', ' ', '  ']:
                                 runTrial(pNum, fNum, valLen, maxW, maxH, colSep)
 
-    ############
-    # __repr__ #
-    ############
+    ################################################
+    # __repr__, points.__repr__, features.__repr__ #
+    ################################################
 
     def back_reprOutput(self, numPts, numFts, truncated=False, defaults='none',
                         addPath=False):
@@ -1392,7 +1393,7 @@ class QueryBackend(DataTestObject):
             else:
                 assert name in fNames
         assert re.match('\s*┌─+$', retSplit[2])
-        dataMatch = re.compile(r'\s.*? │ [0-9\.\s\-\|]+')
+        dataMatch = re.compile(r' +[pf]?t?([0-9]+)?\|? │ [0-9\.\s\-\|]+')
         for line in retSplit[3:-1]:
             assert re.match(dataMatch, line)
             pName = line.split('│')[0].strip()
@@ -1407,6 +1408,23 @@ class QueryBackend(DataTestObject):
             assert retSplit[-1].endswith('>')
         else:
             assert retSplit[-1] == '>'
+
+        addIdxMatch = re.compile(r' [ 0-9|]+? │( +\|?| +[pf]t[0-9]+) │ [0-9\. \-\|]+')
+        for axis, length in [(data.points, numPts), (data.features, numFts)]:
+            axRepr = repr(axis)
+            axSplit = axRepr.split('\n')
+            assert axSplit[0] == "< " + str(length) + " {}s".format(axis._axis)
+            for line in axSplit[1:-1]:
+                print(line)
+                if defaults == 'all':
+                    assert re.match(dataMatch, line)
+                else:
+                    assert re.match(addIdxMatch, line)
+                if truncated:
+                    assert '--' in line
+                else:
+                    assert '--' not in line
+            assert axSplit[-1] == ' >'
 
     def test_repr_notTruncated(self):
         self.back_reprOutput(9, 9)


### PR DESCRIPTION
Modify the `__repr__` and `__str__` methods for `Axis`. The first line of output indicates the count of points/features in the object. The following lines display a point/feature in each row. If point/feature names are present, an additional column is prepended with the index values as well. This is accomplished by modifying the `__str__` output for `Base` so it is also truncated when necessary.  The `__repr__` output is wrapped in angle brackets, the string output is exactly the same but without the angle brackets.