### PR TITLE
combine writeFile into save method

### DIFF
--- a/changelogs/v0.3.0
+++ b/changelogs/v0.3.0
@@ -37,3 +37,6 @@
 * Python 3.6 reached EOL Dec 2021. Support for it has been removed.
 * The mlpy package, since it required python 3.6 , has been removed.
 * The shogun package, since it required python 3.6, has been removed.
+
+### Save ###
+* Combine writeFile() and save() into a single save() method

--- a/documentation/source/_templates/cheatsheet/cheatsheet-template.html
+++ b/documentation/source/_templates/cheatsheet/cheatsheet-template.html
@@ -248,14 +248,14 @@
           {% endblock %}
           {% block io_saving_content %}
           <div class="pad">
-            <p>Nimble data objects can be written to a csv or mtx file or saved as a pickle file.
+            <p>Nimble data objects can be written to a file in a variety of formats.
               <a class="inline" href="docs/generated/nimble.core.interfaces.TrainedLearner.html">TrainedLearner</a>
               objects can also be pickled.</p>
           </div>
           <div class="code">
-            <p> X.<a href="docs/generated/nimble.core.data.Base.writeFile.html">writeFile</a>('saved.csv')</p>
-            <p> X.<a href="docs/generated/nimble.core.data.Base.save.html">save</a>('saved.pickle')</p>
-            <p> trainedLearner.<a href="docs/generated/nimble.core.interfaces.TrainedLearner.save.html">save</a>('saved.pickle')</p>
+            <p> X.<a href="docs/generated/nimble.core.data.Base.save.html">save</a>('data.csv')</p>
+            <p> X.<a href="docs/generated/nimble.core.data.Base.save.html">save</a>('data.pickle')</p>
+            <p> trainedLearner.<a href="docs/generated/nimble.core.interfaces.TrainedLearner.save.html">save</a>('learner.pickle')</p>
           </div>
           {% endblock %}
         </div>

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -285,7 +285,8 @@ def exampleHyperlinks(app, pagename, templatename, context, doctree):
         'train': path('nimble.train'),
         '.train': path('nimble.core.interfaces.TrainedLearner.train'),
         '.apply': path('nimble.core.interfaces.TrainedLearner.apply'),
-        '.copy': path('nimble.core.data.Base.copy')}
+        '.copy': path('nimble.core.data.Base.copy'),
+        '.save': path('nimble.core.data.Base.save')}
     if pagename.startswith('examples/'):
         if 'additional_functionality' in pagename:
             app.nimble_blacklist = {'tempDir.name', 'learnerType'}

--- a/documentation/source/examples/cleaning_data.py
+++ b/documentation/source/examples/cleaning_data.py
@@ -167,7 +167,7 @@ traffic.show('Cleaned traffic data', maxHeight=16)
 
 ## We'd like to be able to load the cleaned data for our Supervised Learning
 ## example any time we want, so we will write it to a new csv file.
-traffic.writeFile('Metro_Interstate_Traffic_Volume_Cleaned.csv')
+traffic.save('Metro_Interstate_Traffic_Volume_Cleaned.csv')
 
 ## **References:**
 

--- a/nimble/_utility.py
+++ b/nimble/_utility.py
@@ -459,6 +459,17 @@ def prettyDictString(inDict, useAnd=False, numberItems=False, keyStr=str,
     return _prettyString(inDict, useAnd, numberItems,
                          iterator=lambda d: d.items(), formatter=itemFormatter)
 
+def quoteStrings(val):
+    """
+    Wrap string values in quotes.
+
+    A helper function convenient for the formatting (*Str) parameters in
+    the pretty*String functions.
+    """
+    if isinstance(val, str):
+        return f'"{val}"'
+    return str(val)
+
 def tableString(table, rowHeader=True, colHeaders=None, roundDigits=None,
                 columnSeparator="  ", maxRowsToShow=None, snipIndex=None,
                 includeTrailingNewLine=True,  rowHeadJustify='right',

--- a/nimble/core/data/dataframe.py
+++ b/nimble/core/data/dataframe.py
@@ -130,8 +130,8 @@ class DataFrame(Base):
 
         return allDataIdentical(self._asNumpyArray(), other._asNumpyArray())
 
-    def _writeFileCSV_implementation(self, outPath, includePointNames,
-                                     includeFeatureNames):
+    def _saveCSV_implementation(self, outPath, includePointNames,
+                                includeFeatureNames):
         """
         Function to write the data in this object to a CSV file at the
         designated path.
@@ -153,8 +153,8 @@ class DataFrame(Base):
         if includeFeatureNames:
             self._data.columns = pd.RangeIndex(len(self._data.columns))
 
-    def _writeFileMTX_implementation(self, outPath, includePointNames,
-                                     includeFeatureNames):
+    def _saveMTX_implementation(self, outPath, includePointNames,
+                                includeFeatureNames):
         """
         Function to write the data in this object to a matrix market
         file at the designated path.

--- a/nimble/core/data/features.py
+++ b/nimble/core/data/features.py
@@ -19,7 +19,7 @@ import nimble
 from nimble.core.logger import handleLogging
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
 from nimble.exceptions import InvalidArgumentValueCombination
-from nimble._utility import prettyListString
+from nimble._utility import prettyListString, quoteStrings
 from ._dataHelpers import limitedTo2D
 
 class Features(ABC):
@@ -2322,7 +2322,7 @@ class Features(ABC):
             stats = allow
         elif basicStatistics:
             if any(stat not in allow for stat in basicStatistics):
-                allowed = prettyListString(allow, True, itemStr="'{}'".format)
+                allowed = prettyListString(allow, True, itemStr=quoteStrings)
                 msg = 'Invalid value found in basicStatistics. Allowed '
                 msg += f'values are {allowed}'
                 raise InvalidArgumentValue(msg)

--- a/nimble/core/data/list.py
+++ b/nimble/core/data/list.py
@@ -182,8 +182,8 @@ class List(Base):
                         return False
         return True
 
-    def _writeFileCSV_implementation(self, outPath, includePointNames,
-                                     includeFeatureNames):
+    def _saveCSV_implementation(self, outPath, includePointNames,
+                                includeFeatureNames):
         """
         Function to write the data in this object to a CSV file at the
         designated path.
@@ -206,8 +206,8 @@ class List(Base):
                     first = False
                 outFile.write('\n')
 
-    def _writeFileMTX_implementation(self, outPath, includePointNames,
-                                     includeFeatureNames):
+    def _saveMTX_implementation(self, outPath, includePointNames,
+                                includeFeatureNames):
         """
         Function to write the data in this object to a matrix market
         file at the designated path.

--- a/nimble/core/data/matrix.py
+++ b/nimble/core/data/matrix.py
@@ -112,8 +112,8 @@ class Matrix(Base):
         return allDataIdentical(self._data, other._data)
 
 
-    def _writeFileCSV_implementation(self, outPath, includePointNames,
-                                     includeFeatureNames):
+    def _saveCSV_implementation(self, outPath, includePointNames,
+                                includeFeatureNames):
         """
         Function to write the data in this object to a CSV file at the
         designated path.
@@ -133,8 +133,8 @@ class Matrix(Base):
 
             np.savetxt(outFile, viewData, delimiter=',', fmt='%s')
 
-    def _writeFileMTX_implementation(self, outPath, includePointNames,
-                                     includeFeatureNames):
+    def _saveMTX_implementation(self, outPath, includePointNames,
+                                includeFeatureNames):
         if not scipy.nimbleAccessible():
             msg = "scipy is not available"
             raise PackageException(msg)

--- a/nimble/core/data/sparse.py
+++ b/nimble/core/data/sparse.py
@@ -272,8 +272,8 @@ class Sparse(Base):
     def _getTypeString_implementation(self):
         return 'Sparse'
 
-    def _writeFileCSV_implementation(self, outPath, includePointNames,
-                                     includeFeatureNames):
+    def _saveCSV_implementation(self, outPath, includePointNames,
+                                includeFeatureNames):
         """
         Function to write the data in this object to a CSV file at the
         designated path.
@@ -306,8 +306,8 @@ class Sparse(Base):
                     outFile.write(str(value))
                 outFile.write('\n')
 
-    def _writeFileMTX_implementation(self, outPath, includePointNames,
-                                     includeFeatureNames):
+    def _saveMTX_implementation(self, outPath, includePointNames,
+                                includeFeatureNames):
         def makeNameString(count, namesItoN):
             nameString = "#"
             for i in range(count):
@@ -1366,17 +1366,17 @@ class SparseView(BaseView, Sparse):
             other = other.copy(to=other.getTypeString())
         return selfConv._matmul__implementation(other)
 
-    def _writeFileCSV_implementation(self, outPath, includePointNames,
-                                     includeFeatureNames):
+    def _saveCSV_implementation(self, outPath, includePointNames,
+                                includeFeatureNames):
         selfConv = self.copy(to="Sparse")
-        selfConv._writeFileCSV_implementation(outPath, includePointNames,
-                                              includeFeatureNames)
+        selfConv._saveCSV_implementation(outPath, includePointNames,
+                                         includeFeatureNames)
 
-    def _writeFileMTX_implementation(self, outPath, includePointNames,
-                                     includeFeatureNames):
+    def _saveMTX_implementation(self, outPath, includePointNames,
+                                includeFeatureNames):
         selfConv = self.copy(to="Sparse")
-        selfConv._writeFileMTX_implementation(outPath, includePointNames,
-                                              includeFeatureNames)
+        selfConv._saveMTX_implementation(outPath, includePointNames,
+                                         includeFeatureNames)
 
     def _convertToNumericTypes_implementation(self, usableTypes):
         self._source._convertToNumericTypes_implementation(usableTypes)

--- a/nimble/core/tune.py
+++ b/nimble/core/tune.py
@@ -23,7 +23,7 @@ from nimble.core.logger import handleLogging, loggingEnabled
 from nimble.core.logger import deepLoggingEnabled
 from nimble.random import pythonRandom, numpyRandom
 from nimble.core._learnHelpers import computeMetrics
-from nimble._utility import prettyDictString, prettyListString
+from nimble._utility import prettyDictString, prettyListString, quoteStrings
 from nimble._utility import mergeArguments
 
 
@@ -168,10 +168,6 @@ class GroupFoldIterator(FoldIterator):
 
         return list(foldDict.values())
 
-def _quoteStr(val):
-    if isinstance(val, str):
-        return '"{}"'.format(val)
-    return str(val)
 
 class Validator(ABC):
     """
@@ -226,7 +222,8 @@ class Validator(ABC):
             self.__class__.__name__, self.learnerName,
             self.performanceFunction.__name__, self.randomSeed)
         if self._keywords:
-            ret += ", " + prettyDictString(self._keywords, valueStr=_quoteStr)
+            ret += ", "
+            ret += prettyDictString(self._keywords, valueStr=quoteStrings)
         ret += ")"
         return ret
 
@@ -643,7 +640,8 @@ class ArgumentSelector(ABC):
     def __repr__(self):
         ret = '{}({}'.format(self.__class__.__name__, self.arguments)
         if self._keywords:
-            ret += ", " + prettyDictString(self._keywords, valueStr=_quoteStr)
+            ret += ", "
+            ret += prettyDictString(self._keywords, valueStr=quoteStrings)
         ret += ')'
         return ret
 

--- a/tests/data/high_dimension_backend.py
+++ b/tests/data/high_dimension_backend.py
@@ -187,15 +187,23 @@ class HighDimensionSafe(DataTestObject):
         for tensor in tensors:
             toSave = self.constructor(tensor)
             toSaveShape = toSave._dims
+            toSaveType = toSave.getTypeString()
             assert len(toSave._dims) > 2
 
             with tempfile.NamedTemporaryFile(suffix=".pickle") as tmpFile:
                 toSave.save(tmpFile.name)
-                loadObj = nimble.data(tmpFile.name)
+                pklObj = nimble.data(tmpFile.name, returnType=toSaveType)
 
-            assert loadObj._dims == toSaveShape
-            assert toSave.isIdentical(loadObj)
-            assert loadObj.isIdentical(toSave)
+            with tempfile.NamedTemporaryFile(suffix=".hdf5") as tmpFile:
+                toSave.save(tmpFile.name)
+                hdf5Obj = nimble.data(tmpFile.name, returnType=toSaveType)
+
+            assert pklObj._dims == hdf5Obj._dims == toSaveShape
+            assert toSave.isIdentical(pklObj)
+
+            assert toSave.isIdentical(hdf5Obj)
+            assert pklObj.isIdentical(toSave)
+            assert hdf5Obj.isIdentical(toSave)
 
     def test_highDimension_getTypeString(self):
         retType = self.constructor([]).getTypeString()
@@ -637,9 +645,9 @@ class HighDimensionModifying(DataTestObject):
             '__rmod__', '__imod__', '__pow__', '__rpow__', '__ipow__',
             '__str__', '__repr__', '__pos__', '__neg__', '__abs__', '__copy__',
             '__deepcopy__', 'isApproximatelyEqual', 'trainAndTestSets',
-            'report', 'isIdentical', 'writeFile', 'getTypeString',
-            'pointView', 'view', 'checkInvariants', 'containsZero', 'save',
-            'toString', 'show', 'copy', 'flatten', 'unflatten',))
+            'report', 'isIdentical', 'getTypeString', 'pointView', 'view',
+            'checkInvariants', 'containsZero', 'save', 'toString', 'show',
+            'copy', 'flatten', 'unflatten',))
         baseDisallowed = baseUser.difference(baseAllowed)
 
         for method in baseDisallowed:

--- a/tests/data/high_level_backend.py
+++ b/tests/data/high_level_backend.py
@@ -1612,7 +1612,7 @@ class HighLevelDataSafe(DataTestObject):
         data = [[1, 1, 1, 1], [2, 2, 2, 2], [3, 3, 3, 3], [4, 4, 4, 4]]
         toTest = self.constructor(data, )
         with tempfile.NamedTemporaryFile(suffix='.csv') as tmpFile:
-            toTest.writeFile(tmpFile.name, fileFormat='csv')
+            toTest.save(tmpFile.name, fileFormat='csv')
 
             toTest = self.constructor(tmpFile.name, name='toTest')
 

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -1,7 +1,7 @@
 """
 Methods tested in this file (none modify the data):
 
-pointCount, featureCount, isIdentical, writeFile, __getitem__,
+pointCount, featureCount, isIdentical, save, __getitem__,
 pointView, featureView, view, containsZero, __eq__, __ne__, toString,
 __repr__, points.__repr__, features.__repr__, points.similarities,
 features.similarities, points.statistics, features.statistics,
@@ -178,13 +178,13 @@ class QueryBackend(DataTestObject):
         assertNoNamesGenerated(toTest2)
 
 
-    #############
-    # writeFile #
-    #############
+    ########
+    # save #
+    ########
 
     @noLogEntryExpected
-    def test_writeFile_CSVhandmade(self):
-        """ Test writeFile() for csv extension with both data and featureNames """
+    def test_save_CSVhandmade(self):
+        """ Test save() for csv extension with both data and featureNames """
         # instantiate object
         data = [[1, 2, 3], [1, 2, 3], [2, 4, 6], [0, 0, 0]]
         pointNames = ['1', 'one', '2', '0']
@@ -193,7 +193,7 @@ class QueryBackend(DataTestObject):
         orig = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
 
         with tempfile.NamedTemporaryFile(suffix=".csv") as tmpFile:
-            toWrite.writeFile(tmpFile.name, fileFormat='csv', includeNames=True)
+            toWrite.save(tmpFile.name, fileFormat='csv', includeNames=True)
 
             # read it back into a different object, then test equality
             readObj = self.constructor(source=tmpFile.name)
@@ -203,7 +203,7 @@ class QueryBackend(DataTestObject):
 
         assert toWrite == orig
 
-    def test_writeFile_CSVhandmade_output(self):
+    def test_save_CSVhandmade_output(self):
         # instantiate object
         data = [[1., 2., 3.], [0., 2., 4.], [0., 0., 0.]]
         pointNames = ['one', '2', '0']
@@ -214,24 +214,24 @@ class QueryBackend(DataTestObject):
         # should be no leading blank lines and data values should be floats
         exp = "pointNames,one,two,three\none,1.0,2.0,3.0\n2,0.0,2.0,4.0\n0,0.0,0.0,0.0\n"
         with tempfile.NamedTemporaryFile(mode='w+', suffix=".csv") as tmpFile:
-            toWrite.writeFile(tmpFile.name, fileFormat='csv', includeNames=True)
+            toWrite.save(tmpFile.name, fileFormat='csv', includeNames=True)
             tmpFile.seek(0)
             assert tmpFile.read() == exp
 
 
-    def test_writeFile_CSVhandmade_lazyNameGeneration(self):
+    def test_save_CSVhandmade_lazyNameGeneration(self):
         # instantiate object
         data = [[1, 2, 3], [1, 2, 3], [2, 4, 6], [0, 0, 0]]
         toWrite = self.constructor(data)
 
         with tempfile.NamedTemporaryFile(suffix=".csv") as tmpFile:
-            toWrite.writeFile(tmpFile.name, fileFormat='csv', includeNames=False)
+            toWrite.save(tmpFile.name, fileFormat='csv', includeNames=False)
             assertNoNamesGenerated(toWrite)
 
-            toWrite.writeFile(tmpFile.name, fileFormat='csv')
+            toWrite.save(tmpFile.name, fileFormat='csv')
             assertNoNamesGenerated(toWrite)
 
-    def test_writeFile_CSV_excludeDefaultNames(self):
+    def test_save_CSV_excludeDefaultNames(self):
         data = [[1, 2, 3], [1, 2, 3], [2, 4, 6], [0, 0, 0]]
         pointNames = ['1', 'one', '2', '0']
         featureNames = ['one', 'two', 'three']
@@ -257,7 +257,7 @@ class QueryBackend(DataTestObject):
             axisExclude = getattr(exclude, axis + 's')
 
             with tempfile.NamedTemporaryFile(suffix=".csv") as tmpFile:
-                exclude.writeFile(tmpFile.name, fileFormat='csv', includeNames=True)
+                exclude.save(tmpFile.name, fileFormat='csv', includeNames=True)
 
                 # read it back into a different object, then test equality
                 if axis == 'point':
@@ -275,8 +275,8 @@ class QueryBackend(DataTestObject):
         excludeAxis('feature')
 
     @noLogEntryExpected
-    def test_writeFile_CSVhandmade_extraCommas(self):
-        """ Test writeFile() when data and names contain commas """
+    def test_save_CSVhandmade_extraCommas(self):
+        """ Test save() when data and names contain commas """
         # instantiate object
         data = [[1, 2, 'a'], [1, 2, 'a,b'], [2, 4, 'a,b,c'], [0, 0, 'd']]
         pointNames = ['1', 'one,1', '2', '0,zero']
@@ -285,7 +285,7 @@ class QueryBackend(DataTestObject):
         orig = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
 
         with tempfile.NamedTemporaryFile(suffix=".csv") as tmpFile:
-            toWrite.writeFile(tmpFile.name, fileFormat='csv', includeNames=True)
+            toWrite.save(tmpFile.name, fileFormat='csv', includeNames=True)
 
             # read it back into a different object, then test equality
             # must specify featureNames=True because 'automatic' will not detect
@@ -297,8 +297,8 @@ class QueryBackend(DataTestObject):
         assert toWrite == orig
 
     @noLogEntryExpected
-    def test_writeFile_CSVhandmade_extraQuotes(self):
-        """ Test writeFile() when data and names contain commas """
+    def test_save_CSVhandmade_extraQuotes(self):
+        """ Test save() when data and names contain commas """
         # instantiate object
         data = [[1, 2, 'with "quote"'], [1, 2, '"quotes","and", "commas"'],
                 [2, 4, 'includes"quote"'], [0, 0, 'd']]
@@ -308,7 +308,7 @@ class QueryBackend(DataTestObject):
         orig = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
 
         with tempfile.NamedTemporaryFile(suffix=".csv") as tmpFile:
-            toWrite.writeFile(tmpFile.name, fileFormat='csv', includeNames=True)
+            toWrite.save(tmpFile.name, fileFormat='csv', includeNames=True)
             # read it back into a different object, then test equality
             # must specify featureNames=True because 'automatic' will not detect
             readObj = self.constructor(source=tmpFile.name, featureNames=True)
@@ -318,8 +318,8 @@ class QueryBackend(DataTestObject):
         assert toWrite == orig
 
     @noLogEntryExpected
-    def test_writeFile_MTXhandmade(self):
-        """ Test writeFile() for mtx extension with both data and featureNames """
+    def test_save_MTXhandmade(self):
+        """ Test save() for mtx extension with both data and featureNames """
         # instantiate object
         data = [[1, 2, 3], [1, 2, 3], [2, 4, 6], [0, 0, 0]]
         featureNames = ['one', 'two', 'three']
@@ -327,7 +327,7 @@ class QueryBackend(DataTestObject):
         toWrite = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
 
         with tempfile.NamedTemporaryFile(suffix=".mtx") as tmpFile:
-            toWrite.writeFile(tmpFile.name, fileFormat='mtx', includeNames=True)
+            toWrite.save(tmpFile.name, fileFormat='mtx', includeNames=True)
 
             # read it back into a different object, then test equality
             readObj = self.constructor(source=tmpFile.name)
@@ -335,21 +335,17 @@ class QueryBackend(DataTestObject):
         assert readObj.isIdentical(toWrite)
         assert toWrite.isIdentical(readObj)
 
-    def test_writeFile_MTXhandmade_lazyNameGeneration(self):
+    def test_save_MTXhandmade_lazyNameGeneration(self):
         # instantiate object
         data = [[1, 2, 3], [1, 2, 3], [2, 4, 6], [0, 0, 0]]
         toWrite = self.constructor(data)
 
         with tempfile.NamedTemporaryFile(suffix=".mtx") as tmpFile:
-            toWrite.writeFile(tmpFile.name, fileFormat='mtx', includeNames=False)
+            toWrite.save(tmpFile.name, fileFormat='mtx', includeNames=False)
 
         assertNoNamesGenerated(toWrite)
 
-    #################
-    # save/LoadData #
-    #################
-
-    def test_save(self):
+    def test_save_pickle(self):
         data = [[1, 2, 3], [1, 2, 3], [2, 4, 6], [0, 0, 0]]
         featureNames = ['one', 'two', 'three']
         pointNames = ['1', 'one', '2', '0']
@@ -370,20 +366,7 @@ class QueryBackend(DataTestObject):
         assert toSave.isIdentical(load2)
         assert load2.isIdentical(toSave)
 
-        with tempfile.NamedTemporaryFile(suffix=".pickle") as tmpFile:
-            # save without extension to ensure the .pickle extension is added
-            fileNameWithoutExtension = tmpFile.name[:-7]
-            # it is important that the saved object has the same name as the
-            # tmpFile otherwise a new file will be created and saved which will
-            # not be cleaned up by tempfile.
-            assert fileNameWithoutExtension + '.pickle' == tmpFile.name
-            toSave.save(fileNameWithoutExtension)
-            load3 = nimble.data(tmpFile.name)
-
-        assert toSave.isIdentical(load3)
-        assert load3.isIdentical(toSave)
-
-    def test_save_lazyNameGeneration(self):
+    def test_save_pickle_lazyNameGeneration(self):
         data = [[1, 2, 3], [1, 2, 3], [2, 4, 6], [0, 0, 0]]
         toSave = self.constructor(data)
 
@@ -392,37 +375,18 @@ class QueryBackend(DataTestObject):
 
         assertNoNamesGenerated(toSave)
 
-    def test_save_extensionHandling(self):
-        data = [[1, 2, 3], [1, 2, 3], [2, 4, 6], [0, 0, 0]]
-        featureNames = ['one', 'two', 'three']
-        pointNames = ['1', 'one', '2', '0']
-        toSave = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
-
-        with tempfile.NamedTemporaryFile(suffix=".pickle") as tmpFile:
-            # save without extension to ensure the .pickle extension is added
-            fileNameWithoutExtension = tmpFile.name[:-7]
-            # it is important that the saved object has the same name as the
-            # tmpFile otherwise a new file will be created and saved which will
-            # not be cleaned up by tempfile.
-            assert fileNameWithoutExtension + '.pickle' == tmpFile.name
-
-            toSave.save(fileNameWithoutExtension)
-            LoadObj = nimble.data(tmpFile.name)
-            assert isinstance(LoadObj, nimble.core.data.Base)
-
-            with raises(InvalidArgumentValue):
-                LoadObj = nimble.data(fileNameWithoutExtension)
-
-    @oneLogEntryExpected
+    @noLogEntryExpected
     def test_saveAndLoad_logCount(self):
         data = [[1, 2, 3], [1, 2, 3], [2, 4, 6], [0, 0, 0]]
         featureNames = ['one', 'two', 'three']
         pointNames = ['1', 'one', '2', '0']
-        toSave = self.constructor(data, pointNames=pointNames, featureNames=featureNames)
+        toSave = self.constructor(data, pointNames=pointNames,
+                                  featureNames=featureNames)
 
-        with tempfile.NamedTemporaryFile(suffix=".pickle") as tmpFile:
-            toSave.save(tmpFile.name)
-            LoadObj = nimble.data(tmpFile.name)
+        for suffix in ['.csv', '.mtx', 'hdf5', '.h5', '.pickle', '.p', '.pkl']:
+            with tempfile.NamedTemporaryFile(suffix=suffix) as tmpFile:
+                toSave.save(tmpFile.name)
+                loadObj = nimble.data(tmpFile.name, useLog=False)
 
     ##############
     # __getitem__#

--- a/tests/data/randomized_sequence_test.py
+++ b/tests/data/randomized_sequence_test.py
@@ -29,7 +29,7 @@ unavailableNoPoints = [
     'featureIterator',
     'shufflePoints',
     'shuffleFeatures',
-    'writeFile',
+    'save',
     'copyPoints',
     'pointView',
     'elementwiseMultiply',
@@ -45,7 +45,7 @@ unavailableNoFeatures = [
     'pointIterator',
     'shufflePoints',
     'shuffleFeatures',
-    'writeFile',
+    'save',
     'copyFeatures',
     'featureView',
     'elementwiseMultiply',
@@ -576,7 +576,7 @@ generators = {'addFeatures': [genObjMatchPoints],
 }
 
 untested = ['featureIterator', 'pointIterator', #iterator equality isn't a sensible thing to check
-            'writeFile', # lets not test this yet
+            'save', # lets not test this yet
             'getTypeString', # won't actually be equal
             'summaryReport', # do we really care about testing this?
             'featureReport', # floating point equality errors? / do we care?

--- a/tests/data/structure_backend.py
+++ b/tests/data/structure_backend.py
@@ -680,7 +680,7 @@ class StructureDataSafe(StructureShared):
         name = 'copyTestName'
         orig = self.constructor(data)
         with tempfile.NamedTemporaryFile(suffix=".csv") as source:
-            orig.writeFile(source.name, 'csv', includeNames=False)
+            orig.save(source.name, 'csv', includeNames=False)
             orig = self.constructor(source.name, name=name)
             path = source.name
 

--- a/tests/logger/testLoggingCount.py
+++ b/tests/logger/testLoggingCount.py
@@ -133,7 +133,6 @@ base_notLogged = [
     'plotFeatureAgainstFeatureRollingAverage', 'plotFeatureDistribution',
     'plotFeatureGroupMeans', 'plotFeatureGroupStatistics', 'pointView',
     'save', 'show', 'solveLinearSystem', 'toString', 'checkInvariants', 'view',
-    'writeFile',
     ]
 base_funcs = base_logged + base_notLogged
 base_tested = list(map(prefixAdder('Base'), base_funcs))

--- a/tests/manualScripts/dataPrepExample.py
+++ b/tests/manualScripts/dataPrepExample.py
@@ -47,4 +47,4 @@ if __name__ == "__main__":
     processed.features.delete(match.anyNonNumeric)
 
     # output the cleaned data set for later usage
-    processed.writeFile(pathOut, includeNames=True)
+    processed.save(pathOut, includeNames=True)

--- a/tests/manualScripts/fileIOExample.py
+++ b/tests/manualScripts/fileIOExample.py
@@ -53,5 +53,5 @@ if __name__ == "__main__":
     assert len(trainInPlace.points) == len(trainOutPlace.points)
 
     # output the split and normalized sets for later usage
-    trainInPlace.writeFile(pathTrain, fileFormat='csv', includeNames=True)
-    testInPlace.writeFile(pathTest, fileFormat='csv', includeNames=True)
+    trainInPlace.save(pathTrain, fileFormat='csv', includeNames=True)
+    testInPlace.save(pathTest, fileFormat='csv', includeNames=True)

--- a/tests/testData.py
+++ b/tests/testData.py
@@ -1575,12 +1575,12 @@ def test_csv_roundtrip_autonames():
         withBoth = nimble.data(data, featureNames=fnames, pointNames=pnames)
 
         with tempfile.NamedTemporaryFile(suffix=".csv") as tmpCSVFnames:
-            withFnames.writeFile(tmpCSVFnames.name, 'csv', includeNames=True)
+            withFnames.save(tmpCSVFnames.name, 'csv', includeNames=True)
             fromFileFnames = nimble.data(source=tmpCSVFnames.name)
             assert fromFileFnames == withFnames
 
         with tempfile.NamedTemporaryFile(suffix=".csv") as tmpCSVBoth:
-            withBoth.writeFile(tmpCSVBoth.name, 'csv', includeNames=True)
+            withBoth.save(tmpCSVBoth.name, 'csv', includeNames=True)
             fromFileBoth = nimble.data(source=tmpCSVBoth.name)
             assert fromFileBoth == withBoth
 
@@ -1592,7 +1592,7 @@ def test_hdf_roundtrip_autonames():
         withPNames = nimble.data(data, pointNames=pNames)
 
         with tempfile.NamedTemporaryFile(suffix=".hdf5") as tmpHDF:
-            withPNames.writeFile(tmpHDF.name, includeNames=True)
+            withPNames.save(tmpHDF.name, includeNames=True)
             fromFile = nimble.data(tmpHDF.name)
             assert withPNames == fromFile
 
@@ -2851,7 +2851,7 @@ def test_data_keepPF_AllPossibleNatOrder():
         data = [[1, 2, 3], [11, 22, 33], [111, 222, 333]]
         orig = nimble.data(source=data)
         with tempfile.NamedTemporaryFile(suffix="." + f) as tmpF:
-            orig.writeFile(tmpF.name, fileFormat=f, includeNames=False)
+            orig.save(tmpF.name, fileFormat=f, includeNames=False)
             tmpF.flush()
 
             poss = [[0], [1], [2], [0, 1], [0, 2], [1, 2], 'all']
@@ -2870,7 +2870,7 @@ def test_data_keepPF_AllPossibleReverseOrder():
         data = [[1, 2, 3], [11, 22, 33], [111, 222, 333]]
         orig = nimble.data(source=data)
         with tempfile.NamedTemporaryFile(suffix="." + f) as tmpF:
-            orig.writeFile(tmpF.name, fileFormat=f, includeNames=False)
+            orig.save(tmpF.name, fileFormat=f, includeNames=False)
             tmpF.flush()
 
             poss = [[0, 1], [0, 2], [1, 2]]
@@ -2903,7 +2903,7 @@ def test_data_keepPF_AllPossibleWithNames_extracted():
     filesForms = ['csv', 'mtx']
     for (t, f) in itertools.product(returnTypes, filesForms):
         with tempfile.NamedTemporaryFile(suffix="." + f) as tmpF:
-            orig.writeFile(tmpF.name, fileFormat=f, includeNames=False)
+            orig.save(tmpF.name, fileFormat=f, includeNames=False)
             tmpF.flush()
 
             poss = [[0], [1], [0, 1], [1, 0], 'all']
@@ -2946,7 +2946,7 @@ def test_data_keepPF_AllPossibleWithNames_fullNamesListProvided():
     filesForms = ['csv', 'mtx']
     for (t, f) in itertools.product(returnTypes, filesForms):
         with tempfile.NamedTemporaryFile(suffix="." + f) as tmpF:
-            orig.writeFile(tmpF.name, fileFormat=f, includeNames=False)
+            orig.save(tmpF.name, fileFormat=f, includeNames=False)
             tmpF.flush()
 
             poss = [[0], [1], [0, 1], [1, 0], [0, 2], [2, 0], [1, 2], [2, 1], 'all']
@@ -2989,7 +2989,7 @@ def test_data_keepPF_AllPossibleWithNames_fullNamesDictProvided():
     filesForms = ['csv', 'mtx']
     for (t, f) in itertools.product(returnTypes, filesForms):
         with tempfile.NamedTemporaryFile(suffix="." + f) as tmpF:
-            orig.writeFile(tmpF.name, fileFormat=f, includeNames=False)
+            orig.save(tmpF.name, fileFormat=f, includeNames=False)
             tmpF.flush()
 
             poss = [[0], [1], [0, 1], [1, 0], [0, 2], [2, 0], [1, 2], [2, 1], 'all']
@@ -3032,7 +3032,7 @@ def test_data_keepPF_AllCombosWithExactNamesProvided():
     filesForms = ['csv', 'mtx']
     for (t, f) in itertools.product(returnTypes, filesForms):
         with tempfile.NamedTemporaryFile(suffix="." + f) as tmpF:
-            orig.writeFile(tmpF.name, fileFormat=f, includeNames=False)
+            orig.save(tmpF.name, fileFormat=f, includeNames=False)
             tmpF.flush()
 
             toUseData = orig.copy(to="pythonlist")


### PR DESCRIPTION
Merged the `save` and `writeFile` methods so there is only one `save` method for writing to a file in any format. 

- Defaults to csv when the format is not specified.
- hdf5 output was untested, added tests