### PR TITLE
Allow feature report to continue if statistic fails

### DIFF
--- a/nimble/core/data/features.py
+++ b/nimble/core/data/features.py
@@ -2358,13 +2358,16 @@ class Features(ABC):
             row = [i]
             quartileCalcs = None
             for stat in stats:
-                if stat in quartiles:
-                    if quartileCalcs is None:
-                        quartileCalcs = nimble.calculate.quartiles(ft)
-                    row.append(quartileCalcs[quartiles[stat]])
-                else:
-                    func = getattr(nimble.calculate, stat)
-                    row.append(func(ft))
+                try:
+                    if stat in quartiles:
+                        if quartileCalcs is None:
+                            quartileCalcs = nimble.calculate.quartiles(ft)
+                        row.append(quartileCalcs[quartiles[stat]])
+                    else:
+                        func = getattr(nimble.calculate, stat)
+                        row.append(func(ft))
+                except ValueError:
+                    row.append(np.nan)
 
             for func in extraStatisticFunctions:
                 row.append(func(ft))

--- a/tests/testData.py
+++ b/tests/testData.py
@@ -851,6 +851,32 @@ def test_data_CSV_emptyFirstValue():
         assert limitCSV.features.getNames() == [None, 'ft1', 'ft2', 'ft3']
         assert not limitCSV.points._namesCreated()
 
+def test_data_CSV_allMissingColumn():
+    with tempfile.NamedTemporaryFile('w+', suffix='.csv') as tmpCSV:
+        tmpCSV.write('ft0,ft1,ft2,ft3\n')
+        tmpCSV.write(',1,a,3.0\n')
+        tmpCSV.write(',4,b,6.0\n')
+        tmpCSV.write(',7,c,9.0\n')
+        tmpCSV.write(',-1,d,-3.0\n')
+        tmpCSV.flush()
+        dfCSVMissing = nimble.data(source=tmpCSV.name)
+        assert dfCSVMissing.getTypeString() == 'DataFrame'
+        dtypes = dfCSVMissing._data.dtypes
+        assert dtypes[0] == np.dtype(float)
+        assert dtypes[1] == np.dtype(int)
+        assert dtypes[2] == np.dtype(object)
+        assert dtypes[3] == np.dtype(float)
+
+    with tempfile.NamedTemporaryFile('w+', suffix='.csv') as tmpCSV:
+        tmpCSV.write('ft0,ft1,ft2,ft3\n')
+        tmpCSV.write('1.,2.,,3.0\n')
+        tmpCSV.write('4.,5.,,6.0\n')
+        tmpCSV.write('7.,8.,,9.0\n')
+        tmpCSV.write('-1.,-2.,,-3.0\n')
+        tmpCSV.flush()
+        mtxCSVMissing = nimble.data(source=tmpCSV.name)
+        assert mtxCSVMissing.getTypeString() == 'Matrix'
+        assert mtxCSVMissing._data.dtype == np.dtype(np.float)
 
 def test_data_MTXArr_data():
     """ Test of data() loading a mtx (arr format) file, default params """


### PR DESCRIPTION
Belen was encountering an error when trying to use `features.report` on data containing all missing values. This was because the `mode` calculation raised an `IndexError` because the `Counter` contained no values.  So, `features.report` was modified to place a `nan` value in the report for any calculations that fails. However, rather than catch the `IndexError`, `mode` was also improved to raise Nimble's `InvalidArgumentValue` exception with a clearer message any time the `Counter` is empty. One last change to `mode` was for Sparse, while we expect the data to contain zeros, it may not so 0 should only be added to the counter when it does.

After fixing this, another error occurred when trying to find the `minimum` or `maximum` values in Belen's data. This was also due to the features that contained all missing values. Numpy's `nanmin` should be able to handle this case, but it fails if the array has an `object_` dtype. One required fix was to convert `object_` dtypes for `minimum` and `maximum`, but I still wondered why Belen's all missing columns were not initially given a `float` dtype in her `DataFrame`. 

When parsing the csv to create the data object, features that were all missing were being left as empty strings to be replaced with `nan` later. The problem was that this constructed a pandas dataframe with a column of strings which applied an object dtype to that column. Later, when converting all of these values to `nan`, the `object_` dtype persists. Now, these columns are identified as requiring conversion after parsing the csv. This allows pandas dataframes, as well as numpy arrays, to accurately set dtypes when loading from a csv that has columns that are all missing.

I initially thought Belen's error was in `features.statistics` not `features.report`, and saw an opportunity to clean up some duplicate code in those tests, so this is also included even though it did not end up relating to the changes in this PR.