### PR TITLE
Swap pylint and pytest dependencies back to the correct entries

### DIFF
--- a/nimble/_dependencies.py
+++ b/nimble/_dependencies.py
@@ -64,8 +64,8 @@ _DEPENDENCIES = [
     Dependency('keras', 'keras>=2.0', 'interfaces', 'Neural Networks'),
     Dependency('autoimpute', 'autoimpute>=0.12', 'interfaces',
                'Imputation & machine learning with missing data'),
-    Dependency('pylint', 'pylint>=6.2', 'development'),
-    Dependency('pytest', 'pytest>=2.7.4', 'development'),
+    Dependency('pytest', 'pytest>=6.2', 'development'),
+    Dependency('pylint', 'pylint>=2.7.4', 'development'),
     Dependency('cython', 'cython>=0.29', 'development'),
     Dependency('sphinx', 'sphinx>=3.3', 'development'),
     ]


### PR DESCRIPTION
Within the python 3.6 EOL PR, these got swapped for some reason. Since it was a swap, the requirements were still in place, just not labeled correctly. Regardless, it has been corrected.