### PR TITLE
identify unique objects in logs

### DIFF
--- a/documentation/source/examples/merging_and_tidying_data.py
+++ b/documentation/source/examples/merging_and_tidying_data.py
@@ -82,7 +82,7 @@ dwtnMinAM.show('Downtown data merged on date', maxHeight=12)
 ## in the combined objects. Once our new feature is added, we can
 ## `points.append` our objects from the same weather station.
 for obj in [dwtnMinAM, dwtnMaxAM, airptMinAM, airptMaxAM]:
-    extreme = 'min' if 'min' in obj.name else 'max'
+    extreme = 'min' if 'min' in obj.path else 'max'
     ftData = [[extreme] for _ in range(len(obj.points))]
     newFt = nimble.data(ftData, featureNames=['extreme'])
     # New feature will be added at index position 1 (after "date" feature)
@@ -98,7 +98,7 @@ dwtnMinAM.show('Downtown combined extreme data', maxHeight=12)
 ## to create a new 'station' feature for each object based on which weather
 ## station location (downtown vs. airport) recorded the data.
 for obj in [dwtnMinAM, airptMinAM]:
-    station = 'downtown' if 'downtown' in obj.name else 'airport'
+    station = 'downtown' if 'downtown' in obj.path else 'airport'
     stationData = [[station] for _ in range(len(obj.points))]
     newFt = nimble.data(stationData, featureNames=['station'])
     obj.features.insert(1, newFt)
@@ -114,7 +114,7 @@ dwtnMinAM.points.append(airptMinAM)
 ## weather station. Taking a look at our data will also help us start exploring
 ## how we can begin to tidy it.
 tempData = dwtnMinAM
-tempData.name = 'combined temperature data'
+tempData.name = 'combinedTemperatureData'
 tempData.points.sort('date')
 
 tempData.show('Fully merged (untidy) data', maxHeight=16)

--- a/nimble/core/_createHelpers.py
+++ b/nimble/core/_createHelpers.py
@@ -2080,12 +2080,6 @@ def createDataFromFile(
 
             response = _getURLResponse(urlManager.source)
             path = source
-            if name is None:
-                if "Content-Disposition" in response.headers:
-                    contentDisp = response.headers["Content-Disposition"][0]
-                    name = contentDisp.split('filename=')[1]
-                else:
-                    name = source.split("/")[-1]
 
             content = response.content
             if response.apparent_encoding is not None:
@@ -2170,10 +2164,6 @@ def createDataFromFile(
             absPath = os.path.abspath(path)
             relPath = path
             pathsToPass = (absPath, relPath)
-
-    if path is not None and name is None:
-        tokens = path.rsplit(os.path.sep)
-        name = tokens[-1]
 
     extracted = (pointNames is True, featureNames is True)
     if selectSuccess:

--- a/nimble/core/create.py
+++ b/nimble/core/create.py
@@ -26,7 +26,7 @@ def data(source, pointNames='automatic', featureNames='automatic',
          keepFeatures='all', treatAsMissing=DEFAULT_MISSING,
          replaceMissingWith=np.nan, rowsArePoints=True,
          ignoreNonNumericalFeatures=False, inputSeparator='automatic',
-         copyData=True, useLog=None):
+         copyData=True, *, useLog=None):
     """
     Function to instantiate one of the Nimble data container types.
 
@@ -196,7 +196,7 @@ def data(source, pointNames='automatic', featureNames='automatic',
     ...     out = cd.write('1,2,3\\n4,5,6')
     >>> fromFile = nimble.data('simpleData.csv')
     >>> fromFile # doctest: +ELLIPSIS
-    <Matrix "simpleData.csv" 2pt x 3ft
+    <Matrix 2pt x 3ft
          0 1 2
        ┌──────
      0 │ 1 2 3
@@ -270,8 +270,7 @@ def data(source, pointNames='automatic', featureNames='automatic',
         msg += "be loaded"
         raise InvalidArgumentType(msg)
 
-    handleLogging(useLog, 'load', returnType, ret.getTypeString(),
-                  len(ret.points), len(ret.features), ret.name, ret.path)
+    handleLogging(useLog, 'load', ret, returnType=returnType)
     return ret
 
 
@@ -531,7 +530,7 @@ def identity(size, pointNames='automatic', featureNames='automatic',
                        returnType=returnType, name=name, useLog=False)
 
 
-def loadTrainedLearner(source, useLog=None):
+def loadTrainedLearner(source, *, useLog=None):
     """
     Load nimble TrainedLearner object.
 
@@ -569,8 +568,7 @@ def loadTrainedLearner(source, useLog=None):
         msg = 'File does not contain a valid Nimble TrainedLearner object.'
         raise InvalidArgumentType(msg)
 
-    handleLogging(useLog, 'load', None, "TrainedLearner",
-                  learnerName=ret.learnerName, learnerArgs=ret.arguments)
+    handleLogging(useLog, 'tl', ret)
     return ret
 
 def fetchFile(source, overwrite=False):

--- a/nimble/core/data/_dataHelpers.py
+++ b/nimble/core/data/_dataHelpers.py
@@ -19,6 +19,7 @@ from nimble._utility import is2DArray
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
 from nimble.exceptions import InvalidArgumentValueCombination
 from nimble.exceptions import ImproperObjectAction, PackageException
+from nimble.core.logger import handleLogging
 
 def binaryOpNamePathMerge(caller, other, ret, nameSource, pathSource):
     """
@@ -1167,3 +1168,15 @@ def getFeatureDtypes(obj):
             dtypeList.append(np.object_)
 
     return tuple(dtypeList)
+
+def prepLog(method):
+    """
+    Provides logging for methods that manipulate data.
+    """
+    @wraps(method)
+    def wrapped(self, *args, useLog=None, **kwargs):
+        ret = method(self, *args, useLog=None, **kwargs)
+        handleLogging(useLog, 'prep', self, wrapped.__name__, ret, *args,
+                      **kwargs)
+        return ret
+    return wrapped

--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -14,6 +14,7 @@ import os.path
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 import shutil
+import re
 
 import numpy as np
 
@@ -22,7 +23,7 @@ from nimble import match
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
 from nimble.exceptions import ImproperObjectAction, PackageException
 from nimble.exceptions import InvalidArgumentValueCombination
-from nimble.core.logger import handleLogging
+from nimble.core.logger import handleLogging, LogID
 from nimble.match import QueryString
 from nimble._utility import cloudpickle, h5py, plt
 from nimble._utility import isDatetime
@@ -48,6 +49,7 @@ from ._dataHelpers import looksNumeric, checkNumeric
 from ._dataHelpers import mergeNames, mergeNonDefaultNames
 from ._dataHelpers import binaryOpNamePathMerge
 from ._dataHelpers import indicesSplit
+from ._dataHelpers import prepLog
 
 def to2args(f):
     """
@@ -77,17 +79,17 @@ class Base(ABC):
     methods that apply point-by-point and feature-by-feature,
     respectively.
     """
-    _id = 0
+    logID = LogID('NIMBLE')
 
     def __init__(self, shape, pointNames=None, featureNames=None, name=None,
                  paths=(None, None), **kwds):
         """
         Class defining important data manipulation operations.
 
-        Specifically, this includes setting the object _id, name, shape,
-        originating paths for the data, and sets the point and feature axis
-        objects. Note: this method (as should all other __init__ methods in
-        this hierarchy) makes use of super().
+        Specifically, this includes setting the object name, shape,
+        originating paths for the data, and sets the point and feature
+        axis objects. Note: this method (as should all other __init__
+        methods in this hierarchy) makes use of super().
 
         Parameters
         ----------
@@ -112,9 +114,6 @@ class Base(ABC):
             Note, however, that this class is the root of the object
             hierarchy as statically defined.
         """
-        self._id = Base._id
-        Base._id += 1
-
         self._dims = list(shape)
         self._name = name
 
@@ -264,9 +263,13 @@ class Base(ABC):
 
     @name.setter
     def name(self, value):
-        if not isinstance(value, str) and value is not None:
-            msg = "The name of an object may only be a string or None"
-            raise ValueError(msg)
+        if value is not None:
+            if not isinstance(value, str):
+                msg = "The name of an object may only be a string or None"
+                raise InvalidArgumentType(msg)
+            if re.search(r'\s', value):
+                msg = "Names are not permitted to have whitespace"
+                raise InvalidArgumentValue(msg)
         self._name = value
 
     @property
@@ -416,7 +419,9 @@ class Base(ABC):
     # Higher Order Operations #
     ###########################
     @limitedTo2D
-    def replaceFeatureWithBinaryFeatures(self, featureToReplace, useLog=None):
+    @prepLog
+    def replaceFeatureWithBinaryFeatures(self, featureToReplace, *,
+                                         useLog=None): # pylint: disable=unused-argument
         """
         Create binary features for each unique value in a feature.
 
@@ -496,14 +501,12 @@ class Base(ABC):
             # insert data at same index of the original feature
             self.features.insert(index, binaryObj, useLog=False)
 
-        handleLogging(useLog, 'prep', "replaceFeatureWithBinaryFeatures",
-                      self.getTypeString(),
-                      Base.replaceFeatureWithBinaryFeatures, featureToReplace)
-
         return ftNames
 
     @limitedTo2D
-    def transformFeatureToIntegers(self, featureToConvert, useLog=None):
+    @prepLog
+    def transformFeatureToIntegers(self, featureToConvert, *,
+                                   useLog=None): # pylint: disable=unused-argument
         """
         Represent each unique value in a feature with a unique integer.
 
@@ -575,16 +578,13 @@ class Base(ABC):
 
         self.features.transform(applyMap, features=ftIndex, useLog=False)
 
-        handleLogging(useLog, 'prep', "transformFeatureToIntegers",
-                      self.getTypeString(), Base.transformFeatureToIntegers,
-                      featureToConvert)
-
         return {v: k for k, v in mapping.items()}
 
     @limitedTo2D
+    @prepLog
     def transformElements(self, toTransform, points=None, features=None,
-                          preserveZeros=False, skipNoneReturnValues=False,
-                          useLog=None):
+                          preserveZeros=False, skipNoneReturnValues=False, *,
+                          useLog=None): # pylint: disable=unused-argument
         """
         Modify each element using a function or mapping.
 
@@ -720,15 +720,13 @@ class Base(ABC):
 
         self._transform_implementation(transformer, points, features)
 
-        handleLogging(useLog, 'prep', 'transformElements',
-                      self.getTypeString(), Base.transformElements,
-                      toTransform, points, features, preserveZeros,
-                      skipNoneReturnValues)
 
     @limitedTo2D
+    @prepLog
     def calculateOnElements(self, toCalculate, points=None, features=None,
                             preserveZeros=False, skipNoneReturnValues=False,
-                            outputType=None, useLog=None):
+                            outputType=None, *,
+                            useLog=None): # pylint: disable=unused-argument
         """
         Apply a calculation to each element.
 
@@ -864,16 +862,12 @@ class Base(ABC):
         ret = self._calculate_backend(calculator, points, features,
                                       preserveZeros, outputType)
 
-        handleLogging(useLog, 'prep', 'calculateOnElements',
-                      self.getTypeString(), Base.calculateOnElements,
-                      toCalculate, points, features, preserveZeros,
-                      skipNoneReturnValues, outputType)
-
         return ret
 
     @limitedTo2D
-    def matchingElements(self, toMatch, points=None, features=None,
-                         useLog=None):
+    @prepLog
+    def matchingElements(self, toMatch, points=None, features=None, *,
+                         useLog=None): # pylint: disable=unused-argument
         """
         Identify values meeting the provided criteria.
 
@@ -982,9 +976,6 @@ class Base(ABC):
             fnames = [fnames[j] for j in ftIdx]
         ret.points.setNames(pnames, useLog=False)
         ret.features.setNames(fnames, useLog=False)
-
-        handleLogging(useLog, 'prep', 'matchingElements', self.getTypeString(),
-                      Base.matchingElements, toMatch, points, features)
 
         return ret
 
@@ -1161,7 +1152,9 @@ class Base(ABC):
         return self._countUnique_implementation(points, features)
 
     @limitedTo2D
-    def groupByFeature(self, by, countUniqueValueOnly=False, useLog=None):
+    @prepLog
+    def groupByFeature(self, by, countUniqueValueOnly=False, *,
+                       useLog=None): # pylint: disable=unused-argument
         """
         Group data object by one or more features.
 
@@ -1263,10 +1256,6 @@ class Base(ABC):
             for obj in res.values():
                 obj.features.delete(by, useLog=False)
 
-        handleLogging(useLog, 'prep', "groupByFeature",
-                      self.getTypeString(), Base.groupByFeature, by,
-                      countUniqueValueOnly)
-
         return res
 
     @limitedTo2D
@@ -1336,8 +1325,9 @@ class Base(ABC):
             with other._treatAs2D():
                 return self.hashCode() == other.hashCode()
 
-    def trainAndTestSets(self, testFraction, labels=None, randomOrder=True,
-                         useLog=None):
+    @prepLog
+    def trainAndTestSets(self, testFraction, labels=None, randomOrder=True, *,
+                         useLog=None): # pylint: disable=unused-argument
         """
         Divide the data into training and testing sets.
 
@@ -1485,8 +1475,8 @@ class Base(ABC):
         if labels is None:
             ret = trainX, testX
             if self.name is not None:
-                trainX.name = self.name + " train"
-                testX.name = self.name + " test"
+                trainX.name = self.name + "_train"
+                testX.name = self.name + "_test"
             else:
                 trainX.name = "train"
                 testX.name = "test"
@@ -1518,10 +1508,10 @@ class Base(ABC):
                 testY = testX.features.extract(toExtract, useLog=False)
 
             if self.name is not None:
-                trainX.name = self.name + " trainX"
-                testX.name = self.name + " testX"
-                trainY.name = self.name + " trainY"
-                testY.name = self.name + " testY"
+                trainX.name = self.name + "_trainX"
+                testX.name = self.name + "_testX"
+                trainY.name = self.name + "_trainY"
+                testY.name = self.name + "_testY"
             else:
                 trainX.name = "trainX"
                 testX.name = "testX"
@@ -1529,9 +1519,6 @@ class Base(ABC):
                 testY.name = "testY"
 
             ret = trainX, trainY, testX, testY
-
-        handleLogging(useLog, 'prep', "trainAndTestSets", self.getTypeString(),
-                      Base.trainAndTestSets, testFraction, labels, randomOrder)
 
         return ret
 
@@ -1541,7 +1528,7 @@ class Base(ABC):
     ########################################
     ########################################
 
-    def report(self, useLog=None):
+    def report(self, *, useLog=None):
         """
         Report containing information regarding the data in this object.
 
@@ -1592,7 +1579,7 @@ class Base(ABC):
         report = nimble.data(results, featureNames=fnames,
                              returnType=self.getTypeString(), useLog=False)
 
-        handleLogging(useLog, 'data', "summary", str(report))
+        handleLogging(useLog, 'report', "summary", str(report))
 
         return report
 
@@ -3102,7 +3089,9 @@ class Base(ABC):
     ##################################################################
     ##################################################################
     @limitedTo2D
-    def transpose(self, useLog=None):
+    @prepLog
+    def transpose(self, *,
+                  useLog=None): # pylint: disable=unused-argument
         """
         Invert the feature and point indices of the data.
 
@@ -3156,9 +3145,6 @@ class Base(ABC):
                             self.points._getNamesNoGeneration())
         self.points.setNames(ptNames, useLog=False)
         self.features.setNames(ftNames, useLog=False)
-
-        handleLogging(useLog, 'prep', "transpose", self.getTypeString(),
-                      Base.transpose)
 
     @property
     @limitedTo2D
@@ -3396,8 +3382,10 @@ class Base(ABC):
         return self.copy()
 
     @limitedTo2D
+    @prepLog
     def replaceRectangle(self, replaceWith, pointStart, featureStart,
-                         pointEnd=None, featureEnd=None, useLog=None):
+                         pointEnd=None, featureEnd=None, *,
+                         useLog=None): # pylint: disable=unused-argument
         """
         Replace values in the data with other values.
 
@@ -3520,10 +3508,6 @@ class Base(ABC):
         self._replaceRectangle_implementation(replaceWith, psIndex, fsIndex,
                                               peIndex, feIndex)
 
-        handleLogging(useLog, 'prep', "replaceRectangle",
-                      self.getTypeString(), Base.replaceRectangle, replaceWith,
-                      pointStart, featureStart, pointEnd, featureEnd)
-
 
     def _flattenNames(self, order):
         """
@@ -3554,7 +3538,9 @@ class Base(ABC):
                 ret.append(' | '.join([p, f]))
         return ret
 
-    def flatten(self, order='point', useLog=None):
+    @prepLog
+    def flatten(self, order='point', *,
+                useLog=None): # pylint: disable=unused-argument
         """
         Modify this object so that its values are in a single point.
 
@@ -3649,9 +3635,6 @@ class Base(ABC):
         self.features.setNames(fNames, useLog=False)
         self.points.setNames(['Flattened'], useLog=False)
 
-        handleLogging(useLog, 'prep', "flatten", self.getTypeString(),
-                      Base.flatten, order)
-
 
     def _unflattenNames(self):
         """
@@ -3704,7 +3687,9 @@ class Base(ABC):
 
 
     @limitedTo2D
-    def unflatten(self, dataDimensions, order='point', useLog=None):
+    @prepLog
+    def unflatten(self, dataDimensions, order='point', *,
+                  useLog=None): # pylint: disable=unused-argument
         """
         Adjust a single point or feature to contain multiple points.
 
@@ -3865,13 +3850,12 @@ class Base(ABC):
         self.points.setNames(pNames, useLog=False)
         self.features.setNames(fNames, useLog=False)
 
-        handleLogging(useLog, 'prep', "unflatten", self.getTypeString(),
-                      Base.unflatten, dataDimensions, order)
-
 
     @limitedTo2D
+    @prepLog
     def merge(self, other, point='strict', feature='union', onFeature=None,
-              force=False, useLog=None):
+              force=False, *,
+              useLog=None): # pylint: disable=unused-argument
         """
         Combine data from another object with this object.
 
@@ -4100,8 +4084,6 @@ class Base(ABC):
         else:
             self._genericMergeFrontend(other, point, feature, onFeature)
 
-        handleLogging(useLog, 'prep', "merge", self.getTypeString(),
-                      Base.merge, other, point, feature, onFeature, force)
 
     def _genericStrictMerge_implementation(self, other, point, feature,
                                            onFeature, force):
@@ -5157,15 +5139,9 @@ class Base(ABC):
     def _referenceFrom_implementation(self, other, kwargs):
         """
         Reinitialize the object with the new keyword arguments.
-
-        __init__ affects _id for this object and Base. self._id should stay
-        the same and Base._id should be not increment.
         """
         # pylint: disable=unused-argument
-        idVal = self._id
         self.__init__(**kwargs)
-        self._id = idVal
-        Base._id -= 1
 
     def _arrangePointNames(self, maxRows, nameLength, rowHolder, nameHold,
                            quoteNames):

--- a/nimble/core/data/features.py
+++ b/nimble/core/data/features.py
@@ -20,7 +20,7 @@ from nimble.core.logger import handleLogging
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
 from nimble.exceptions import InvalidArgumentValueCombination
 from nimble._utility import prettyListString, quoteStrings
-from ._dataHelpers import limitedTo2D
+from ._dataHelpers import limitedTo2D, prepLog
 
 class Features(ABC):
     """
@@ -110,7 +110,10 @@ class Features(ABC):
         """
         return self._getNames()
 
-    def setName(self, oldIdentifier, newName, useLog=None):
+
+    @prepLog
+    def setName(self, oldIdentifier, newName, *,
+                useLog=None): # pylint: disable=unused-argument
         """
         Set or change a featureName.
 
@@ -149,9 +152,12 @@ class Features(ABC):
         --------
         column, title, header, heading, attribute, identifier
         """
-        self._setName(oldIdentifier, newName, useLog)
+        self._setName(oldIdentifier, newName)
 
-    def setNames(self, assignments, useLog=None):
+
+    @prepLog
+    def setNames(self, assignments, *,
+                 useLog=None): # pylint: disable=unused-argument
         """
         Set or rename all of the feature names of this object.
 
@@ -191,7 +197,7 @@ class Features(ABC):
         --------
         columns, titles, headers, headings, attributes, identifiers
         """
-        self._setNames(assignments, useLog)
+        self._setNames(assignments)
 
     def getIndex(self, identifier):
         """
@@ -291,8 +297,10 @@ class Features(ABC):
     # Structural Operations #
     #########################
     @limitedTo2D
+    @prepLog
     def copy(self, toCopy=None, start=None, end=None, number=None,
-             randomize=False, useLog=None):
+             randomize=False, *,
+             useLog=None): # pylint: disable=unused-argument
         """
         Copy certain features of this object.
 
@@ -432,11 +440,13 @@ class Features(ABC):
         --------
         duplicate, replicate, clone
         """
-        return self._copy(toCopy, start, end, number, randomize, useLog)
+        return self._copy(toCopy, start, end, number, randomize)
 
     @limitedTo2D
+    @prepLog
     def extract(self, toExtract=None, start=None, end=None, number=None,
-                randomize=False, useLog=None):
+                randomize=False, *,
+                useLog=None): # pylint: disable=unused-argument
         """
         Move certain features of this object into their own object.
 
@@ -654,11 +664,13 @@ class Features(ABC):
         --------
         move, pull, separate, withdraw, cut, vsplit
         """
-        return self._extract(toExtract, start, end, number, randomize, useLog)
+        return self._extract(toExtract, start, end, number, randomize)
 
     @limitedTo2D
+    @prepLog
     def delete(self, toDelete=None, start=None, end=None, number=None,
-               randomize=False, useLog=None):
+               randomize=False, *,
+               useLog=None): # pylint: disable=unused-argument
         """
         Remove certain features from this object.
 
@@ -816,11 +828,13 @@ class Features(ABC):
         --------
         remove, drop, exclude, eliminate, destroy, cut
         """
-        self._delete(toDelete, start, end, number, randomize, useLog)
+        self._delete(toDelete, start, end, number, randomize)
 
     @limitedTo2D
+    @prepLog
     def retain(self, toRetain=None, start=None, end=None, number=None,
-               randomize=False, useLog=None):
+               randomize=False, *,
+               useLog=None): # pylint: disable=unused-argument
         """
         Keep only certain features of this object.
 
@@ -978,7 +992,7 @@ class Features(ABC):
         --------
         keep, hold, maintain, preserve, remove
         """
-        self._retain(toRetain, start, end, number, randomize, useLog)
+        self._retain(toRetain, start, end, number, randomize)
 
     @limitedTo2D
     def count(self, condition):
@@ -1028,7 +1042,9 @@ class Features(ABC):
         return self._count(condition)
 
     @limitedTo2D
-    def sort(self, by=None, reverse=False, useLog=None):
+    @prepLog
+    def sort(self, by=None, reverse=False, *,
+             useLog=None): # pylint: disable=unused-argument
         """
         Arrange the features in this object.
 
@@ -1127,10 +1143,12 @@ class Features(ABC):
         --------
         arrange, order
         """
-        self._sort(by, reverse, useLog)
+        self._sort(by, reverse)
 
     @limitedTo2D
-    def transform(self, function, features=None, useLog=None):
+    @prepLog
+    def transform(self, function, features=None, *,
+                  useLog=None): # pylint: disable=unused-argument
         """
         Modify this object by applying a function to each feature.
 
@@ -1209,13 +1227,15 @@ class Features(ABC):
         --------
         apply, modify, alter, change, map, compute
         """
-        self._transform(function, features, useLog)
+        self._transform(function, features)
 
     ###########################
     # Higher Order Operations #
     ###########################
     @limitedTo2D
-    def calculate(self, function, features=None, useLog=None):
+    @prepLog
+    def calculate(self, function, features=None, *,
+                  useLog=None): # pylint: disable=unused-argument
         """
         Apply a calculation to each feature.
 
@@ -1301,10 +1321,12 @@ class Features(ABC):
         --------
         apply, modify, alter, statistics, stats, compute
         """
-        return self._calculate(function, features, useLog)
+        return self._calculate(function, features)
 
     @limitedTo2D
-    def matching(self, function, useLog=None):
+    @prepLog
+    def matching(self, function, *,
+                 useLog=None): # pylint: disable=unused-argument
         """
         Identifying features matching the given criteria.
 
@@ -1364,10 +1386,12 @@ class Features(ABC):
         boolean, equivalent, identical, same, matches, equals, compare,
         comparison, same
         """
-        return self._matching(function, useLog)
+        return self._matching(function)
 
     @limitedTo2D
-    def insert(self, insertBefore, toInsert, useLog=None):
+    @prepLog
+    def insert(self, insertBefore, toInsert, *,
+               useLog=None): # pylint: disable=unused-argument
         """
         Insert more features into this object.
 
@@ -1452,10 +1476,12 @@ class Features(ABC):
         --------
         embed, include, inject, alter, position
         """
-        self._insert(insertBefore, toInsert, False, useLog)
+        self._insert(insertBefore, toInsert, False)
 
     @limitedTo2D
-    def append(self, toAppend, useLog=None):
+    @prepLog
+    def append(self, toAppend, *,
+               useLog=None): # pylint: disable=unused-argument
         """
         Append features to this object.
 
@@ -1538,10 +1564,13 @@ class Features(ABC):
         affix, adjoin, concatenate, concat, hstack, add, attach, join,
         merge
         """
-        self._insert(None, toAppend, True, useLog)
+        self._insert(None, toAppend, True)
 
     @limitedTo2D
-    def replace(self, data, features=None, useLog=None, **dataKwds):
+    @prepLog
+    def replace(self, data, features=None, *,
+                useLog=None, # pylint: disable=unused-argument
+                **dataKwds):
         """
         Replace the data in one or more of the features in this object.
 
@@ -1618,10 +1647,12 @@ class Features(ABC):
         --------
         change, substitute, alter, transform
         """
-        return self._replace(data, features, useLog, **dataKwds)
+        return self._replace(data, features, **dataKwds)
 
     @limitedTo2D
-    def mapReduce(self, mapper, reducer, useLog=None):
+    @prepLog
+    def mapReduce(self, mapper, reducer, *,
+                  useLog=None): # pylint: disable=unused-argument
         """
         Apply a mapper and reducer function to this object.
 
@@ -1668,10 +1699,12 @@ class Features(ABC):
          1 │    <class 'str'>    2
         >
         """
-        return self._mapReduce(mapper, reducer, useLog)
+        return self._mapReduce(mapper, reducer)
 
     @limitedTo2D
-    def permute(self, order=None, useLog=None):
+    @prepLog
+    def permute(self, order=None, *,
+                useLog=None): # pylint: disable=unused-argument
         """
         Permute the indexing of the features.
 
@@ -1745,11 +1778,13 @@ class Features(ABC):
         --------
         reorder, rearrange, shuffle
         """
-        self._permute(order, useLog)
+        self._permute(order)
 
     @limitedTo2D
-    def fillMatching(self, fillWith, matchingElements, features=None,
-                     useLog=None, **kwarguments):
+    @prepLog
+    def fillMatching(self, fillWith, matchingElements, features=None, *,
+                     useLog=None, # pylint: disable=unused-argument
+                     **kwarguments):
         """
         Replace given values in each feature with other values.
 
@@ -1843,11 +1878,12 @@ class Features(ABC):
         >
         """
         return self._fillMatching(fillWith, matchingElements, features,
-                                  useLog, **kwarguments)
+                                  **kwarguments)
 
     @limitedTo2D
-    def normalize(self, function, applyResultTo=None, features=None,
-                  useLog=None):
+    @prepLog
+    def normalize(self, function, applyResultTo=None, features=None, *,
+                  useLog=None): # pylint: disable=unused-argument
         """
         Modify all features in this object using the given function.
 
@@ -1970,12 +2006,11 @@ class Features(ABC):
             msg = 'applyResultTo must be None or an instance of Base'
             raise InvalidArgumentType(msg)
 
-        handleLogging(useLog, 'prep', 'features.normalize',
-                      self._base.getTypeString(), Features.normalize,
-                      function, applyResultTo, features)
 
     @limitedTo2D
-    def splitByParsing(self, feature, rule, resultingNames, useLog=None):
+    @prepLog
+    def splitByParsing(self, feature, rule, resultingNames, *,
+                       useLog=None): # pylint: disable=unused-argument
         """
         Split a feature into multiple features.
 
@@ -2150,12 +2185,11 @@ class Features(ABC):
         self._base._dims[1] = numRetFeatures
         self.setNames(fNames, useLog=False)
 
-        handleLogging(useLog, 'prep', 'features.splitByParsing',
-                      self._base.getTypeString(), Features.splitByParsing,
-                      feature, rule, resultingNames)
 
     @limitedTo2D
-    def repeat(self, totalCopies, copyFeatureByFeature):
+    @prepLog
+    def repeat(self, totalCopies, copyFeatureByFeature, *,
+               useLog=None): # pylint: disable=unused-argument
         """
         Create an object using copies of this object's features.
 
@@ -2177,6 +2211,13 @@ class Features(ABC):
             copies are made as if the object is only iterated once,
             making ``totalCopies`` copies of each feature before
             iterating to the next feature.
+        useLog : bool, None
+            Local control for whether to send object creation to the
+            logger. If None (default), use the value as specified in the
+            "logger" "enabledByDefault" configuration option. If True,
+            send to the logger regardless of the global option. If
+            False, do **NOT** send to the logger, regardless of the
+            global option.
 
         Returns
         -------
@@ -2276,7 +2317,7 @@ class Features(ABC):
         return self._unique()
 
     @limitedTo2D
-    def report(self, basicStatistics=True, extraStatisticFunctions=(),
+    def report(self, basicStatistics=True, extraStatisticFunctions=(), *,
                useLog=None):
         """
         Report containing a summary and statistics for each feature.
@@ -2372,7 +2413,7 @@ class Features(ABC):
 
         report = nimble.data(results, pnames, fnames, useLog=False)
 
-        handleLogging(useLog, 'data', "feature", str(report))
+        handleLogging(useLog, 'report', "feature", str(report))
 
         return report
 
@@ -2653,11 +2694,11 @@ class Features(ABC):
         pass
 
     @abstractmethod
-    def _setName(self, oldIdentifier, newName, useLog):
+    def _setName(self, oldIdentifier, newName):
         pass
 
     @abstractmethod
-    def _setNames(self, assignments, useLog):
+    def _setNames(self, assignments):
         pass
 
     @abstractmethod
@@ -2673,19 +2714,19 @@ class Features(ABC):
         pass
 
     @abstractmethod
-    def _copy(self, toCopy, start, end, number, randomize, useLog=None):
+    def _copy(self, toCopy, start, end, number, randomize):
         pass
 
     @abstractmethod
-    def _extract(self, toExtract, start, end, number, randomize, useLog=None):
+    def _extract(self, toExtract, start, end, number, randomize):
         pass
 
     @abstractmethod
-    def _delete(self, toDelete, start, end, number, randomize, useLog=None):
+    def _delete(self, toDelete, start, end, number, randomize):
         pass
 
     @abstractmethod
-    def _retain(self, toRetain, start, end, number, randomize, useLog=None):
+    def _retain(self, toRetain, start, end, number, randomize):
         pass
 
     @abstractmethod
@@ -2693,39 +2734,39 @@ class Features(ABC):
         pass
 
     @abstractmethod
-    def _sort(self, by, reverse, useLog=None):
+    def _sort(self, by, reverse,):
         pass
 
     @abstractmethod
-    def _transform(self, function, limitTo, useLog=None):
+    def _transform(self, function, limitTo):
         pass
 
     @abstractmethod
-    def _calculate(self, function, limitTo, useLog=None):
+    def _calculate(self, function, limitTo):
         pass
 
     @abstractmethod
-    def _matching(self, function, useLog=None):
+    def _matching(self, function):
         pass
 
     @abstractmethod
-    def _insert(self, insertBefore, toInsert, append=False, useLog=None):
+    def _insert(self, insertBefore, toInsert, append=False):
         pass
 
     @limitedTo2D
-    def _replace(self, data, locations, useLog=None):
+    def _replace(self, data, locations):
         pass
 
     @abstractmethod
-    def _mapReduce(self, mapper, reducer, useLog=None):
+    def _mapReduce(self, mapper, reducer):
         pass
 
     @abstractmethod
-    def _permute(self, order=None, useLog=None):
+    def _permute(self, order=None):
         pass
 
     @abstractmethod
-    def _fillMatching(self, match, fill, limitTo, useLog=None, **kwarguments):
+    def _fillMatching(self, match, fill, limitTo, **kwarguments):
         pass
 
     @abstractmethod

--- a/nimble/core/data/points.py
+++ b/nimble/core/data/points.py
@@ -14,9 +14,8 @@ from abc import ABC, abstractmethod
 from collections import OrderedDict
 
 import nimble
-from nimble.core.logger import handleLogging
 from nimble.exceptions import ImproperObjectAction
-from ._dataHelpers import limitedTo2D
+from ._dataHelpers import limitedTo2D, prepLog
 
 class Points(ABC):
     """
@@ -104,7 +103,10 @@ class Points(ABC):
         """
         return self._getNames()
 
-    def setName(self, oldIdentifier, newName, useLog=None):
+
+    @prepLog
+    def setName(self, oldIdentifier, newName, *,
+                useLog=None): # pylint: disable=unused-argument
         """
         Set or change a pointName.
 
@@ -143,9 +145,12 @@ class Points(ABC):
         --------
         row, key, index, header, heading, identifier
         """
-        self._setName(oldIdentifier, newName, useLog)
+        self._setName(oldIdentifier, newName)
 
-    def setNames(self, assignments, useLog=None):
+
+    @prepLog
+    def setNames(self, assignments, *,
+                 useLog=None): # pylint: disable=unused-argument
         """
         Set or rename all of the point names of this object.
 
@@ -185,7 +190,7 @@ class Points(ABC):
         --------
         rows, keys, indexes, indices, headers, headings, identifiers
         """
-        self._setNames(assignments, useLog)
+        self._setNames(assignments)
 
     def getIndex(self, identifier):
         """
@@ -284,9 +289,10 @@ class Points(ABC):
     #########################
     # Structural Operations #
     #########################
-
+    @prepLog
     def copy(self, toCopy=None, start=None, end=None, number=None,
-             randomize=False, useLog=None):
+             randomize=False, *,
+             useLog=None): # pylint: disable=unused-argument
         """
         Copy certain points of this object.
 
@@ -410,10 +416,12 @@ class Points(ABC):
         --------
         duplicate, replicate, clone
         """
-        return self._copy(toCopy, start, end, number, randomize, useLog)
+        return self._copy(toCopy, start, end, number, randomize)
 
+    @prepLog
     def extract(self, toExtract=None, start=None, end=None, number=None,
-                randomize=False, useLog=None):
+                randomize=False, *,
+                useLog=None): # pylint: disable=unused-argument
         """
         Move certain points of this object into their own object.
 
@@ -609,10 +617,12 @@ class Points(ABC):
         --------
         move, pull, separate, withdraw, cut, hsplit
         """
-        return self._extract(toExtract, start, end, number, randomize, useLog)
+        return self._extract(toExtract, start, end, number, randomize)
 
+    @prepLog
     def delete(self, toDelete=None, start=None, end=None, number=None,
-               randomize=False, useLog=None):
+               randomize=False, *,
+               useLog=None): # pylint: disable=unused-argument
         """
         Remove certain points from this object.
 
@@ -758,10 +768,12 @@ class Points(ABC):
         --------
         remove, drop, exclude, eliminate, destroy, cut
         """
-        self._delete(toDelete, start, end, number, randomize, useLog)
+        self._delete(toDelete, start, end, number, randomize)
 
+    @prepLog
     def retain(self, toRetain=None, start=None, end=None, number=None,
-               randomize=False, useLog=None):
+               randomize=False, *,
+               useLog=None): # pylint: disable=unused-argument
         """
         Keep only certain points of this object.
 
@@ -904,7 +916,7 @@ class Points(ABC):
          'a' │ 1 0 0
         >
         """
-        self._retain(toRetain, start, end, number, randomize, useLog)
+        self._retain(toRetain, start, end, number, randomize)
 
     @limitedTo2D
     def count(self, condition):
@@ -953,7 +965,9 @@ class Points(ABC):
         """
         return self._count(condition)
 
-    def sort(self, by=None, reverse=False, useLog=None):
+    @prepLog
+    def sort(self, by=None, reverse=False, *,
+             useLog=None): # pylint: disable=unused-argument
         """
         Arrange the points in this object.
 
@@ -1059,10 +1073,12 @@ class Points(ABC):
         --------
         arrange, order
         """
-        self._sort(by, reverse, useLog)
+        self._sort(by, reverse)
 
     @limitedTo2D
-    def transform(self, function, points=None, useLog=None):
+    @prepLog
+    def transform(self, function, points=None, *,
+                  useLog=None): # pylint: disable=unused-argument
         """
         Modify this object by applying a function to each point.
 
@@ -1137,13 +1153,15 @@ class Points(ABC):
          2 │ 7 7 7 7 7
         >
         """
-        self._transform(function, points, useLog)
+        self._transform(function, points)
 
     ###########################
     # Higher Order Operations #
     ###########################
     @limitedTo2D
-    def calculate(self, function, points=None, useLog=None):
+    @prepLog
+    def calculate(self, function, points=None, *,
+                  useLog=None): # pylint: disable=unused-argument
         """
         Apply a calculation to each point.
 
@@ -1226,10 +1244,12 @@ class Points(ABC):
 
         Keywords: apply, modify, alter
         """
-        return self._calculate(function, points, useLog)
+        return self._calculate(function, points)
 
     @limitedTo2D
-    def matching(self, function, useLog=None):
+    @prepLog
+    def matching(self, function, *,
+                 useLog=None): # pylint: disable=unused-argument
         """
         Identifying points matching the given criteria.
 
@@ -1293,9 +1313,11 @@ class Points(ABC):
         boolean, equivalent, identical, same, matches, equals, compare,
         comparison, same
         """
-        return self._matching(function, useLog)
+        return self._matching(function)
 
-    def insert(self, insertBefore, toInsert, useLog=None):
+    @prepLog
+    def insert(self, insertBefore, toInsert, *,
+               useLog=None): # pylint: disable=unused-argument
         """
         Insert more points into this object.
 
@@ -1380,9 +1402,11 @@ class Points(ABC):
          3 │  1   2   3
         >
         """
-        self._insert(insertBefore, toInsert, False, useLog)
+        self._insert(insertBefore, toInsert, False)
 
-    def append(self, toAppend, useLog=None):
+    @prepLog
+    def append(self, toAppend, *,
+               useLog=None): # pylint: disable=unused-argument
         """
         Append points to this object.
 
@@ -1470,9 +1494,12 @@ class Points(ABC):
         affix, adjoin, concatenate, concat, vstack, add, attach, join,
         merge
         """
-        self._insert(None, toAppend, True, useLog)
+        self._insert(None, toAppend, True)
 
-    def replace(self, data, points=None, useLog=None, **dataKwds):
+    @prepLog
+    def replace(self, data, points=None, *,
+                useLog=None, # pylint: disable=unused-argument
+                **dataKwds):
         """
         Replace the data in one or more of the points in this object.
 
@@ -1550,10 +1577,12 @@ class Points(ABC):
         --------
         change, substitute, alter, transform
         """
-        return self._replace(data, points, useLog, **dataKwds)
+        return self._replace(data, points, **dataKwds)
 
     @limitedTo2D
-    def mapReduce(self, mapper, reducer, useLog=None):
+    @prepLog
+    def mapReduce(self, mapper, reducer, *,
+                  useLog=None): # pylint: disable=unused-argument
         """
         Apply a mapper and reducer function to this object.
 
@@ -1606,9 +1635,11 @@ class Points(ABC):
         --------
         map, reduce, apply
         """
-        return self._mapReduce(mapper, reducer, useLog)
+        return self._mapReduce(mapper, reducer)
 
-    def permute(self, order=None, useLog=None):
+    @prepLog
+    def permute(self, order=None, *,
+                useLog=None): # pylint: disable=unused-argument
         """
         Permute the indexing of the points.
 
@@ -1682,11 +1713,13 @@ class Points(ABC):
         --------
         reorder, rearrange, shuffle
         """
-        self._permute(order, useLog)
+        self._permute(order)
 
     @limitedTo2D
-    def fillMatching(self, fillWith, matchingElements, points=None,
-                     useLog=None, **kwarguments):
+    @prepLog
+    def fillMatching(self, fillWith, matchingElements, points=None, *,
+                     useLog=None, # pylint: disable=unused-argument,
+                     **kwarguments):
         """
         Replace given values in each point with other values.
 
@@ -1779,11 +1812,13 @@ class Points(ABC):
         >
         """
         return self._fillMatching(fillWith, matchingElements, points,
-                                  useLog, **kwarguments)
+                                  **kwarguments)
 
     @limitedTo2D
+    @prepLog
     def splitByCollapsingFeatures(self, featuresToCollapse, featureForNames,
-                                  featureForValues, useLog=None):
+                                  featureForValues, *,
+                                  useLog=None): # pylint: disable=unused-argument
         """
         Separate feature/value pairs into unique points.
 
@@ -1921,16 +1956,13 @@ class Points(ABC):
                     appendedPts.append(f"{name}_{i}")
             self.setNames(appendedPts, useLog=False)
 
-        handleLogging(useLog, 'prep', 'points.splitByCollapsingFeatures',
-                      self._base.getTypeString(),
-                      Points.splitByCollapsingFeatures, featuresToCollapse,
-                      featureForNames, featureForValues)
 
     @limitedTo2D
+    @prepLog
     def combineByExpandingFeatures(self, featureWithFeatureNames,
                                    featuresWithValues,
-                                   modifyDuplicateFeatureNames=False,
-                                   useLog=None):
+                                   modifyDuplicateFeatureNames=False, *,
+                                   useLog=None): # pylint: disable=unused-argument
         """
         Combine similar points based on a differentiating feature.
 
@@ -2129,12 +2161,9 @@ class Points(ABC):
         if self._base.points._namesCreated():
             self.setNames(pNames, useLog=False)
 
-        handleLogging(useLog, 'prep', 'points.combineByExpandingFeatures',
-                      self._base.getTypeString(),
-                      Points.combineByExpandingFeatures,
-                      featureWithFeatureNames, featuresWithValues)
-
-    def repeat(self, totalCopies, copyPointByPoint):
+    @prepLog
+    def repeat(self, totalCopies, copyPointByPoint, *,
+               useLog=None): # pylint: disable=unused-argument
         """
         Create an object using copies of this object's points.
 
@@ -2156,6 +2185,13 @@ class Points(ABC):
             copies are made as if the object is only iterated once,
             making ``totalCopies`` copies of each point before iterating
             to the next point.
+        useLog : bool, None
+            Local control for whether to send object creation to the
+            logger. If None (default), use the value as specified in the
+            "logger" "enabledByDefault" configuration option. If True,
+            send to the logger regardless of the global option. If
+            False, do **NOT** send to the logger, regardless of the
+            global option.
 
         Returns
         -------
@@ -2524,11 +2560,11 @@ class Points(ABC):
         pass
 
     @abstractmethod
-    def _setName(self, oldIdentifier, newName, useLog):
+    def _setName(self, oldIdentifier, newName):
         pass
 
     @abstractmethod
-    def _setNames(self, assignments, useLog):
+    def _setNames(self, assignments):
         pass
 
     @abstractmethod
@@ -2544,19 +2580,19 @@ class Points(ABC):
         pass
 
     @abstractmethod
-    def _copy(self, toCopy, start, end, number, randomize, useLog=None):
+    def _copy(self, toCopy, start, end, number, randomize):
         pass
 
     @abstractmethod
-    def _extract(self, toExtract, start, end, number, randomize, useLog=None):
+    def _extract(self, toExtract, start, end, number, randomize):
         pass
 
     @abstractmethod
-    def _delete(self, toDelete, start, end, number, randomize, useLog=None):
+    def _delete(self, toDelete, start, end, number, randomize):
         pass
 
     @abstractmethod
-    def _retain(self, toRetain, start, end, number, randomize, useLog=None):
+    def _retain(self, toRetain, start, end, number, randomize):
         pass
 
     @abstractmethod
@@ -2564,39 +2600,39 @@ class Points(ABC):
         pass
 
     @abstractmethod
-    def _sort(self, by, reverse, useLog=None):
+    def _sort(self, by, reverse):
         pass
 
     @abstractmethod
-    def _transform(self, function, limitTo, useLog=None):
+    def _transform(self, function, limitTo):
         pass
 
     @abstractmethod
-    def _calculate(self, function, limitTo, useLog=None):
+    def _calculate(self, function, limitTo):
         pass
 
     @abstractmethod
-    def _matching(self, function, useLog=None):
+    def _matching(self, function):
         pass
 
     @abstractmethod
-    def _insert(self, insertBefore, toInsert, append=False, useLog=None):
+    def _insert(self, insertBefore, toInsert, append=False):
         pass
 
     @limitedTo2D
-    def _replace(self, data, locations, useLog=None):
+    def _replace(self, data, locations):
         pass
 
     @abstractmethod
-    def _mapReduce(self, mapper, reducer, useLog=None):
+    def _mapReduce(self, mapper, reducer):
         pass
 
     @abstractmethod
-    def _permute(self, order=None, useLog=None):
+    def _permute(self, order=None):
         pass
 
     @abstractmethod
-    def _fillMatching(self, match, fill, limitTo, useLog=None, **kwarguments):
+    def _fillMatching(self, match, fill, limitTo, **kwarguments):
         pass
 
     @abstractmethod

--- a/nimble/core/data/stretch.py
+++ b/nimble/core/data/stretch.py
@@ -237,9 +237,11 @@ class StretchSparse(Stretch):
     def _stretchArithmetic_implementation(self, opName, other):
         if not isinstance(other, Stretch):
             if self._source.shape[0] == 1 and other.shape[0] > 1:
-                lhs = self._source.points.repeat(other.shape[0], True)
+                lhs = self._source.points.repeat(other.shape[0], True,
+                                                 useLog=False)
             elif self._source.shape[1] == 1 and other.shape[1] > 1:
-                lhs = self._source.features.repeat(other.shape[1], True)
+                lhs = self._source.features.repeat(other.shape[1], True,
+                                                   useLog=False)
             else:
                 lhs = self._source
             rhs = other.copy()
@@ -247,12 +249,12 @@ class StretchSparse(Stretch):
         elif self._numPts == 1:
             selfFts = len(self._source.features)
             otherPts = len(other._source.points)
-            lhs = self._source.points.repeat(otherPts, True)
-            rhs = other._source.features.repeat(selfFts, True)
+            lhs = self._source.points.repeat(otherPts, True, useLog=False)
+            rhs = other._source.features.repeat(selfFts, True, useLog=False)
         else:
             selfPts = len(self._source.points)
             otherFts = len(other._source.features)
-            rhs = other._source.points.repeat(selfPts, True)
-            lhs = self._source.features.repeat(otherFts, True)
+            rhs = other._source.points.repeat(selfPts, True, useLog=False)
+            lhs = self._source.features.repeat(otherFts, True, useLog=False)
 
         return lhs._binaryOperations_implementation(opName, rhs)

--- a/nimble/core/data/views.py
+++ b/nimble/core/data/views.py
@@ -49,7 +49,6 @@ class BaseView(Base, metaclass=ABCMeta):
         Included due to best practices so args may automatically be
         passed further up into the hierarchy if needed.
     """
-
     def __init__(self, source, pointStart, pointEnd, featureStart, featureEnd,
                  **kwds):
         self._source = source
@@ -143,16 +142,18 @@ class BaseView(Base, metaclass=ABCMeta):
         else:
             yield self
 
+    # pylint: disable=unused-argument
     ###########################
     # Higher Order Operations #
     ###########################
 
     @baseExceptionDoc
-    def replaceFeatureWithBinaryFeatures(self, featureToReplace, useLog=None):
+    def replaceFeatureWithBinaryFeatures(self, featureToReplace, *,
+                                         useLog=None):
         readOnlyException("replaceFeatureWithBinaryFeatures")
 
     @baseExceptionDoc
-    def transformFeatureToIntegers(self, featureToConvert, useLog=None):
+    def transformFeatureToIntegers(self, featureToConvert, *, useLog=None):
         readOnlyException("transformFeatureToIntegers")
 
     @baseExceptionDoc
@@ -182,29 +183,29 @@ class BaseView(Base, metaclass=ABCMeta):
     @baseExceptionDoc
     def transformElements(self, toTransform, points=None, features=None,
                           preserveZeros=False, skipNoneReturnValues=False,
-                          useLog=None):
+                          *, useLog=None):
         readOnlyException("transform")
 
     @baseExceptionDoc
-    def transpose(self, useLog=None):
+    def transpose(self, *, useLog=None):
         readOnlyException("transpose")
 
     @baseExceptionDoc
     def replaceRectangle(self, replaceWith, pointStart, featureStart,
-                         pointEnd=None, featureEnd=None, useLog=None):
+                         pointEnd=None, featureEnd=None, *, useLog=None):
         readOnlyException("replaceRectangle")
 
     @baseExceptionDoc
-    def flatten(self, order='point', useLog=None):
+    def flatten(self, order='point', *, useLog=None):
         readOnlyException("flatten")
 
     @baseExceptionDoc
-    def unflatten(self, dataDimensions, order='point', useLog=None):
+    def unflatten(self, dataDimensions, order='point', *, useLog=None):
         readOnlyException("unflatten")
 
     @baseExceptionDoc
     def merge(self, other, point='strict', feature='union', onFeature=None,
-              force=False, useLog=None):
+              force=False, *, useLog=None):
         readOnlyException('merge')
 
     ###############################################################
@@ -257,17 +258,18 @@ class PointsView(Points, metaclass=ABCMeta):
     base : BaseView
         The BaseView instance that will be queried.
     """
+    # pylint: disable=unused-argument
 
     ####################################
     # Low Level Operations, Disallowed #
     ####################################
 
     @pointsExceptionDoc
-    def setName(self, oldIdentifier, newName, useLog=None):
+    def setName(self, oldIdentifier, newName, *, useLog=None):
         readOnlyException('setName')
 
     @pointsExceptionDoc
-    def setNames(self, assignments, useLog=None):
+    def setNames(self, assignments, *, useLog=None):
         readOnlyException('setNames')
 
     #####################################
@@ -276,37 +278,37 @@ class PointsView(Points, metaclass=ABCMeta):
 
     @pointsExceptionDoc
     def extract(self, toExtract=None, start=None, end=None, number=None,
-                randomize=False, useLog=None):
+                randomize=False, *, useLog=None):
         readOnlyException('extract')
 
     @pointsExceptionDoc
     def delete(self, toDelete=None, start=None, end=None, number=None,
-               randomize=False, useLog=None):
+               randomize=False, *, useLog=None):
         readOnlyException('delete')
 
     @pointsExceptionDoc
     def retain(self, toRetain=None, start=None, end=None, number=None,
-               randomize=False, useLog=None):
+               randomize=False, *, useLog=None):
         readOnlyException('retain')
 
     @pointsExceptionDoc
-    def insert(self, insertBefore, toInsert, useLog=None):
+    def insert(self, insertBefore, toInsert, *, useLog=None):
         readOnlyException('insert')
 
     @pointsExceptionDoc
-    def append(self, toAppend, useLog=None):
+    def append(self, toAppend, *, useLog=None):
         readOnlyException('append')
 
     @pointsExceptionDoc
-    def permute(self, order=None, useLog=None):
+    def permute(self, order=None, *, useLog=None):
         readOnlyException('permute')
 
     @pointsExceptionDoc
-    def sort(self, by=None, reverse=False, useLog=None):
+    def sort(self, by=None, reverse=False, *, useLog=None):
         readOnlyException('sort')
 
     @pointsExceptionDoc
-    def transform(self, function, points=None, useLog=None):
+    def transform(self, function, points=None, *, useLog=None):
         readOnlyException('transform')
 
     ######################################
@@ -315,23 +317,23 @@ class PointsView(Points, metaclass=ABCMeta):
 
     @pointsExceptionDoc
     def fillMatching(self, fillWith, matchingElements, points=None,
-                     useLog=None, **kwarguments):
+                     *, useLog=None, **kwarguments):
         readOnlyException('fill')
 
     @pointsExceptionDoc
     def splitByCollapsingFeatures(self, featuresToCollapse, featureForNames,
-                                  featureForValues, useLog=None):
+                                  featureForValues, *, useLog=None):
         readOnlyException('splitByCollapsingFeatures')
 
     @pointsExceptionDoc
     def combineByExpandingFeatures(self, featureWithFeatureNames,
                                    featuresWithValues,
                                    modifyDuplicateFeatureNames=False,
-                                   useLog=None):
+                                   *, useLog=None):
         readOnlyException('combineByExpandingFeatures')
 
     @pointsExceptionDoc
-    def replace(self, data, points=None, useLog=None, **dataKwds):
+    def replace(self, data, points=None, *, useLog=None, **dataKwds):
         readOnlyException('replace')
 
 @inheritDocstringsFactory(Features)
@@ -345,17 +347,18 @@ class FeaturesView(Features, metaclass=ABCMeta):
     base : BaseView
         The BaseView instance that will be queried.
     """
+    # pylint: disable=unused-argument
 
     ####################################
     # Low Level Operations, Disallowed #
     ####################################
 
     @featuresExceptionDoc
-    def setName(self, oldIdentifier, newName, useLog=None):
+    def setName(self, oldIdentifier, newName, *, useLog=None):
         readOnlyException('setName')
 
     @featuresExceptionDoc
-    def setNames(self, assignments, useLog=None):
+    def setNames(self, assignments, *, useLog=None):
         readOnlyException('setNames')
 
     #####################################
@@ -364,37 +367,37 @@ class FeaturesView(Features, metaclass=ABCMeta):
 
     @featuresExceptionDoc
     def extract(self, toExtract=None, start=None, end=None, number=None,
-                randomize=False, useLog=None):
+                randomize=False, *, useLog=None):
         readOnlyException('extract')
 
     @featuresExceptionDoc
     def delete(self, toDelete=None, start=None, end=None, number=None,
-               randomize=False, useLog=None):
+               randomize=False, *, useLog=None):
         readOnlyException('delete')
 
     @featuresExceptionDoc
     def retain(self, toRetain=None, start=None, end=None, number=None,
-               randomize=False, useLog=None):
+               randomize=False, *, useLog=None):
         readOnlyException('retain')
 
     @featuresExceptionDoc
-    def insert(self, insertBefore, toInsert, useLog=None):
+    def insert(self, insertBefore, toInsert, *, useLog=None):
         readOnlyException('insert')
 
     @featuresExceptionDoc
-    def append(self, toAppend, useLog=None):
+    def append(self, toAppend, *, useLog=None):
         readOnlyException('append')
 
     @featuresExceptionDoc
-    def permute(self, order=None, useLog=None):
+    def permute(self, order=None, *, useLog=None):
         readOnlyException('permute')
 
     @featuresExceptionDoc
-    def sort(self, by=None, reverse=False, useLog=None):
+    def sort(self, by=None, reverse=False, *, useLog=None):
         readOnlyException('sort')
 
     @featuresExceptionDoc
-    def transform(self, function, features=None, useLog=None):
+    def transform(self, function, features=None, *, useLog=None):
         readOnlyException('transform')
 
     ######################################
@@ -403,18 +406,18 @@ class FeaturesView(Features, metaclass=ABCMeta):
 
     @featuresExceptionDoc
     def fillMatching(self, fillWith, matchingElements, features=None,
-                     useLog=None, **kwarguments):
+                     *, useLog=None, **kwarguments):
         readOnlyException('fill')
 
     @featuresExceptionDoc
     def normalize(self, function, applyResultTo=None, features=None,
-                  useLog=None):
+                  *, useLog=None):
         readOnlyException('normalize')
 
     @featuresExceptionDoc
-    def splitByParsing(self, feature, rule, resultingNames, useLog=None):
+    def splitByParsing(self, feature, rule, resultingNames, *, useLog=None):
         readOnlyException('splitByParsing')
 
     @featuresExceptionDoc
-    def replace(self, data, features=None, useLog=None, **dataKwds):
+    def replace(self, data, features=None, *, useLog=None, **dataKwds):
         readOnlyException('replace')

--- a/nimble/core/learn.py
+++ b/nimble/core/learn.py
@@ -296,7 +296,7 @@ def showLearnerParameterDefaults(name):
 
 @trackEntry
 def normalizeData(learnerName, trainX, trainY=None, testX=None, arguments=None,
-                  randomSeed=None, useLog=None, **kwarguments):
+                  randomSeed=None, *, useLog=None, **kwarguments):
     """
     Modify data according to a produced model.
 
@@ -439,7 +439,7 @@ def normalizeData(learnerName, trainX, trainY=None, testX=None, arguments=None,
 
 @trackEntry
 def fillMatching(learnerName, matchingElements, trainX, arguments=None,
-                 points=None, features=None, useLog=None, **kwarguments):
+                 points=None, features=None, *, useLog=None, **kwarguments):
     """
     Fill matching values using imputation learners.
 
@@ -589,7 +589,7 @@ def fillMatching(learnerName, matchingElements, trainX, arguments=None,
 @trackEntry
 def train(learnerName, trainX, trainY=None, arguments=None, scoreMode='label',
           multiClassStrategy='default', randomSeed=None, tuning=None,
-          performanceFunction=None, useLog=None, **kwarguments):
+          performanceFunction=None, *, useLog=None, **kwarguments):
     """
     Train a specified learner using the provided data.
 
@@ -746,7 +746,7 @@ def train(learnerName, trainX, trainY=None, arguments=None, scoreMode='label',
     funcString = interface.getCanonicalName() + '.' + trueLearnerName
     handleLogging(useLog, "run", "train", trainX, trainY, None, None,
                   funcString, bestArguments, trainedLearner.randomSeed,
-                  time=totalTime)
+                  time=totalTime, returned=trainedLearner)
 
     return trainedLearner
 
@@ -754,7 +754,7 @@ def train(learnerName, trainX, trainY=None, arguments=None, scoreMode='label',
 def trainAndApply(learnerName, trainX, trainY=None, testX=None, arguments=None,
                   output=None, scoreMode='label', multiClassStrategy='default',
                   randomSeed=None, tuning=None, performanceFunction=None,
-                  useLog=None, **kwarguments):
+                  *, useLog=None, **kwarguments):
     """
     Train a model and apply it to the test data.
 
@@ -925,10 +925,10 @@ def trainAndApply(learnerName, trainX, trainY=None, testX=None, arguments=None,
 
     extraInfo = None
     if merged != trainedLearner.arguments:
-        extraInfo = {"bestArguments": trainedLearner.arguments}
+        extraInfo = {'Best Arguments': trainedLearner.arguments}
     handleLogging(useLog, "run", "trainAndApply", trainX, trainY, testX, None,
                   learnerName, merged, trainedLearner.randomSeed,
-                  extraInfo=extraInfo, time=totalTime)
+                  extraInfo=extraInfo, time=totalTime, returned=results)
 
     return results
 
@@ -955,7 +955,7 @@ def _trainAndTestBackend(learnerName, trainX, trainY, testX, testY,
 def trainAndTest(learnerName, trainX, trainY, testX, testY,
                  performanceFunction, arguments=None, output=None,
                  scoreMode='label', multiClassStrategy='default',
-                 randomSeed=None, tuning=None, useLog=None,
+                 randomSeed=None, tuning=None, *, useLog=None,
                  **kwarguments):
     """
     Train a model and get the results of its performance.
@@ -1127,7 +1127,7 @@ def trainAndTest(learnerName, trainX, trainY, testX, testY,
         metrics[key.__name__] = value
     extraInfo = None
     if merged != trainedLearner.arguments:
-        extraInfo = {"bestArguments": trainedLearner.arguments}
+        extraInfo = {'Best Arguments': trainedLearner.arguments}
     handleLogging(useLog, "run", 'trainAndTest', trainX, trainY, testX, testY,
                   learnerName, merged, trainedLearner.randomSeed, metrics,
                   extraInfo, totalTime)
@@ -1140,7 +1140,7 @@ def trainAndTestOnTrainingData(
     learnerName, trainX, trainY, performanceFunction,
     crossValidationError=False, folds=5, arguments=None, output=None,
     scoreMode='label', multiClassStrategy='default', randomSeed=None,
-    tuning=None, useLog=None, **kwarguments):
+    tuning=None, *, useLog=None, **kwarguments):
     """
     Train a model using the train data and get the performance results.
 
@@ -1305,7 +1305,7 @@ def trainAndTestOnTrainingData(
 
     if trainedLearner.tuning is not None:
         bestArgs = trainedLearner.arguments
-        extraInfo = {"bestArguments": bestArgs}
+        extraInfo = {'Best Arguments': bestArgs}
     else:
         bestArgs = merged
         extraInfo = None

--- a/nimble/core/logger/__init__.py
+++ b/nimble/core/logger/__init__.py
@@ -10,5 +10,6 @@ from .session_logger import handleLogging
 from .session_logger import loggingEnabled
 from .session_logger import deepLoggingEnabled
 from .session_logger import stringToDatetime
+from .session_logger import LogID
 
 active = None

--- a/nimble/core/tune.py
+++ b/nimble/core/tune.py
@@ -227,7 +227,7 @@ class Validator(ABC):
         ret += ")"
         return ret
 
-    def validate(self, arguments=None, useLog=None, **kwarguments):
+    def validate(self, arguments=None, *, useLog=None, **kwarguments):
         """
         Apply the validation to a learner with the given arguments.
         """
@@ -509,12 +509,10 @@ class HoldoutValidator(Validator):
 
         metrics = {self.performanceFunction.__name__: performance}
         deepLog = loggingEnabled(useLog) and deepLoggingEnabled()
-
         handleLogging(deepLog, "deepRun", self.__class__.__name__,
                       self.X, self.Y, self._validateX, self._validateY,
                       self.learnerName, arguments, self.randomSeed,
-                      metrics=metrics, extraInfo=self._keywords,
-                      time=totalTime)
+                      metrics=metrics, time=totalTime)
 
         return performance
 
@@ -1062,7 +1060,7 @@ class Tuning:
         else:
             selector = self._selector(arguments, **self._selectorArgs)
         for argSet in selector:
-            performance = self.validator.validate(argSet, useLog)
+            performance = self.validator.validate(argSet, useLog=useLog)
             selector.update(performance)
 
         # reverse based on optimal for performanceFunction

--- a/nimble/random/randomness.py
+++ b/nimble/random/randomness.py
@@ -17,7 +17,7 @@ from nimble.core._createHelpers import validateReturnType, initDataObject
 pythonRandom = random.Random(42)
 numpyRandom = np.random.RandomState(42) # pylint: disable=no-member
 
-def setSeed(seed, useLog=None):
+def setSeed(seed, *, useLog=None):
     """
     Set the seeds on all sources of randomness in nimble.
 
@@ -44,7 +44,7 @@ setSeed._settable = True
 
 def data(numPoints, numFeatures, sparsity, pointNames='automatic',
          featureNames='automatic', elementType='float', returnType=None,
-         name=None, randomSeed=None, useLog=None):
+         name=None, randomSeed=None, *, useLog=None):
     """
     Generate a data object with random contents.
 
@@ -202,9 +202,7 @@ def data(numPoints, numFeatures, sparsity, pointNames='automatic',
                          featureNames=featureNames, returnType=returnType,
                          name=name, copyData=False, skipDataProcessing=True)
 
-    handleLogging(useLog, 'load', returnType, "Random " + ret.getTypeString(),
-                  numPoints, numFeatures, name, sparsity=sparsity,
-                  seed=randomSeed)
+    handleLogging(useLog, 'load', ret, sparsity=sparsity, seed=randomSeed)
 
     return ret
 
@@ -259,7 +257,7 @@ def _stillDefaultState():
 #return _stillDefault
 
 @contextmanager
-def alternateControl(seed=None, useLog=None):
+def alternateControl(seed=None, *, useLog=None):
     """
     Context manager to operate outside of the current random state.
 

--- a/tests/data/high_level_backend.py
+++ b/tests/data/high_level_backend.py
@@ -1618,24 +1618,24 @@ class HighLevelDataSafe(DataTestObject):
 
             trX, trY, teX, teY = toTest.trainAndTestSets(.5, 0)
 
-            assert trX.name == 'toTest trainX'
+            assert trX.name == 'toTest_trainX'
             assert trX.path == tmpFile.name
             assert trX.absolutePath == tmpFile.name
             assert trX.relativePath == os.path.relpath(tmpFile.name)
 
-            assert trY.name == 'toTest trainY'
+            assert trY.name == 'toTest_trainY'
             assert trY.path == tmpFile.name
             assert trY.path == tmpFile.name
             assert trY.absolutePath == tmpFile.name
             assert trY.relativePath == os.path.relpath(tmpFile.name)
 
-            assert teX.name == 'toTest testX'
+            assert teX.name == 'toTest_testX'
             assert teX.path == tmpFile.name
             assert teX.path == tmpFile.name
             assert teX.absolutePath == tmpFile.name
             assert teX.relativePath == os.path.relpath(tmpFile.name)
 
-            assert teY.name == 'toTest testY'
+            assert teY.name == 'toTest_testY'
             assert teY.path == tmpFile.name
             assert teY.path == tmpFile.name
             assert teY.absolutePath == tmpFile.name
@@ -2053,7 +2053,7 @@ class HighLevelDataSafe(DataTestObject):
         toTest = self.constructor(data, pointNames=ptNames, featureNames=ftNames)
         repeated = toTest.points.repeat(totalCopies=1, copyPointByPoint=True)
 
-    @noLogEntryExpected
+    @logCountAssertionFactory(2)
     def test_points_repeat_1D(self):
         data = [0, 1, 2, 3]
         ptNames = ['pt']
@@ -2070,7 +2070,7 @@ class HighLevelDataSafe(DataTestObject):
         # return is same for either copyPointByPoint when 1D
         assert repeated1 == repeated2
 
-    @noLogEntryExpected
+    @oneLogEntryExpected
     def test_points_repeat_2D_copyPointByPointFalse(self):
         data = [[1, 2, 3, 0], [4, 5, 6, 0], [0, 0, 0, 0]]
         ptNames = ['1', '4', '0']
@@ -2092,7 +2092,7 @@ class HighLevelDataSafe(DataTestObject):
         ptNames = ['1', '4', '0']
         ftNames = ['a', 'b', 'c', 'd']
         toTest = self.constructor(data, pointNames=ptNames, featureNames=ftNames)
-        repeated = toTest.points.repeat(3, copyPointByPoint=True)
+        repeated = toTest.points.repeat(3, copyPointByPoint=True, useLog=False)
 
         expData = [[1, 2, 3, 0], [1, 2, 3, 0], [1, 2, 3, 0],
                    [4, 5, 6, 0], [4, 5, 6, 0], [4, 5, 6, 0],
@@ -2126,7 +2126,7 @@ class HighLevelDataSafe(DataTestObject):
         toTest = self.constructor(data, pointNames=ptNames, featureNames=ftNames)
         repeated = toTest.features.repeat(totalCopies=1, copyFeatureByFeature=False)
 
-    @noLogEntryExpected
+    @logCountAssertionFactory(2)
     def test_features_repeat_1D(self):
         data = [[0], [1], [2], [3]]
         ptNames = ['pt0', 'pt1', 'pt2', 'pt3']
@@ -2143,7 +2143,7 @@ class HighLevelDataSafe(DataTestObject):
         # return is same for either copyFeatureByFeature when 1D
         assert repeated1 == repeated2
 
-    @noLogEntryExpected
+    @oneLogEntryExpected
     def test_features_repeat_2D_copyFeatureByFeatureFalse(self):
         data = [[1, 2, 3, 0], [4, 5, 6, 0], [0, 0, 0, 0]]
         ptNames = ['1', '4', '0']
@@ -2165,7 +2165,7 @@ class HighLevelDataSafe(DataTestObject):
         ptNames = ['1', '4', '0']
         ftNames = ['a', 'b', 'c', 'd']
         toTest = self.constructor(data, pointNames=ptNames, featureNames=ftNames)
-        repeated = toTest.features.repeat(3, copyFeatureByFeature=True)
+        repeated = toTest.features.repeat(3, copyFeatureByFeature=True, useLog=False)
 
         expData = [[1, 1, 1, 2, 2, 2, 3, 3, 3, 0, 0, 0],
                    [4, 4, 4, 5, 5, 5, 6, 6, 6, 0, 0, 0],
@@ -2989,8 +2989,8 @@ class HighLevelModifying(DataTestObject):
     def test_features_normalize_parameterCount(self):
         obj = self.constructor([[1, 2], [3, 4]])
         a, _, _, d = nimble._utility.inspectArguments(obj.features.normalize)
-        assert len(a) == 5 # self, function, applyResultTo, features, useLog
-        assert d == (None, None, None)
+        assert len(a) == 4 # self, function, applyResultTo, features
+        assert d == (None, None)
 
     def test_features_normalize_exception_unexpectedInputType(self):
         obj = self.constructor([[1, 2], [3, 4]])

--- a/tests/data/low_level_backend.py
+++ b/tests/data/low_level_backend.py
@@ -87,21 +87,6 @@ class LowLevelBackend(object):
         """ Test that object validation has been setup """
         assert hasattr(Base, 'objectValidation')
 
-    #######
-    # _id #
-    #######
-    def test_id_allUnique(self):
-        a = self.constructor()
-        b = self.constructor()
-        c = self.constructor()
-        d = self.constructor()
-        # The _id for returned objects will not always increment by one, but
-        # no additional internal objects are created during a call to
-        # constructor() so here each new object _id will increment by one
-        assert b._id == a._id + 1
-        assert c._id == b._id + 1
-        assert d._id == c._id + 1
-
     ############################
     # points._nameDifference() #
     ############################

--- a/tests/data/structure_backend.py
+++ b/tests/data/structure_backend.py
@@ -7059,7 +7059,6 @@ class StructureModifying(StructureShared):
         featureNames = ['one', 'two', 'three']
         pNames = ['1', 'one', '2', '0']
         orig = self.constructor(data1, pointNames=pNames, featureNames=featureNames)
-        origID = orig._id
         idOrig = id(orig)
 
         data2 = [[-1, -2, -3, -4]]
@@ -7069,7 +7068,6 @@ class StructureModifying(StructureShared):
 
         ret = orig._referenceFrom(other)  # RET CHECK
 
-        assert orig._id == origID
         assert id(orig) == idOrig
         assert orig._data is other._data
         assert '-1' in orig.points.getNames()
@@ -7082,7 +7080,6 @@ class StructureModifying(StructureShared):
         pNames = ['1', 'one', '2', '0']
         orig = self.constructor(data1, name='orig', pointNames=pNames,
                                 featureNames=featureNames)
-        origID = orig._id
         idOrig = id(orig)
 
         data2 = [[-1, -2, -3, -4]]
@@ -7093,7 +7090,6 @@ class StructureModifying(StructureShared):
 
         orig._referenceFrom(other.view())
 
-        assert orig._id == origID
         assert id(orig) == idOrig
         assert orig._data is not other._data # copy must be made for view
         assert orig == other

--- a/tests/data/view_access_backend.py
+++ b/tests/data/view_access_backend.py
@@ -70,7 +70,7 @@ class ViewAccess(DataTestObject):
             testObject.transpose()
 
         with raises(TypeError, match="disallowed for View objects"):
-            testObject.replaceRectangle(self, [99, 99, 99], 0, 0, 0, 2)
+            testObject.replaceRectangle([99, 99, 99], 0, 0, 0, 2)
 
         with raises(TypeError, match="disallowed for View objects"):
             testObject.flatten()

--- a/tests/landingPage/additional_functionality_output.txt
+++ b/tests/landingPage/additional_functionality_output.txt
@@ -14,14 +14,14 @@ wifi signal strengths
 ...............................................................................
 .                                  SESSION 0                                  .
 ...............................................................................
-REGEX: Matrix Loaded                                               \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
+REGEX: Loaded: wifiData                                            \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
 # of points    2000
 # of features  8
-name           wifiData
 REGEX: path           \S+
 REGEX:                \S+
+logID          _NIMBLE_0_
 ...............................................................................
-REGEX: Matrix.features.setNames                                    \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
+REGEX: wifiData.features.setNames                                  \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
 Arguments: assignments=['source0', 'source1', 'source2', 'source3', 'source4',
            'source5', 'source6', 'room']
 ...............................................................................
@@ -42,14 +42,14 @@ Wifi signal strength data from 7 sources in 4 possible rooms
 ...............................................................................
 .                                  SESSION 0                                  .
 ...............................................................................
-REGEX: Matrix Loaded                                               \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
+REGEX: Loaded: wifiData                                            \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
 # of points    2000
 # of features  8
-name           wifiData
 REGEX: path           \S+
 REGEX:                \S+
+logID          _NIMBLE_0_
 ...............................................................................
-REGEX: Matrix.features.setNames                                    \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
+REGEX: wifiData.features.setNames                                  \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
 Arguments: assignments=['source0', 'source1', 'source2', 'source3', 'source4',
            'source5', 'source6', 'room']
 ...............................................................................
@@ -106,7 +106,7 @@ testY                     467                       1
 
 Arguments: k=7
 Random Seed: 2127877500
-Extra Info: Fold=2/3
+Fold: 2/3
 Metrics: fractionCorrect=0.9764453961456103
 ...............................................................................
 REGEX: Completed\sin\s\d+\.\d{3}\sseconds\s+\d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
@@ -120,7 +120,7 @@ testY                     466                       1
 
 Arguments: k=7
 Random Seed: 2127877500
-Extra Info: Fold=3/3
+Fold: 3/3
 Metrics: fractionCorrect=0.9785407725321889
 ...............................................................................
 REGEX: "nimble.KNNClassifier" Hyperparameter Tuning                \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
@@ -137,35 +137,57 @@ REGEX: Completed\sin\s\d+\.\d{3}\sseconds\s+\d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
 
 trainAndTest("nimble.KNNClassifier")
 Data                      # points                  # features
-wifiData trainX           1400                      7
-wifiData trainY           1400                      1
-wifiData testX            600                       7
-wifiData testY            600                       1
+wifiData_trainX           1400                      7
+wifiData_trainY           1400                      1
+wifiData_testX            600                       7
+wifiData_testY            600                       1
 
 Arguments: k=Tune([3, 5, 7])
 Random Seed: 99320166
-Extra Info: bestArguments={'k': 3}
+Best Arguments: {'k': 3}
 Metrics: fractionCorrect=0.985
 ...............................................................................
                                   NIMBLE LOGS
 ...............................................................................
 .                                  SESSION 0                                  .
 ...............................................................................
-REGEX: Matrix Loaded                                               \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
+REGEX: Loaded: wifiData                                            \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
 # of points    2000
 # of features  8
-name           wifiData
 REGEX: path           \S+
 REGEX:                \S+
+logID          _NIMBLE_0_
+...............................................................................
+REGEX: wifiData.features.setNames                                  \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
+Arguments: assignments=['source0', 'source1', 'source2', 'source3', 'source4',
+           'source5', 'source6', 'room']
+...............................................................................
+REGEX: wifiData.points.permute                                     \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
+...............................................................................
+REGEX: wifiData.points.copy                                        \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
+Arguments: number=5, randomize=True
+Returned: _NIMBLE_1_
+...............................................................................
+REGEX: wifiData.points.copy                                        \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
+Arguments: number=5, randomize=True
+Returned: _NIMBLE_2_
+...............................................................................
+REGEX: wifiData.trainAndTestSets                                   \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
+Arguments: testFraction=0.3, labels=room, randomOrder=False
+Returned: wifiData_trainX, wifiData_trainY, wifiData_testX, wifiData_testY
+...............................................................................
+REGEX: wifiData_testX.points.calculate                             \d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
+Arguments: function=leastDistance
+Returned: _NIMBLE_9_
 ...............................................................................
 REGEX: Completed\sin\s\d+\.\d{3}\sseconds\s+\d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
 
 trainAndTest("custom.LeastFeatureMeanDistance")
 Data                      # points                  # features
-wifiData trainX           1400                      7
-wifiData trainY           1400                      1
-wifiData testX            600                       7
-wifiData testY            600                       1
+wifiData_trainX           1400                      7
+wifiData_trainY           1400                      1
+wifiData_testX            600                       7
+wifiData_testY            600                       1
 
 Random Seed: 506456970
 Metrics: fractionCorrect=0.9716666666666667
@@ -174,13 +196,13 @@ REGEX: Completed\sin\s\d+\.\d{3}\sseconds\s+\d{4}-\d\d-\d\d\s\d\d:\d\d:\d\d
 
 trainAndTest("nimble.KNNClassifier")
 Data                      # points                  # features
-wifiData trainX           1400                      7
-wifiData trainY           1400                      1
-wifiData testX            600                       7
-wifiData testY            600                       1
+wifiData_trainX           1400                      7
+wifiData_trainY           1400                      1
+wifiData_testX            600                       7
+wifiData_testY            600                       1
 
 Arguments: k=Tune([3, 5, 7])
 Random Seed: 99320166
-Extra Info: bestArguments={'k': 3}
+Best Arguments: {'k': 3}
 Metrics: fractionCorrect=0.985
 ...............................................................................

--- a/tests/landingPage/merging_and_tidying_data_output.txt
+++ b/tests/landingPage/merging_and_tidying_data_output.txt
@@ -1,5 +1,5 @@
 Example of data file structure
-"downtown_am_min.csv" 712pt x 13ft
+712pt x 13ft
         'date'   'hr0'  'hr1'  'hr2'  'hr3'  'hr4'  'hr5'  'hr6'  'hr7'  'hr8'  'hr9'  'hr10' 'hr11'
     ┌───────────────────────────────────────────────────────────────────────────────────────────────
   0 │ 2011-01-01 2.840  2.019         2.839  2.838  2.840  2.020  1.199  2.839  6.119  8.579  7.760
@@ -11,7 +11,7 @@ Example of data file structure
 711 │ 2012-12-31 0.380  0.379  -0.440 -0.441 -1.261 -0.441 -0.440 -0.440 -1.260 0.379  1.199  2.020
 
 Downtown data merged on date
-"downtown_am_min.csv" 717pt x 25ft
+717pt x 25ft
         'date'   'hr0'  'hr1'  'hr2'  'hr3' 'hr4'  'hr5'  'hr6'  'hr7'  ── 'hr16' 'hr17' 'hr18' 'hr19' 'hr20' 'hr21' 'hr22' 'hr23'
     ┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   0 │ 2011-01-01 2.840  2.019         2.839 2.838  2.840  2.020  1.199  ── 10.219 11.039 10.219 10.219 9.399  9.399  9.399  11.859
@@ -23,7 +23,7 @@ Downtown data merged on date
 716 │ 2012-04-16                                                        ── 25.800 25.798 25.799 24.159 23.339 20.878 20.880 21.699
 
 Downtown combined extreme data
-"downtown_am_min.csv" 1430pt x 26ft
+1430pt x 26ft
          'date'   'extreme' 'hr0'  'hr1'  'hr2'  'hr3' 'hr4'  'hr5'  ── 'hr16' 'hr17' 'hr18' 'hr19' 'hr20' 'hr21' 'hr22' 'hr23'
      ┌─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
    0 │ 2011-01-01    min    2.840  2.019         2.839 2.838  2.840  ── 10.219 11.039 10.219 10.219 9.399  9.399  9.399  11.859
@@ -35,7 +35,7 @@ Downtown combined extreme data
 1429 │ 2012-09-25    max                                             ── 20.061 20.060 19.240 18.422 17.602 17.600 17.600 17.601
 
 Fully merged (untidy) data
-"combined temperature data" 2840pt x 27ft
+"combinedTemperatureData" 2840pt x 27ft
          'date'   'station' 'extreme' 'hr0' 'hr1' 'hr2'  'hr3'  'hr4'  ── 'hr16' 'hr17' 'hr18' 'hr19' 'hr20' 'hr21' 'hr22' 'hr23'
      ┌───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
    0 │ 2011-01-01  downtown    min    2.840 2.019        2.839  2.838  ── 10.219 11.039 10.219 10.219 9.399  9.399  9.399  11.859
@@ -51,7 +51,7 @@ Fully merged (untidy) data
 2839 │ 2012-12-31  airport     max    0.391 0.421 -0.399 -0.400 -1.248 ── 3.681  3.681  3.661  3.661  3.682  3.681  3.670  3.651
 
 Split points by collapsing the hour features
-"combined temperature data" 68160pt x 5ft
+"combinedTemperatureData" 68160pt x 5ft
           'date'   'station' 'extreme' 'hour' 'temp'
       ┌─────────────────────────────────────────────
     0 │ 2011-01-01  downtown    min     hr0   2.840
@@ -67,7 +67,7 @@ Split points by collapsing the hour features
 68159 │ 2012-12-31  airport     max     hr9   0.422
 
 Date and hour sorted
-"combined temperature data" 68160pt x 5ft
+"combinedTemperatureData" 68160pt x 5ft
           'date'   'station' 'extreme' 'hour' 'temp'
       ┌─────────────────────────────────────────────
     0 │ 2011-01-01  downtown    min      0    2.840
@@ -83,7 +83,7 @@ Date and hour sorted
 68159 │ 2012-12-31  airport     max      23   3.651
 
 Combined points by expanding extreme feature
-"combined temperature data" 35064pt x 5ft
+"combinedTemperatureData" 35064pt x 5ft
           'date'   'station' 'min' 'max' 'hour'
       ┌────────────────────────────────────────
     0 │ 2011-01-01  downtown 2.840 2.840   0
@@ -99,7 +99,7 @@ Combined points by expanding extreme feature
 35063 │ 2012-12-31  airport  3.649 3.651   23
 
 Split features by parsing the date feature
-"combined temperature data" 35064pt x 7ft
+"combinedTemperatureData" 35064pt x 7ft
         'year' 'month' 'day' 'station' 'min' 'max' 'hour'
       ┌──────────────────────────────────────────────────
     0 │  2011     01     01   downtown 2.840 2.840   0

--- a/tests/logger/testLoggingCount.py
+++ b/tests/logger/testLoggingCount.py
@@ -139,28 +139,28 @@ base_tested = list(map(prefixAdder('Base'), base_funcs))
 
 features_logged = [
     'append', 'calculate', 'copy', 'delete', 'extract', 'fillMatching',
-    'insert', 'mapReduce', 'matching', 'normalize', 'permute', 'replace',
-    'report', 'retain', 'setName', 'setNames', 'sort', 'transform',
+    'insert', 'mapReduce', 'matching', 'normalize', 'permute', 'repeat',
+    'replace', 'report', 'retain', 'setName', 'setNames', 'sort', 'transform',
     'splitByParsing',
     ]
 features_notLogged = [
-    'count', 'repeat', 'getIndex', 'getIndices', 'getName', 'getNames',
-    'hasName', 'plot', 'plotMeans', 'plotStatistics', 'similarities',
-    'statistics', 'unique',
+    'count', 'getIndex', 'getIndices', 'getName', 'getNames', 'hasName',
+    'plot', 'plotMeans', 'plotStatistics', 'similarities', 'statistics',
+    'unique',
     ]
 features_funcs = features_logged + features_notLogged
 features_tested = list(map(prefixAdder('Features'), features_funcs))
 
 points_logged = [
     'append', 'calculate', 'copy', 'delete', 'extract', 'fillMatching',
-    'insert', 'mapReduce', 'matching', 'permute', 'replace', 'retain',
-    'setName', 'setNames', 'sort', 'transform', 'combineByExpandingFeatures',
-    'splitByCollapsingFeatures',
+    'insert', 'mapReduce', 'matching', 'permute', 'repeat', 'replace',
+    'retain', 'setName', 'setNames', 'sort', 'transform',
+    'combineByExpandingFeatures', 'splitByCollapsingFeatures',
     ]
 points_notLogged = [
-    'count', 'repeat', 'getIndex', 'getIndices', 'getName', 'getNames',
-    'hasName', 'plot', 'plotMeans', 'plotStatistics', 'similarities',
-    'statistics', 'unique',
+    'count', 'getIndex', 'getIndices', 'getName', 'getNames', 'hasName',
+    'plot', 'plotMeans', 'plotStatistics', 'similarities', 'statistics',
+    'unique',
     ]
 points_funcs = points_logged + points_notLogged
 points_tested = list(map(prefixAdder('Points'), points_funcs))

--- a/tests/manualScripts/plottingExample.py
+++ b/tests/manualScripts/plottingExample.py
@@ -151,7 +151,7 @@ if __name__ == "__main__":
 
     checkGradObj = checkObj.points.calculate(addGradient)
     checkGradObj = checkGradObj.features.calculate(addGradient)
-    checkGradObj.name = "Checkerboard with linear gradient"
+    checkGradObj.name = "Checkerboard_with_linear_gradient"
 
     # plot
     #heatMap: checkboard pattern, even columns 0s, odds = 1's, offset every other point
@@ -260,7 +260,7 @@ if __name__ == "__main__":
         fnames = ['Trial #' + str(i) for i in range(1, 11)]
         plotObj = nimble.data(d, pointNames=pnames,
                               featureNames=fnames)
-        plotObj.name = 'Patient Trials'
+        plotObj.name = 'Patient_Trials'
 
         pathBar = getOutPath(outDir, "pointMinMax")
         # stat function returning multiple values

--- a/tests/testData.py
+++ b/tests/testData.py
@@ -1122,10 +1122,6 @@ def test_data_objName_and_path_CSV():
             relExp = os.path.relpath(ret.absolutePath)
             assert ret.relativePath == relExp
 
-            retDefName = nimble.data(source=tmpCSV.name)
-            tokens = tmpCSV.name.rsplit(os.path.sep)
-            assert retDefName.name == tokens[len(tokens) - 1]
-
 
 def test_data_objName_and_path_MTXArr():
     for t in returnTypes:
@@ -1147,10 +1143,6 @@ def test_data_objName_and_path_MTXArr():
             relExp = os.path.relpath(ret.absolutePath)
             assert ret.relativePath == relExp
 
-            retDefName = nimble.data(source=tmpMTXArr.name)
-            tokens = tmpMTXArr.name.rsplit(os.path.sep)
-            assert retDefName.name == tokens[len(tokens) - 1]
-
 
 def test_data_objName_and_path_MTXCoo():
     for t in returnTypes:
@@ -1171,10 +1163,6 @@ def test_data_objName_and_path_MTXCoo():
 
             relExp = os.path.relpath(ret.absolutePath)
             assert ret.relativePath == relExp
-
-            retDefName = nimble.data(source=tmpMTXCoo.name)
-            tokens = tmpMTXCoo.name.rsplit(os.path.sep)
-            assert retDefName.name == tokens[len(tokens) - 1]
 
 
 ###################################
@@ -1982,7 +1970,6 @@ def test_data_GZIP_passedOpen():
             tempGZIP.seek(0)
             fromGZIP = nimble.data(tempGZIP, returnType=t)
             assert fromList == fromGZIP
-            assert fromGZIP.name == os.path.basename(tempGZIP.name)
             assert fromGZIP.path  == tempGZIP.name
             assert fromGZIP.absolutePath == tempGZIP.name
             assert fromGZIP.relativePath == os.path.relpath(tempGZIP.name)
@@ -1996,7 +1983,6 @@ def test_data_ZIP_passedOpen():
             tempZIP.seek(0)
             fromZIP = nimble.data(tempZIP, returnType=t)
             assert fromList == fromZIP
-            assert fromZIP.name == os.path.basename(tempZIP.name)
             assert fromZIP.path  == tempZIP.name
             assert fromZIP.absolutePath == tempZIP.name
             assert fromZIP.relativePath == os.path.relpath(tempZIP.name)
@@ -2013,7 +1999,6 @@ def test_data_TAR_passedOpen():
             tempTAR.seek(0)
             fromZIP = nimble.data(tempTAR, returnType=t)
             assert fromList == fromZIP
-            assert fromZIP.name == os.path.basename(tempTAR.name)
             assert fromZIP.path  == tempTAR.name
             assert fromZIP.absolutePath == tempTAR.name
             assert fromZIP.relativePath == os.path.relpath(tempTAR.name)


### PR DESCRIPTION
Update logs to use the object `name` attribute when available, otherwise use a unique `logID` value. The current log uses returnType, which is often the same for most objects in a session. This makes it very difficult to identify which object the logged action is actually occurring on. To further identify objects in the log, any actions that return a `Base` or `TrainedLearner` object will record the name and/or id of that object(s) in the log as well. This can help determine the source of the object, though many operations that are not logged also create new objects.

The format to log an action was returnType[.points/features].method, so whitespace is no longer permitted in names to maintain this "code-like" appearance. With this change, the `name` attribute for `Base` is no longer set to a filename for files because these may contain whitespace. This should not be problematic as the `path` should provide sufficient information.

The `logID` attribute for `Base` and `TrainedLearner` objects are generated when the object is logged using the `LogID` descriptor. When a logging entry is created,  a new `logID` will be generated for the object if one doesn't already exist. This improves on the former `_id` attribute, as it only applies to the logged objects so the `logID` values will be sequential within the log. `logID` is also a public attribute as users may wish to search the log by this value.  If a name is present for an object, the `logID` will not be displayed, however it is always stored in the log. This allows searches for the `logID` to find the associated named object and provides a unique identifier if duplicate names are used.

The `useLog` parameter was changed to a keyword-only parameter to support the `prepLog` decorator. This ensures that the decorator does not need to be concerned that useLog was passed as a positional argument. This should be a beneficial change overall as well as it makes changing the `useLog` value a more explicit decision, preventing it from being accidentally set by a misplaced argument (this was occurring in one of the tests).  This change also removed logging from backend methods in `axis.py` and applies it only to the user facing methods. Annoyingly, pylint does not identify that the useLog parameter is being consumed by the `prepLog` decorator, so methods that use this decorator must explicitly disable the warning. `useLog` was always placed on it's own line to ensure that disabling the warning only applied to the `useLog` parameter and the warning would still trigger for the other parameters.
