### PR TITLE
handle all missing in axis repr correctly

### DIFF
--- a/nimble/core/data/axis.py
+++ b/nimble/core/data/axis.py
@@ -115,10 +115,10 @@ class Axis(ABC):
 
         start = len(indent) - 1 # to remove extra indentation when adding col
         string = obj._show(indent=indent, quoteNames=False)
-        match = re.search(u' +\u2502[ \u2502\u2500]+\n', string)
+        match = re.search(u'\n +\u2502[ \u2502\u2500]+\n', string)
         newLine = u' {} \u2502{}\n'.format
         if match:
-            top, bottom = string.split(match.group(0))
+            top, bottom = string.split(match.group(0)[1:])
             for i, line in enumerate(top.split('\n')[:-1]):
                 if i < 3:
                     continue
@@ -127,10 +127,10 @@ class Axis(ABC):
                     ret += newLine(str(i - 3).rjust(maxIdxLen), line)
                 else:
                     ret += line + '\n'
+
             if self._namesCreated():
-                if maxIdxLen > 2:
-                    ret += ' ' + u'\u2502'.rjust(maxIdxLen) + u' \u2502'
-            ret += match.group(0)[start:]
+                ret += ' ' + u'\u2502'.rjust(maxIdxLen) + u' \u2502'
+            ret += match.group(0)[start + 1:]
 
             bottomIdx = len(self) - len(bottom.split('\n')) + 1
             for i, line in enumerate(bottom.split('\n')[:-1]):

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -1381,6 +1381,11 @@ class QueryBackend(DataTestObject):
     def back_reprOutput(self, numPts, numFts, truncated=False, defaults='none',
                         addPath=False):
         randGen = nimble.random.data("List", numPts, numFts, 0)
+        # make a row and column all missing
+        def makeMissing(vect):
+            return [np.nan for _ in vect]
+        randGen.points.transform(makeMissing, points=1)
+        randGen.features.transform(makeMissing, features=1)
         kwargs = {}
         if defaults != 'all':
             pNames = ['pt' + str(i) for i in range(numPts)]
@@ -1419,7 +1424,7 @@ class QueryBackend(DataTestObject):
                 assert name in fNames
 
         assert re.match(u'\s*\u250C\u2500+$', retSplit[2])
-        dataMatch = re.compile(u"( +| +[0-9]+| +'[pf]t[0-9]+'| +\u2502) \u2502 [-0-9\. \u2502\u2500]+")
+        dataMatch = re.compile(u"( +| +[0-9]+| +'[pf]t[0-9]+'| +\u2502) \u2502($| [-0-9\. \u2502\u2500]+)")
         for line in retSplit[3:-1]:
             assert re.match(dataMatch, line)
             pName = line.split(u'\u2502')[0].strip()
@@ -1446,7 +1451,7 @@ class QueryBackend(DataTestObject):
         else:
             assert retSplit[-1] == '>'
 
-        addIdxMatch = re.compile(u' [ 0-9\u2502]+? \u2502( +\u2502?| +[pf]t[0-9]+) \u2502 [-0-9\. \u2502\u2500]+')
+        addIdxMatch = re.compile(u' [ 0-9\u2502]+? \u2502( +\u2502?| +[pf]t[0-9]+) \u2502($| [-0-9\. \u2502\u2500]+)')
         for axis, length in [(data.points, numPts), (data.features, numFts)]:
             axRepr = repr(axis)
             axSplit = axRepr.split('\n')


### PR DESCRIPTION
The `repr` for `Axis` modifies the a string of the `Base` object and uses a regular expression to identify the line that truncates the data. When a line contains all missing data, the regex would also mistakenly identify this as the truncation row. Now the regex will not match these lines. The tests were modified to include a point and feature with all missing data.