### PR TITLE
Limit hyperopt version to avoid numpy compatibility error

### DIFF
--- a/nimble/_dependencies.py
+++ b/nimble/_dependencies.py
@@ -57,7 +57,7 @@ _DEPENDENCIES = [
     Dependency('h5py', 'h5py>=2.10', 'operation', 'Loading hdf5 files'),
     Dependency('dateutil', 'python-dateutil>=2.6', 'operation',
                'Parsing strings to datetime objects'),
-    Dependency('hyperopt', 'hyperopt>=0.2', 'operation',
+    Dependency('hyperopt', 'hyperopt>=0.2,<=0.2.5', 'operation',
                'Bayesian approach for hyperparameter tuning'),
     Dependency('sklearn', 'scikit-learn>=0.19', 'interfaces',
                'Machine Learning'),


### PR DESCRIPTION
Avoid attribute error by limiting version to before backward incompatible changes wrt numpy randomness. See:

https://github.com/hyperopt/hyperopt/issues/829
https://github.com/hyperopt/hyperopt-sklearn/issues/179
