### PR TITLE
Support for unsupervised performance functions

### DIFF
--- a/documentation/source/examples/additional_functionality.py
+++ b/documentation/source/examples/additional_functionality.py
@@ -43,6 +43,7 @@ In this example we will learn about:
 import tempfile
 
 import nimble
+from nimble.calculate import fractionCorrect
 
 tempDir = tempfile.TemporaryDirectory('nimble-logs')
 
@@ -310,9 +311,9 @@ rTestY = rTrainY.points.extract(number=500, useLog=False)
 expAcc = rTestY.points.count(lambda pt: pt[0] == pt[1]) / len(rTestY.points)
 print('LeastFeatureMeanDistance test expected accuracy', expAcc)
 
-actAcc = nimble.trainAndTest(LeastFeatureMeanDistance, rTrainX, rTrainY[:, 0],
-                             rTestX, rTestY[:, 0],
-                             nimble.calculate.fractionCorrect, useLog=False)
+actAcc = nimble.trainAndTest(LeastFeatureMeanDistance, fractionCorrect,
+                             rTrainX, rTrainY[:, 0], rTestX, rTestY[:, 0],
+                             useLog=False)
 print('LeastFeatureMeanDistance test actual accuracy', actAcc)
 
 ## Our actual prediction accuracy is very similar to our expected accuracy so
@@ -326,9 +327,8 @@ print('LeastFeatureMeanDistance test actual accuracy', actAcc)
 trainX, trainY, testX, testY = wifi.trainAndTestSets(testFraction=0.3,
                                                      labels='room',
                                                      randomOrder=False)
-performance = nimble.trainAndTest(LeastFeatureMeanDistance,
-                                  trainX, trainY, testX, testY,
-                                  nimble.calculate.fractionCorrect)
+performance = nimble.trainAndTest(LeastFeatureMeanDistance, fractionCorrect,
+                                  trainX, trainY, testX, testY)
 print('LeastFeatureMeanDistance accuracy:', performance)
 
 ## Our simple custom learner worked quite well, predicting the correct room in
@@ -366,9 +366,8 @@ nimble.settings.set('logger', 'enableDeepLogging', 'True')
 ## we will set it to perform 3-fold cross-validation instead of the default
 ## 5-fold. Then, `trainAndTest` will apply the `k` value that performed the
 ## best during validation to the test data.
-performance = nimble.trainAndTest('nimble.KNNClassifier', trainX, trainY,
-                                  testX, testY,
-                                  nimble.calculate.fractionCorrect,
+performance = nimble.trainAndTest('nimble.KNNClassifier', fractionCorrect,
+                                  trainX, trainY, testX, testY,
                                   k=nimble.Tune([3, 5, 7]),
                                   tuning=nimble.Tuning(folds=3))
 

--- a/documentation/source/examples/supervised_learning.py
+++ b/documentation/source/examples/supervised_learning.py
@@ -71,8 +71,8 @@ learners = ['sklearn.LinearRegression', 'sklearn.Ridge', 'sklearn.Lasso',
             'sklearn.KNeighborsRegressor', 'sklearn.GradientBoostingRegressor']
 rootMeanSquareError = nimble.calculate.rootMeanSquareError
 for learner in learners:
-    performance = nimble.trainAndTest(learner, trainX, trainY, testX, testY,
-                                      rootMeanSquareError)
+    performance = nimble.trainAndTest(learner, rootMeanSquareError, trainX,
+                                      trainY, testX, testY)
     print(learner, 'error:', performance)
 
 ## `'sklearn.KNeighborsRegressor'` and `'sklearn.GradientBoostingRegressor'`
@@ -137,7 +137,7 @@ print(gbTL.tuning.bestResult, gbTL.tuning.bestArguments)
 ## as the default value so we already know how it performs on our testing data.
 ## However, `gbTL` found `learning_rate` of 1 outperformed the default, 0.1.
 ## Let's see how it performs on our testing (out-of-sample) data.
-gbPerf = gbTL.test(testX, testY, rootMeanSquareError)
+gbPerf = gbTL.test(rootMeanSquareError, testX, testY) 
 print('sklearn.GradientBoostingRegressor', 'learning_rate=1', 'error', gbPerf)
 
 ## Applying our learner ##

--- a/nimble/core/_learnHelpers.py
+++ b/nimble/core/_learnHelpers.py
@@ -6,6 +6,7 @@ functions are contained in learn.py without the distraction of helpers.
 """
 
 from functools import wraps
+import numbers
 
 import numpy as np
 
@@ -548,21 +549,17 @@ def _validTrainData(trainX, trainY):
                 msg += "number of points as trainX"
                 raise InvalidArgumentValueCombination(msg)
 
-def _validTestData(testX, testY, testRequired):
+def _validTestData(testX, testY):
     # testX is allowed to be None, sometimes it is appropriate to have it be
     # filled using the trainX argument (ie things which transform data, or
     # learn internal structure)
-    if testRequired[0] and testX is None:
-        raise InvalidArgumentType("testX must be provided")
     if testX is not None:
         if not isinstance(testX, Base):
             msg = "testX may only be an object derived from Base"
             raise InvalidArgumentType(msg)
 
-    if testRequired[1] and testY is None:
-        raise InvalidArgumentType("testY must be provided")
     if testY is not None:
-        if not isinstance(testY, (Base, str, int, int)):
+        if not isinstance(testY, (Base, str, numbers.Integral)):
             msg = "testY may only be an object derived from Base, or an ID "
             msg += "of the feature containing labels in testX"
             raise InvalidArgumentType(msg)
@@ -589,9 +586,8 @@ def _validScoreMode(scoreMode):
     accepted value.
     """
     if scoreMode is not None:
-        scoreMode = scoreMode.lower()
-        if scoreMode not in ['label', 'bestscore', 'allscores']:
-            msg = "scoreMode may only be 'label', 'bestScore', or 'allScores'"
+        if scoreMode.lower() not in ['bestscore', 'allscores']:
+            msg = "scoreMode may only be None, 'bestScore', or 'allScores'"
             raise InvalidArgumentValue(msg)
 
 
@@ -620,26 +616,25 @@ def _2dOutputFlagCheck(X, Y, scoreMode, multiClassStrategy):
         needToCheck = False
 
     if needToCheck:
-        if scoreMode is not None and scoreMode != 'label':
+        if scoreMode is not None:
             msg = "When dealing with multi dimensional outputs / predictions, "
-            msg += "the scoreMode flag is required to be set to 'label'"
+            msg += "the scoreMode flag is required to be set to None"
             raise InvalidArgumentValueCombination(msg)
-        if multiClassStrategy is not None and multiClassStrategy != 'default':
+        if multiClassStrategy is not None:
             msg = "When dealing with multi dimensional outputs / predictions, "
             msg += "the multiClassStrategy flag is required to be set to "
-            msg += "'default'"
+            msg += "None"
             raise InvalidArgumentValueCombination(msg)
 
 
 def validateLearningArguments(
-        trainX, trainY=None, testX=None, testXRequired=False, testY=None,
-        testYRequired=False, arguments=None, scoreMode=None,
-        multiClassStrategy=None):
+        trainX, trainY=None, testX=None, testY=None, arguments=None,
+        multiClassStrategy=None, scoreMode=None):
     """
     Argument validation for learning functions.
     """
     _validTrainData(trainX, trainY)
-    _validTestData(testX, testY, [testXRequired, testYRequired])
+    _validTestData(testX, testY)
     _validArguments(arguments)
     _validScoreMode(scoreMode)
     _validMultiClassStrategy(multiClassStrategy)

--- a/nimble/core/interfaces/_interface_helpers.py
+++ b/nimble/core/interfaces/_interface_helpers.py
@@ -616,13 +616,12 @@ def extractConfidenceScores(predictionScores, featureNamesItoN):
 
     return scoreMap
 
-def validateTestingArguments(testX, testY=None, testYRequired=False,
-                             arguments=None, scoreMode=None,
-                             has2dOutput=False):
+def validateTestingArguments(testX, testY=None, arguments=None,
+                             has2dOutput=False, scoreMode=None):
     """
     Argument validation for trained learner methods.
     """
-    _validTestData(testX, testY, [True, testYRequired])
+    _validTestData(testX, testY)
     _validArguments(arguments)
     _validScoreMode(scoreMode)
     _2dOutputFlagCheck(has2dOutput, None, scoreMode, None)

--- a/nimble/core/tune.py
+++ b/nimble/core/tune.py
@@ -188,16 +188,12 @@ class Validator(ABC):
             raise AttributeError("A Validator must have a name attribute")
 
         self.learnerName = learnerName
-        if Y is None:
-            msg = "Validation can only be performed for supervised learning. "
-            msg += "Y data cannot be None"
-            raise InvalidArgumentValue(msg)
 
         if isinstance(Y, (int, str, list)):
             X = X.copy()
             Y = X.features.extract(Y, useLog=False)
 
-        if not len(X.points) == len(Y.points):
+        if Y is not None and not len(X.points) == len(Y.points):
             msg = "X and Y must contain the same number of points"
             raise InvalidArgumentValueCombination(msg)
         self.X = X
@@ -502,8 +498,8 @@ class HoldoutValidator(Validator):
     def _validate(self, arguments):
         startTime = time.process_time()
         performance = nimble.trainAndTest(
-            self.learnerName, self.X, self.Y, self.validateX, self.validateY,
-            self.performanceFunction, arguments=arguments,
+            self.learnerName, self.performanceFunction, self.X, self.Y,
+            self.validateX, self.validateY, arguments=arguments,
             randomSeed=self.randomSeed, useLog=False)
         totalTime = time.process_time() - startTime
 
@@ -612,7 +608,7 @@ class HoldoutData(HoldoutValidator):
             self._lastArguments = arguments
 
         performance = self._trainedLearner.test(
-            self.validateX, self.validateY, self.performanceFunction,
+            self.performanceFunction, self.validateX, self.validateY,
             useLog=False)
 
         return performance

--- a/tests/calculate/binary_test.py
+++ b/tests/calculate/binary_test.py
@@ -99,38 +99,38 @@ def test_binary_metricsAsPerformanceFunction():
     testData = nimble.data(rawTest, useLog=False)
 
     tl = train('nimble.KNNClassifier', trainData, 0, arguments={'k': 1}, useLog=False)
-    score1 = tl.test(testData, 0, truePositive, useLog=False)
+    score1 = tl.test(truePositive, testData, 0, useLog=False)
     assert score1 == 6
     assert truePositive.optimal == 'max'
 
-    score2 = tl.test(testData, 0, falsePositive, useLog=False)
+    score2 = tl.test(falsePositive, testData, 0, useLog=False)
     assert score2 == 8
     assert falsePositive.optimal == 'min'
 
-    score3 = tl.test(testData, 0, trueNegative, useLog=False)
+    score3 = tl.test(trueNegative, testData, 0, useLog=False)
     assert score3 == 2
     assert trueNegative.optimal == 'max'
 
-    score4 = tl.test(testData, 0, falseNegative, useLog=False)
+    score4 = tl.test(falseNegative, testData, 0, useLog=False)
     assert score4 == 4
     assert falseNegative.optimal == 'min'
 
-    score5 = tl.test(testData, 0, recall, useLog=False)
+    score5 = tl.test(recall, testData, 0, useLog=False)
     assert score5 == .6
     assert recall.optimal == 'max'
 
-    score6 = tl.test(testData, 0, precision, useLog=False)
+    score6 = tl.test(precision, testData, 0, useLog=False)
     assert score6 == 6 / 14
     assert precision.optimal == 'max'
 
-    score7 = tl.test(testData, 0, specificity, useLog=False)
+    score7 = tl.test(specificity, testData, 0, useLog=False)
     assert score7 == .2
     assert specificity.optimal == 'max'
 
-    score8 = tl.test(testData, 0, balancedAccuracy, useLog=False)
+    score8 = tl.test(balancedAccuracy, testData, 0, useLog=False)
     assert score8 == .4
     assert balancedAccuracy.optimal == 'max'
 
-    score9 = tl.test(testData, 0, f1Score, useLog=False)
+    score9 = tl.test(f1Score, testData, 0, useLog=False)
     assert score9 == .5
     assert f1Score.optimal == 'max'

--- a/tests/customLearners/custom_learner_test.py
+++ b/tests/customLearners/custom_learner_test.py
@@ -181,7 +181,7 @@ def testCustomLearnerGetScores():
     testObj = nimble.data(tdata)
 
     name = LoveAtFirstSightClassifier
-    preds = nimble.trainAndApply(name, trainX=trainObj, trainY=labelsObj, testX=testObj, scoreMode='label')
+    preds = nimble.trainAndApply(name, trainX=trainObj, trainY=labelsObj, testX=testObj)
     assert len(preds.points) == 3
     assert len(preds.features) == 1
     best = nimble.trainAndApply(name, trainX=trainObj, trainY=labelsObj, testX=testObj, scoreMode='bestScore')

--- a/tests/interfaces/autoimpute_interface_test.py
+++ b/tests/interfaces/autoimpute_interface_test.py
@@ -89,15 +89,15 @@ def test_autoimpute_MiLinearRegression():
         # test data cannot have missing values
         testX.features.fillMatching(fill.mean, match.missing)
 
-        rmse = nimble.trainAndTest('autoimpute.MiLinearRegression', trainX,
-                                   trainY, testX, testY, rootMeanSquareError,
+        rmse = nimble.trainAndTest('autoimpute.MiLinearRegression', rootMeanSquareError,
+                                   trainX, trainY, testX, testY,
                                    mi_kwgs={'n': 1, 'strategy': {'x': 'mean'}})
 
         nimble.fillMatching('autoimpute.SingleImputer', match.missing, trainX,
                             strategy='mean')
 
-        exp = nimble.trainAndTest('skl.LinearRegression', trainX, trainY,
-                                  testX, testY, rootMeanSquareError)
+        exp = nimble.trainAndTest('skl.LinearRegression', rootMeanSquareError,
+                                  trainX, trainY, testX, testY)
 
         np.testing.assert_almost_equal(rmse, exp)
 
@@ -108,15 +108,15 @@ def test_autoimpute_MiLinearRegression_noNames():
         trainX, trainY, testX, testY = data.trainAndTestSets(0.25, labels=0)
         testX.features.fillMatching(fill.mean, match.missing)
 
-        rmse = nimble.trainAndTest('autoimpute.MiLinearRegression', trainX,
-                                   trainY, testX, testY, rootMeanSquareError,
+        rmse = nimble.trainAndTest('autoimpute.MiLinearRegression', rootMeanSquareError,
+                                   trainX, trainY, testX, testY,
                                    mi_kwgs={'n': 1, 'strategy':'mode'})
 
         nimble.fillMatching('autoimpute.SingleImputer', match.missing, trainX,
                             strategy='mode')
 
-        exp = nimble.trainAndTest('skl.LinearRegression', trainX, trainY,
-                                  testX, testY, rootMeanSquareError)
+        exp = nimble.trainAndTest('skl.LinearRegression', rootMeanSquareError,
+                                  trainX, trainY, testX, testY)
 
         np.testing.assert_almost_equal(rmse, exp)
 
@@ -127,8 +127,8 @@ def test_autoimpute_MiLinearRegression_exception_noStrategy():
     trainX, trainY, testX, testY = data.trainAndTestSets(0.25, labels='y')
     testX.features.fillMatching(fill.mean, match.missing)
 
-    nimble.trainAndTest('autoimpute.MiLinearRegression', trainX, trainY,
-                        testX, testY, rootMeanSquareError, mi_kwgs={'n': 1})
+    nimble.trainAndTest('autoimpute.MiLinearRegression', rootMeanSquareError,
+                        trainX, trainY, testX, testY, mi_kwgs={'n': 1})
 
 @autoimputeSkipDec
 def test_autoimpute_MiLogisticRegression():
@@ -137,17 +137,16 @@ def test_autoimpute_MiLogisticRegression():
         trainX, trainY, testX, testY = data.trainAndTestSets(0.25, labels='y')
         # test data cannot have missing values
         testX.features.fillMatching(fill.mean, match.missing)
-        fc = nimble.trainAndTest('autoimpute.MiLogisticRegression', trainX,
-                                 trainY, testX, testY, fractionCorrect,
-                                 model_lib='sklearn',
+        fc = nimble.trainAndTest('autoimpute.MiLogisticRegression', fractionCorrect,
+                                 trainX, trainY, testX, testY, model_lib='sklearn',
                                  mi_kwgs={'n': 1, 'strategy': {'x': 'mean'},
                                           'seed': 0})
 
         nimble.fillMatching('autoimpute.SingleImputer', match.missing, trainX,
                             strategy='mean')
 
-        exp = nimble.trainAndTest('skl.LogisticRegression', trainX, trainY,
-                                  testX, testY, fractionCorrect, randomSeed=0)
+        exp = nimble.trainAndTest('skl.LogisticRegression', fractionCorrect,
+                                  trainX, trainY, testX, testY, randomSeed=0)
 
         np.testing.assert_almost_equal(fc, exp)
 
@@ -158,8 +157,8 @@ def test_autoimpute_MiLogisticRegression_directMultipleImputer():
         trainX, trainY, testX, testY = data.trainAndTestSets(0.25, labels='y')
         # test data cannot have missing values
         testX.features.fillMatching(fill.mean, match.missing)
-        trainArgs = ['autoimpute.MiLogisticRegression', trainX, trainY, testX,
-                     testY, fractionCorrect,]
+        trainArgs = ['autoimpute.MiLogisticRegression', fractionCorrect,
+                     trainX, trainY, testX, testY]
         try:
             fc = nimble.trainAndTest(*trainArgs, model_lib='sklearn',
                                      mi=nimble.Init('MultipleImputer', n=1,
@@ -175,8 +174,8 @@ def test_autoimpute_MiLogisticRegression_directMultipleImputer():
         nimble.fillMatching(imputer, match.missing, trainX,
                             n=1, strategy='interpolate')
 
-        exp = nimble.trainAndTest('skl.LogisticRegression', trainX, trainY,
-                                  testX, testY, fractionCorrect)
+        exp = nimble.trainAndTest('skl.LogisticRegression', fractionCorrect,
+                                  trainX, trainY, testX, testY)
 
         np.testing.assert_almost_equal(fc, exp)
 
@@ -187,16 +186,15 @@ def test_autoimpute_MiLogisticRegression_noNames():
         trainX, trainY, testX, testY = data.trainAndTestSets(0.25, labels=0)
 
         testX.features.fillMatching(fill.mean, match.missing)
-        fc = nimble.trainAndTest('autoimpute.MiLogisticRegression', trainX,
-                                 trainY, testX, testY, fractionCorrect,
-                                 model_lib='sklearn',
+        fc = nimble.trainAndTest('autoimpute.MiLogisticRegression', fractionCorrect,
+                                 trainX, trainY, testX, testY, model_lib='sklearn',
                                  mi_kwgs={'n': 1, 'strategy': 'median'})
 
         nimble.fillMatching('autoimpute.SingleImputer', match.missing, trainX,
                             strategy='median')
 
-        exp = nimble.trainAndTest('skl.LogisticRegression', trainX, trainY,
-                                  testX, testY, fractionCorrect)
+        exp = nimble.trainAndTest('skl.LogisticRegression', fractionCorrect,
+                                  trainX, trainY, testX, testY)
 
         np.testing.assert_almost_equal(fc, exp)
 
@@ -206,8 +204,8 @@ def test_autoimpute_MiLogisticRegression_exception_noStrategy():
     data = getDataWithMissing('Matrix', yBinary=True)
     trainX, trainY, testX, testY = data.trainAndTestSets(0.25, labels='y')
     testX.features.fillMatching(fill.mean, match.missing)
-    nimble.trainAndTest('autoimpute.MiLogisticRegression', trainX, trainY,
-                        testX, testY, fractionCorrect)
+    nimble.trainAndTest('autoimpute.MiLogisticRegression', fractionCorrect,
+                        trainX, trainY, testX, testY)
 
 @autoimputeSkipDec
 @raises(InvalidArgumentValue)
@@ -216,6 +214,6 @@ def test_autoimpute_MiLogisticRegression_exception_directMultipleImputerNoStrate
     trainX, trainY, testX, testY = data.trainAndTestSets(0.25, labels='y')
 
     testX.features.fillMatching(fill.mean, match.missing)
-    nimble.trainAndTest('autoimpute.MiLogisticRegression', trainX, trainY,
-                        testX, testY, fractionCorrect,
+    nimble.trainAndTest('autoimpute.MiLogisticRegression', fractionCorrect,
+                        trainX, trainY, testX, testY,
                         mi=nimble.Init('MultipleImputer', n=1))

--- a/tests/interfaces/keras_interface_test.py
+++ b/tests/interfaces/keras_interface_test.py
@@ -87,11 +87,12 @@ def testKerasAPI(optimizer):
                              metrics=['accuracy'], epochs=20, batch_size=128)
 
     #########test trainAndTest
-    x = nimble.trainAndTest('keras.Sequential', trainX=x_train, testX=x_train, trainY=y_train,
-                            testY=y_train, optimizer=optimizer, layers=layers,
-                            loss='binary_crossentropy', metrics=['accuracy'], epochs=20,
-                            batch_size=128,
-                            performanceFunction=nimble.calculate.loss.rootMeanSquareError)
+    RMSE = nimble.calculate.loss.rootMeanSquareError
+    x = nimble.trainAndTest('keras.Sequential', RMSE, trainX=x_train,
+                            testX=x_train, trainY=y_train, testY=y_train,
+                            optimizer=optimizer, layers=layers,
+                            loss='binary_crossentropy', metrics=['accuracy'],
+                            epochs=20, batch_size=128)
 
     #####test fit with Sequential object
     try:

--- a/tests/interfaces/scikit_learn_interface_test.py
+++ b/tests/interfaces/scikit_learn_interface_test.py
@@ -69,8 +69,8 @@ def testSciKitLearnHandmadeRegression():
     data2 = [[0, 1]]
     testObj = nimble.data(data2, useLog=False)
 
-    ret = nimble.trainAndApply(toCall("LinearRegression"), trainingObj, trainY="Y", testX=testObj,
-                            output=None, arguments={})
+    ret = nimble.trainAndApply(toCall("LinearRegression"), trainingObj,
+                               trainY="Y", testX=testObj, arguments={})
 
     assert ret is not None
 
@@ -112,8 +112,8 @@ def testSciKitLearnHandmadeClustering():
     data2 = [[1, 0], [1, 1], [5, 1], [3, 4]]
     testObj = nimble.data(data2, useLog=False)
 
-    ret = nimble.trainAndApply(toCall("KMeans"), trainingObj, testX=testObj, output=None,
-                            arguments={'n_clusters': 3})
+    ret = nimble.trainAndApply(toCall("KMeans"), trainingObj, testX=testObj,
+                               arguments={'n_clusters': 3})
 
     # clustering returns a row vector of indices, referring to the cluster centers,
     # we don't care about the exact numbers, this verifies that the appropriate
@@ -157,7 +157,7 @@ def testSciKitLearnScoreMode():
     data2 = [[2, 3], [-200, 0]]
     testObj = nimble.data(data2, useLog=False)
 
-    # default scoreMode is 'label'
+    # default scoredMode is None
     ret = nimble.trainAndApply(toCall("SVC"), trainingObj, trainY="Y", testX=testObj, arguments={})
     assert len(ret.points) == 2
     assert len(ret.features) == 1
@@ -186,7 +186,7 @@ def testSciKitLearnScoreModeBinary():
     data2 = [[2, 1], [25, 0]]
     testObj = nimble.data(data2, useLog=False)
 
-    # default scoreMode is 'label'
+    # default scoredMode is None
     ret = nimble.trainAndApply(toCall("SVC"), trainingObj, trainY="Y", testX=testObj, arguments={})
     assert len(ret.points) == 2
     assert len(ret.features) == 1

--- a/tests/interfaces/universal_integration_test.py
+++ b/tests/interfaces/universal_integration_test.py
@@ -138,7 +138,7 @@ def testApplyFeatureNames():
             trainLabels.features.setNames(['label'])
             trainData.features.transform(lambda ft: abs(ft))
             testData.features.transform(lambda ft: abs(ft))
-            for mode in ['label', 'allScores', 'bestScore']:
+            for mode in [None, 'allScores', 'bestScore']:
                 strResult = None
                 try:
                     result = nimble.trainAndApply(interfaceName + '.' + learner,
@@ -152,7 +152,7 @@ def testApplyFeatureNames():
                             testData, scoreMode=mode)
                 except InvalidArgumentValue:
                     # try multioutput learner; only label mode is allowed
-                    if mode != 'label':
+                    if mode is not None:
                         continue
                     multiLabels = trainLabels.copy()
                     labels2 = trainLabels.copy()
@@ -166,7 +166,7 @@ def testApplyFeatureNames():
                         continue # incompatible data for this operation
                 except Exception:
                     continue
-                if mode == 'label':
+                if mode is None:
                     assert result.features.getName(0) == 'label'
                 elif mode == 'bestScore':
                     assert result.features.getNames() == ['label', 'bestScore']

--- a/tests/interfaces/universal_test.py
+++ b/tests/interfaces/universal_test.py
@@ -5,6 +5,7 @@ Unit tests for the universal interface object.
 import warnings
 
 import nimble
+from nimble.calculate import performanceFunction
 from nimble.exceptions import InvalidArgumentValue
 from nimble.exceptions import InvalidArgumentValueCombination
 from nimble.exceptions import PackageException
@@ -385,6 +386,7 @@ def test_warningscapture_TL_test():
     cData = generateClassificationData(2, 10, 5)
     ((trainX, trainY), (testX, testY)) = cData
 
+    @performanceFunction('max', requires1D=False, sameFtCount=False)
     def metric(x, y):
         return 0
 
@@ -393,7 +395,7 @@ def test_warningscapture_TL_test():
 
     @oneLogEntryExpected
     def wrapped(arg):
-        arg.test(testX, testY, metric)
+        arg.test(metric, testX, testY)
 
     backend_warningscapture(wrapped, prep)
 
@@ -483,10 +485,11 @@ def test_warningscapture_TL_exceptions_featureMismatch():
         backend_warningscapture(wrapped, prep)
 
     with raises(InvalidArgumentValueCombination):
+        @performanceFunction('max')
         def metric(x, y):
             pass
         def wrapped(tl):
-            tl.test(testX, testY, metric)
+            tl.test(metric, testX, testY)
         backend_warningscapture(wrapped, prep)
 
     with raises(InvalidArgumentValueCombination):

--- a/tests/logger/testLoggingFlags.py
+++ b/tests/logger/testLoggingFlags.py
@@ -141,16 +141,15 @@ def test_trainAndApply():
 def test_trainAndTest():
     def wrapped(trainX, trainY, testX, testY, useLog):
         return nimble.trainAndTest(
-            learnerName, trainX, trainY, testX, testY,
-            performanceFunction=fractionIncorrect, useLog=useLog)
+            learnerName, fractionIncorrect, trainX, trainY, testX, testY,
+            useLog=useLog)
 
     backend(wrapped, runAndCheck)
 
 def test_trainAndTestOnTrainingData_trainError():
     def wrapped(trainX, trainY, testX, testY, useLog):
         return nimble.trainAndTestOnTrainingData(
-            learnerName, trainX, trainY, performanceFunction=fractionIncorrect,
-            useLog=useLog)
+            learnerName, fractionIncorrect, trainX, trainY, useLog=useLog)
 
     backend(wrapped, runAndCheck)
 
@@ -179,8 +178,7 @@ def test_TrainedLearner_test():
     tl = nimble.train(learnerName, trainX, trainY, useLog=False)
 
     def wrapped(trainX, trainY, testX, testY, useLog):
-        return tl.test(testX, testY, performanceFunction=fractionIncorrect,
-                       useLog=useLog)
+        return tl.test(fractionIncorrect, testX, testY, useLog=useLog)
 
     backend(wrapped, runAndCheck)
 
@@ -256,7 +254,7 @@ def test_Deep_train():
     def wrapped(trainX, trainY, testX, testY, useLog):
         k = nimble.Tune([2, 3])  # trigger hyperparameter tuning
         return nimble.train(
-            learnerName, trainX, trainY, performanceFunction=fractionIncorrect,
+            learnerName, trainX, trainY, tuning=fractionIncorrect,
             useLog=useLog, k=k)
     wrapped.__name__ = 'train'
     backendDeep(wrapped, runAndCheck)
@@ -265,8 +263,8 @@ def test_Deep_trainAndApply():
     def wrapped(trainX, trainY, testX, testY, useLog):
         k = nimble.Tune([2, 3])  # trigger hyperparameter tuning
         return nimble.trainAndApply(
-            learnerName, trainX, trainY, testX,
-            performanceFunction=fractionIncorrect, useLog=useLog, k=k)
+            learnerName, trainX, trainY, testX, tuning=fractionIncorrect,
+            useLog=useLog, k=k)
     wrapped.__name__ = 'trainAndApply'
     backendDeep(wrapped, runAndCheck)
 
@@ -274,16 +272,16 @@ def test_Deep_trainAndTest():
     def wrapped(trainX, trainY, testX, testY, useLog):
         k = nimble.Tune([2, 3])  # trigger hyperparameter tuning
         return nimble.trainAndTest(
-            learnerName, trainX, trainY, testX, testY,
-            performanceFunction=fractionIncorrect, useLog=useLog, k=k)
+            learnerName, fractionIncorrect, trainX, trainY, testX, testY,
+            useLog=useLog, k=k)
     wrapped.__name__ = 'trainAndTest'
     backendDeep(wrapped, runAndCheck)
 
 def test_Deep_trainAndTestOnTrainingData_CVError():
     def wrapped(trainX, trainY, testX, testY, useLog):
         return nimble.trainAndTestOnTrainingData(
-            learnerName, trainX, trainY, performanceFunction=fractionIncorrect,
-            crossValidationError=True, useLog=useLog)
+            learnerName, fractionIncorrect, trainX, trainY,
+            crossValidationFolds=5, useLog=useLog)
     wrapped.__name__ = 'trainAndTestOnTrainingData'
     backendDeep(wrapped, runAndCheck)
 

--- a/tests/logger/testLoggingIO.py
+++ b/tests/logger/testLoggingIO.py
@@ -66,8 +66,8 @@ def prepopulatedLogSafetyWrapper(testFunc):
             testYObj = testObj.features.extract(3)
             # run and crossVal
             results = nimble.trainAndTest(
-                'nimble.KNNClassifier', trainX=trainObj, trainY=trainYObj,
-                testX=testObj, testY=testYObj, performanceFunction=RMSE,
+                'nimble.KNNClassifier', RMSE, trainX=trainObj,
+                trainY=trainYObj, testX=testObj, testY=testYObj,
                 arguments={"k": nimble.Tune([3, 5])})
         # edit log sessionNumbers and timestamps
         location = nimble.settings.get("logger", "location")
@@ -277,9 +277,8 @@ def testRunTypeFunctionsUseLog():
     assert re.search(randomSeedPattern, logInfo)
 
     # trainAndTest
-    performance = nimble.trainAndTest("sciKitLearn.SVC", trainXObj, trainYObj,
-                                   testXObj, testYObj,
-                                   performanceFunction=RMSE)
+    performance = nimble.trainAndTest(
+        "sciKitLearn.SVC", RMSE, trainXObj, trainYObj, testXObj, testYObj)
     logInfo = getLastLogData()
     assert "'function': 'trainAndTest'" in logInfo
     # ensure that metrics is storing performanceFunction and result
@@ -297,7 +296,7 @@ def testRunTypeFunctionsUseLog():
 
     # trainAndTestOnTrainingData
     results = nimble.trainAndTestOnTrainingData(
-        "sciKitLearn.SVC", trainXObj, trainYObj, performanceFunction=RMSE)
+        "sciKitLearn.SVC", RMSE, trainXObj, trainYObj)
     logInfo = getLastLogData()
     assert "'function': 'trainAndTestOnTrainingData'" in logInfo
     # ensure that metrics is storing performanceFunction and result
@@ -315,9 +314,8 @@ def testRunTypeFunctionsUseLog():
     logInfo = getLastLogData()
     assert "'randomSeed': 123" in logInfo
 
-    res = nimble.trainAndTest("sciKitLearn.SVC", trainXObj, trainYObj,
-                              testXObj, testYObj, performanceFunction=RMSE,
-                              randomSeed=123)
+    res = nimble.trainAndTest("sciKitLearn.SVC", RMSE, trainXObj, trainYObj,
+                              testXObj, testYObj, randomSeed=123)
     logInfo = getLastLogData()
     assert "'randomSeed': 123" in logInfo
 
@@ -329,8 +327,7 @@ def testRunTypeFunctionsUseLog():
     assert "'randomSeed': 123" in logInfo
 
     results = nimble.trainAndTestOnTrainingData(
-        "sciKitLearn.SVC", trainXObj, trainYObj,  performanceFunction=RMSE,
-        randomSeed=123)
+        "sciKitLearn.SVC", RMSE, trainXObj, trainYObj, randomSeed=123)
     logInfo = getLastLogData()
     assert "'randomSeed': 123" in logInfo
 
@@ -343,7 +340,7 @@ def testRunTypeFunctionsUseLog():
     assert re.search(randomSeedPattern, logInfo) is None
 
     # TrainedLearner.test
-    performance = tl.test(testXObj, testYObj, performanceFunction=RMSE)
+    performance = tl.test(RMSE, testXObj, testYObj)
     logInfo = getLastLogData()
     assert f"'function': '{tl.logID}.test'" in logInfo
     # ensure that metrics is storing performanceFunction and result

--- a/tests/manualScripts/fullPipeLineExample.py
+++ b/tests/manualScripts/fullPipeLineExample.py
@@ -24,14 +24,13 @@ if __name__ == "__main__":
     testObj = nimble.data(source=data2, featureNames=variables)
     tesObjNoY = testObj.features.copy([0,1,2])
 
-    results = trainAndTest('sciKitLearn.SVC', trainX=trainObj, trainY=3,
-                            testX=testObj, testY=3, performanceFunction=fractionIncorrect)
+    results = trainAndTest('sciKitLearn.SVC', fractionIncorrect, 
+                           trainX=trainObj, trainY=3, testX=testObj, testY=3)
     print('Standard trainAndTest call, fractionIncorrect: ' + str(results))
     print("")
 
     resultsLabelsOvO = trainAndApply('sciKitLearn.SVC', trainX=trainObj, trainY=3,
-                             testX=tesObjNoY, scoreMode='label',
-                             multiClassStrategy="OneVsOne")
+                             testX=tesObjNoY, multiClassStrategy="OneVsOne")
     print('One vs One predictions (aka labels format):')
     print(resultsLabelsOvO)
 
@@ -48,8 +47,7 @@ if __name__ == "__main__":
     print(resultsAllScoresOvO)
 
     resultsLabelsOvA = trainAndApply('sciKitLearn.SVC', trainX=trainObj, trainY=3,
-                             testX=tesObjNoY, scoreMode='label',
-                             multiClassStrategy="OneVsAll")
+                             testX=tesObjNoY, multiClassStrategy="OneVsAll")
     print('One vs All predictions (aka labels format):')
     print(resultsLabelsOvA)
 

--- a/tests/manualScripts/ridgeRegressionCustom.py
+++ b/tests/manualScripts/ridgeRegressionCustom.py
@@ -37,8 +37,7 @@ if __name__ == "__main__":
 
     # Using cross validation to explicitly determine a winning argument set
     results = nimble.train("nimble.RidgeRegression", trainX, trainY,
-                           performanceFunction=RMSE,
-                           lamb=nimble.Tune([0, .5, 1]))
+                           tuning=RMSE, lamb=nimble.Tune([0, .5, 1]))
     bestArguments = results.tuning.bestArguments
     bestScore = results.tuning.bestResult
 
@@ -49,5 +48,5 @@ if __name__ == "__main__":
     # Also: arguments to the learner are given in the python **kwargs style, not as
     # an explicit dict like  seen above.
     # Using lamb = 1 in this case so that there actually are errors
-    error = nimble.trainAndTest("nimble.RidgeRegression", trainX, trainY, testX, testY, RMSE, lamb=1)
+    error = nimble.trainAndTest("nimble.RidgeRegression", RMSE, trainX, trainY, testX, testY, lamb=1)
     print("rootMeanSquareError of predictions with lamb=1: " + str(error))

--- a/tests/testLearnDataIntegrity.py
+++ b/tests/testLearnDataIntegrity.py
@@ -8,6 +8,7 @@ import pytest
 
 import nimble
 from nimble.exceptions import InvalidArgumentValue
+from nimble.calculate import fractionIncorrect
 from nimble.random import pythonRandom
 from tests.helpers import assertCalled
 from tests.helpers import generateClassificationData
@@ -79,26 +80,24 @@ def wrappedTrainAndApplyOvA(learnerName, trainX, trainY, testX, testY):
 
 def wrappedTrainAndTest(learnerName, trainX, trainY, testX, testY):
     # our performance function doesn't actually matter, we're just checking the data
-    return nimble.trainAndTest(learnerName, trainX, trainY, testX, testY,
-                               performanceFunction=nimble.calculate.fractionIncorrect)
+    return nimble.trainAndTest(learnerName, fractionIncorrect, trainX, trainY,
+                               testX, testY)
 
 
 def wrappedTLTest(learnerName, trainX, trainY, testX, testY):
     # our performance function doesn't actually matter, we're just checking the data
     tl = nimble.train(learnerName, trainX, trainY)
-    return tl.test(testX, testY, performanceFunction=nimble.calculate.fractionIncorrect)
+    return tl.test(fractionIncorrect, testX, testY)
 
 
 def wrappedTrainAndTestOvO(learnerName, trainX, trainY, testX, testY):
-    return nimble.trainAndTest(learnerName, trainX, trainY, testX, testY,
-                               performanceFunction=nimble.calculate.fractionIncorrect,
-                               multiClassStrategy='OneVsOne')
+    return nimble.trainAndTest(learnerName, fractionIncorrect, trainX, trainY,
+                               testX, testY, multiClassStrategy='OneVsOne')
 
 
 def wrappedTrainAndTestOvA(learnerName, trainX, trainY, testX, testY):
-    return nimble.trainAndTest(learnerName, trainX, trainY, testX, testY,
-                               performanceFunction=nimble.calculate.fractionIncorrect,
-                               multiClassStrategy='OneVsAll')
+    return nimble.trainAndTest(learnerName, fractionIncorrect, trainX, trainY,
+                               testX, testY, multiClassStrategy='OneVsAll')
 
 
 def setupAndCallIncrementalTrain(learnerName, trainX, trainY, testX, testY):
@@ -287,9 +286,8 @@ def testArgumentIntegrityTrainAndTest():
     arguments = {'k': 1}
     train = nimble.data([[0, 0, 0], [0, 1, 1], [1, 0, 2], [1, 1, 3]])
     test = nimble.data([[0, 1, 1], [1, 0, 2]])
-    perf = nimble.trainAndTest('nimble.KNNClassifier', train, 2, test, 2,
-                               performanceFunction=nimble.calculate.fractionIncorrect,
-                               arguments=arguments)
+    perf = nimble.trainAndTest('nimble.KNNClassifier', fractionIncorrect,
+                               train, 2, test, 2, arguments=arguments)
 
 def testArgumentIntegrityTrainAndTestOnTrainingData():
     arguments = {'k': 1}
@@ -297,14 +295,13 @@ def testArgumentIntegrityTrainAndTestOnTrainingData():
     mergeArgumentsCalled = assertCalled(nimble.core.learn, 'mergeArguments')
     with mergeArgumentsCalled:
         perf = nimble.trainAndTestOnTrainingData(
-            'nimble.KNNClassifier', train, 2, arguments=arguments,
-            performanceFunction=nimble.calculate.fractionIncorrect)
+            'nimble.KNNClassifier', fractionIncorrect, train, 2,
+            arguments=arguments)
 
     with mergeArgumentsCalled:
         perf = nimble.trainAndTestOnTrainingData(
-            'nimble.KNNClassifier', train, 2, folds=2, arguments=arguments,
-            crossValidationError=True,
-            performanceFunction=nimble.calculate.fractionIncorrect)
+            'nimble.KNNClassifier', fractionIncorrect, train, 2, folds=2,
+            arguments=arguments, crossValidationError=True)
 
 
 @assertCalled(nimble.core.interfaces.universal_interface, 'mergeArguments')
@@ -322,4 +319,4 @@ def testArgumentIntegrityTLTest():
     train = nimble.data([[0, 0, 0], [0, 1, 1], [1, 0, 2], [1, 1, 3]])
     test = nimble.data([[0, 1, 1], [1, 0, 2]])
     tl = nimble.train('nimble.KNNClassifier', train, 2, arguments=arguments)
-    perf = tl.test(test, 2, performanceFunction=nimble.calculate.fractionIncorrect)
+    perf = tl.test(fractionIncorrect, test, 2)

--- a/tests/test_train_apply_test_frontends.py
+++ b/tests/test_train_apply_test_frontends.py
@@ -69,17 +69,17 @@ def test_trainAndTest_dataInputs():
 
     learner = 'nimble.KNNClassifier'
     # Expected outcomes
-    exp = nimble.trainAndTest(learner, trainObjData, trainObjLabels, testObjData, testObjLabels, fractionIncorrect)
+    exp = nimble.trainAndTest(learner, fractionIncorrect, trainObjData, trainObjLabels, testObjData, testObjLabels)
     # trainX and testX contain labels
-    out1 = nimble.trainAndTest(learner, trainObj, 3, testObj, 3, fractionIncorrect)
-    out2 = nimble.trainAndTest(learner, trainObj, 'label', testObj, 'label', fractionIncorrect)
+    out1 = nimble.trainAndTest(learner, fractionIncorrect, trainObj, 3, testObj, 3)
+    out2 = nimble.trainAndTest(learner, fractionIncorrect, trainObj, 'label', testObj, 'label')
     assert out1 == exp
     assert out2 == exp
     # trainX contains labels
-    out3 = nimble.trainAndTest(learner, trainObj, 3, testObjData, testObjLabels, fractionIncorrect)
+    out3 = nimble.trainAndTest(learner, fractionIncorrect, trainObj, 3, testObjData, testObjLabels)
     assert out3 == exp
     # testX contains labels
-    out4 = nimble.trainAndTest(learner, trainObjData, trainObjLabels, testObj, 3, fractionIncorrect)
+    out4 = nimble.trainAndTest(learner, fractionIncorrect, trainObjData, trainObjLabels, testObj, 3)
     assert out4 == exp
 
 def test_TrainedLearnerTest_dataInputs():
@@ -99,15 +99,15 @@ def test_TrainedLearnerTest_dataInputs():
     learner = 'nimble.KNNClassifier'
     tl = nimble.train(learner, trainObjData, trainObjLabels)
     # Expected outcome
-    exp = nimble.trainAndTest(learner, trainObjData, trainObjLabels, testObjData,
-                              testObjLabels, fractionIncorrect)
+    exp = nimble.trainAndTest(learner, fractionIncorrect, trainObjData,
+                              trainObjLabels, testObjData, testObjLabels)
     # testX contains labels
-    out1 = tl.test(testObj, 3, fractionIncorrect)
-    out2 = tl.test(testObj, 'label', fractionIncorrect)
+    out1 = tl.test(fractionIncorrect, testObj, 3)
+    out2 = tl.test(fractionIncorrect, testObj, 'label')
     assert out1 == exp
     assert out2 == exp
     # testX no labels
-    out3 = tl.test(testObjData, testObjLabels, fractionIncorrect)
+    out3 = tl.test(fractionIncorrect, testObjData, testObjLabels)
     assert out3 == exp
 
 
@@ -182,24 +182,25 @@ def test_trainAndTest():
     testObj1 = nimble.data(source=testData1)
 
     #with default ie no args
-    runError = trainAndTest('nimble.KNNClassifier', trainObj1, 3, testObj1, 3, fractionIncorrect)
+    runError = trainAndTest('nimble.KNNClassifier', fractionIncorrect,
+                            trainObj1, 3, testObj1, 3)
     assert isinstance(runError, float)
 
     #with one argument for the algorithm
-    runError = trainAndTest('nimble.KNNClassifier', trainObj1, 3, testObj1, 3, fractionIncorrect, k=1)
+    runError = trainAndTest('nimble.KNNClassifier', fractionIncorrect, trainObj1, 3, testObj1, 3, k=1)
     assert isinstance(runError, float)
 
     #with multiple values for one argument for the algorithm
-    runError = trainAndTest('nimble.KNNClassifier', trainObj1, 3, testObj1, 3,
-                            fractionIncorrect, k=nimble.Tune([1, 2]),
+    runError = trainAndTest('nimble.KNNClassifier', fractionIncorrect,
+                            trainObj1, 3, testObj1, 3, k=nimble.Tune([1, 2]),
                             tuning=Tuning(folds=3))
     assert isinstance(runError, float)
 
     #with small data set
     data1 = [[1, 0, 0, 1], [0, 1, 0, 2], [0, 0, 1, 3], [1, 0, 0, 1], [0, 1, 0, 2]]
     trainObj1 = nimble.data(source=data1, featureNames=variables)
-    runError = trainAndTest('nimble.KNNClassifier', trainObj1, 3, testObj1, 3,
-                            fractionIncorrect, k=nimble.Tune([1, 2]),
+    runError = trainAndTest('nimble.KNNClassifier', fractionIncorrect,
+                            trainObj1, 3, testObj1, 3, k=nimble.Tune([1, 2]),
                             tuning=Tuning(folds=3))
     assert isinstance(runError, float)
 
@@ -246,39 +247,39 @@ def test_multioutput_learners_callable_from_all():
     ret_TLA_1 = TL1.apply(testX)
 
     # trainAndTest()
-    ret_TT_multi = nimble.trainAndTest(testName, trainX=trainX, trainY=trainY, testX=testX, testY=testY,
-                                    performanceFunction=metric, lamb=1)
-    ret_TT_0 = nimble.trainAndTest(wrappedName, trainX=trainX, trainY=trainY0, testX=testX, testY=testY0,
-                                performanceFunction=metric, lamb=1)
-    ret_TT_1 = nimble.trainAndTest(wrappedName, trainX=trainX, trainY=trainY1, testX=testX, testY=testY1,
-                                performanceFunction=metric, lamb=1)
+    ret_TT_multi = nimble.trainAndTest(testName, metric, trainX=trainX, trainY=trainY, testX=testX, testY=testY,
+                                       lamb=1)
+    ret_TT_0 = nimble.trainAndTest(wrappedName, metric, trainX=trainX, trainY=trainY0, testX=testX, testY=testY0,
+                                   lamb=1)
+    ret_TT_1 = nimble.trainAndTest(wrappedName, metric, trainX=trainX, trainY=trainY1, testX=testX, testY=testY1,
+                                   lamb=1)
 
     # trainAndTestOnTrainingData()
-    ret_TTTD_multi = nimble.trainAndTestOnTrainingData(testName, trainX=trainX, trainY=trainY, performanceFunction=metric,
-                                                    lamb=1)
-    ret_TTTD_0 = nimble.trainAndTestOnTrainingData(wrappedName, trainX=trainX, trainY=trainY0, performanceFunction=metric,
-                                                lamb=1)
-    ret_TTTD_1 = nimble.trainAndTestOnTrainingData(wrappedName, trainX=trainX, trainY=trainY1, performanceFunction=metric,
-                                                lamb=1)
+    ret_TTTD_multi = nimble.trainAndTestOnTrainingData(
+        testName, metric, trainX=trainX, trainY=trainY, lamb=1)
+    ret_TTTD_0 = nimble.trainAndTestOnTrainingData(
+        wrappedName, metric, trainX=trainX, trainY=trainY0, lamb=1)
+    ret_TTTD_1 = nimble.trainAndTestOnTrainingData(
+        wrappedName, metric, trainX=trainX, trainY=trainY1, lamb=1)
 
     # Control randomness for each cross-validation so folds are consistent
     with nimble.random.alternateControl(seed=0):
         ret_TTTD_multi_cv = nimble.trainAndTestOnTrainingData(
-            testName, trainX=trainX, trainY=trainY, performanceFunction=metric,
-            lamb=1, crossValidationError=True)
+            testName, metric, trainX=trainX, trainY=trainY, lamb=1,
+            crossValidationFolds=5)
     with nimble.random.alternateControl(seed=0):
         ret_TTTD_0_cv = nimble.trainAndTestOnTrainingData(
-            wrappedName, trainX=trainX, trainY=trainY0,
-            performanceFunction=metric, lamb=1, crossValidationError=True)
+            wrappedName, metric, trainX=trainX, trainY=trainY0, lamb=1,
+            crossValidationFolds=5)
     with nimble.random.alternateControl(seed=0):
         ret_TTTD_1_cv = nimble.trainAndTestOnTrainingData(
-            testName, trainX=trainX, trainY=trainY1,
-            performanceFunction=metric, lamb=1, crossValidationError=True)
+            testName, metric, trainX=trainX, trainY=trainY1, lamb=1,
+            crossValidationFolds=5)
 
     # tl.test()
-    ret_TLT_multi = TLmulti.test(testX, testY, metric)
-    ret_TLT_0 = TL0.test(testX, testY0, metric)
-    ret_TLT_1 = TL1.test(testX, testY1, metric)
+    ret_TLT_multi = TLmulti.test(metric, testX, testY)
+    ret_TLT_0 = TL0.test(metric, testX, testY0)
+    ret_TLT_1 = TL1.test(metric, testX, testY1)
 
     # confirm consistency
 
@@ -376,46 +377,6 @@ def test_trainAndApply_multiClassStrat_disallowed_multiOutput():
 
 
 @raises(InvalidArgumentValueCombination)
-def test_trainAndTest_scoreMode_disallowed_multioutput():
-    data = [[0, 1, 0], [0, 0, 2], [12, 0, 0], [2, 2, 2], [0, 1, 0], [0, 0, 2], [12, 0, 0], [2, 2, 2], [0, 1, 0],
-            [0, 0, 2], ]
-    trainX = nimble.data(data)
-
-    data = [[10, -10], [2, -2], [1200, -1200], [222, -222], [10, -10], [2, -2], [1200, -1200], [222, -222], [10, -10],
-            [2, -2]]
-    trainY = nimble.data(data)
-
-    data = [[5, 5, 5], [0, 0, 1]]
-    testX = nimble.data(data)
-
-    data = [[555, -555], [1, -1]]
-    testY = nimble.data(data)
-
-    testName = 'nimble.MultiOutputRidgeRegression'
-    metric = nimble.calculate.meanFeaturewiseRootMeanSquareError
-
-    nimble.trainAndTest(testName, trainX=trainX, trainY=trainY, testX=testX, testY=testY, performanceFunction=metric,
-                     scoreMode="allScores", lamb=1)
-
-
-@raises(InvalidArgumentValueCombination)
-def test_trainAndTestOnTrainingData_scoreMode_disallowed_multioutput():
-    data = [[0, 1, 0], [0, 0, 2], [12, 0, 0], [2, 2, 2], [0, 1, 0], [0, 0, 2], [12, 0, 0], [2, 2, 2], [0, 1, 0],
-            [0, 0, 2], ]
-    trainX = nimble.data(data)
-
-    data = [[10, -10], [2, -2], [1200, -1200], [222, -222], [10, -10], [2, -2], [1200, -1200], [222, -222], [10, -10],
-            [2, -2]]
-    trainY = nimble.data(data)
-
-    testName = 'nimble.MultiOutputRidgeRegression'
-    metric = nimble.calculate.meanFeaturewiseRootMeanSquareError
-
-    nimble.trainAndTestOnTrainingData(testName, trainX=trainX, trainY=trainY, performanceFunction=metric,
-                                   scoreMode="allScores", lamb=1)
-
-
-@raises(InvalidArgumentValueCombination)
 def test_trainAndTest_multiclassStrat_disallowed_multioutput():
     data = [[0, 1, 0], [0, 0, 2], [12, 0, 0], [2, 2, 2], [0, 1, 0], [0, 0, 2], [12, 0, 0], [2, 2, 2], [0, 1, 0],
             [0, 0, 2], ]
@@ -434,8 +395,8 @@ def test_trainAndTest_multiclassStrat_disallowed_multioutput():
     testName = 'nimble.MultiOutputRidgeRegression'
     metric = nimble.calculate.meanFeaturewiseRootMeanSquareError
 
-    nimble.trainAndTest(testName, trainX=trainX, trainY=trainY, testX=testX, testY=testY, performanceFunction=metric,
-                     multiClassStrategy="OneVsOne", lamb=1)
+    nimble.trainAndTest(testName, metric, trainX=trainX, trainY=trainY,
+                        testX=testX, testY=testY, multiClassStrategy="OneVsOne", lamb=1)
 
 
 @raises(InvalidArgumentValueCombination)
@@ -451,8 +412,8 @@ def test_trainAndTestOnTrainingData_multiclassStrat_disallowed_multioutput():
     testName = 'nimble.MultiOutputRidgeRegression'
     metric = nimble.calculate.meanFeaturewiseRootMeanSquareError
 
-    nimble.trainAndTestOnTrainingData(testName, trainX=trainX, trainY=trainY, performanceFunction=metric,
-                                   multiClassStrategy="OneVsOne", lamb=1)
+    nimble.trainAndTestOnTrainingData(testName, metric, trainX=trainX,
+                                      trainY=trainY, multiClassStrategy="OneVsOne", lamb=1)
 
 
 def test_trainFunctions_Tune_triggered_errors():
@@ -481,31 +442,28 @@ def test_trainFunctions_Tune_triggered_errors():
     # folds too large
     with raises(InvalidArgumentValueCombination, match="folds"):
         nimble.train(learner, trainObjData, trainObjLabels,
-                     performanceFunction=fractionIncorrect,
                      k=nimble.Tune([1, 3]),
-                     tuning=Tuning(folds=11))
+                     tuning=Tuning(folds=11, performanceFunction=fractionIncorrect))
     with raises(InvalidArgumentValueCombination, match="folds"):
         nimble.trainAndApply(learner, trainObjData, trainObjLabels, testObjData,
                              performanceFunction=fractionIncorrect,
                              k=nimble.Tune([1, 3]),
-                             tuning=Tuning(folds=11))
+                             tuning=Tuning(folds=11, performanceFunction=fractionIncorrect))
     with raises(InvalidArgumentValueCombination, match="folds"):
-        nimble.trainAndTest(learner, trainObjData, trainObjLabels, testObjData,
-                            testObjLabels, performanceFunction=fractionIncorrect,
-                            k=nimble.Tune([1, 3]),
-                            tuning=Tuning(folds=11))
+        nimble.trainAndTest(learner, fractionIncorrect, trainObjData,
+                            trainObjLabels, testObjData, testObjLabels,
+                            k=nimble.Tune([1, 3]), tuning=Tuning(folds=11))
     with raises(InvalidArgumentValueCombination, match="folds"):
         # training error
-        nimble.trainAndTestOnTrainingData(learner, trainObjData, trainObjLabels,
-                                          performanceFunction=fractionIncorrect,
+        nimble.trainAndTestOnTrainingData(learner, fractionIncorrect,
+                                          trainObjData, trainObjLabels,
                                           k=nimble.Tune([1, 3]),
                                           tuning=Tuning(folds=11))
     with raises(InvalidArgumentValueCombination, match="folds"):
         # cross-validation error
-        nimble.trainAndTestOnTrainingData(learner, trainObjData, trainObjLabels,
-                                          performanceFunction=fractionIncorrect,
-                                          crossValidationError=True, folds=11,
-                                          k=5)
+        nimble.trainAndTestOnTrainingData(learner, fractionIncorrect,
+                                          trainObjData, trainObjLabels,
+                                          crossValidationFolds=11, k=5)
 
 def test_frontend_Tune_triggering():
     #with small data set
@@ -519,17 +477,15 @@ def test_frontend_Tune_triggering():
     # confirm that the calls are being made
     with calledTune:
         train('nimble.KNNClassifier', trainX=trainObj, trainY=labelsObj,
-              performanceFunction=fractionIncorrect, k=nimble.Tune([1, 2]))
+              tuning=fractionIncorrect, k=nimble.Tune([1, 2]))
 
     with calledTune:
         trainAndApply('nimble.KNNClassifier', trainX=trainObj, trainY=labelsObj,
-                      performanceFunction=fractionIncorrect, testX=trainObj,
-                      k=nimble.Tune([1, 2]))
+                      testX=trainObj, tuning=fractionIncorrect, k=nimble.Tune([1, 2]))
 
     with calledTune:
-        trainAndTest('nimble.KNNClassifier', trainX=trainObj, trainY=labelsObj,
-                     testX=trainObj, testY=labelsObj,
-                     performanceFunction=fractionIncorrect,
+        trainAndTest('nimble.KNNClassifier', fractionIncorrect, trainX=trainObj,
+                     trainY=labelsObj, testX=trainObj, testY=labelsObj,
                      k=nimble.Tune([1, 2]))
 
 def test_frontend_Tune_triggering_success():
@@ -541,7 +497,7 @@ def test_frontend_Tune_triggering_success():
     labelsObj = nimble.data(source=labels)
 
     tl = train('nimble.KNNClassifier', trainX=trainObj, trainY=labelsObj,
-               performanceFunction=fractionIncorrect, k=nimble.Tune([1, 2]))
+               tuning=fractionIncorrect, k=nimble.Tune([1, 2]))
     assert hasattr(tl, 'apply')
     assert tl.tuning is not None
     assert tl.tuning.bestArguments == {'k': 1} or tl.tuning.bestArguments == {'k': 2}
@@ -549,13 +505,13 @@ def test_frontend_Tune_triggering_success():
     assert tl.tuning.validator.folds == 5
 
     result = trainAndApply('nimble.KNNClassifier', trainX=trainObj, trainY=labelsObj,
-                           testX=trainObj, performanceFunction=fractionIncorrect,
+                           testX=trainObj, tuning=fractionIncorrect,
                            k=nimble.Tune([1, 2]))
     assert isinstance(result, nimble.core.data.Matrix)
 
-    error = trainAndTest('nimble.KNNClassifier', trainX=trainObj, trainY=labelsObj,
-                         testX=trainObj, testY=labelsObj, performanceFunction=fractionIncorrect,
-                         k=nimble.Tune([1, 2]))
+    error = trainAndTest('nimble.KNNClassifier', fractionIncorrect,
+                         trainX=trainObj, trainY=labelsObj, testX=trainObj,
+                         testY=labelsObj, k=nimble.Tune([1, 2]))
     assert isinstance(error, float)
 
 
@@ -604,46 +560,45 @@ def test_train_logCount_noTune():
 @oneLogEntryExpected
 def test_trainAndApply_logCount_noTune():
     def wrapped(learner, trainX, trainY, testX, testY, performanceFunction):
-        return nimble.trainAndApply(learner, trainX, trainY, testX,
-                                    performanceFunction=performanceFunction)
+        return nimble.trainAndApply(learner, trainX, trainY, testX)
     back_logCount(wrapped)
 
 @oneLogEntryExpected
 def test_trainAndTest_logCount_noTune():
     def wrapped(learner, trainX, trainY, testX, testY, performanceFunction):
-        return nimble.trainAndTest(learner, trainX, trainY, testX, testY, performanceFunction)
+        return nimble.trainAndTest(learner, performanceFunction, trainX, trainY, testX, testY)
     back_logCount(wrapped)
 
 @oneLogEntryExpected
 def test_trainAndTestOnTrainingData_logCount_noTune():
     def wrapped(learner, trainX, trainY, testX, testY, performanceFunction):
-        return nimble.trainAndTestOnTrainingData(learner, trainX, trainY, performanceFunction)
+        return nimble.trainAndTestOnTrainingData(learner, performanceFunction, trainX, trainY)
     back_logCount(wrapped)
 
 @logCountAssertionFactory(12)
 def test_train_logCount_withTune_deep():
     def wrapped(learner, trainX, trainY, testX, testY, performanceFunction):
-        return nimble.train(learner, trainX, trainY, performanceFunction=performanceFunction, k=nimble.Tune([1, 2]))
+        return nimble.train(learner, trainX, trainY, tuning=performanceFunction, k=nimble.Tune([1, 2]))
     back_logCount(wrapped)
 
 @logCountAssertionFactory(12)
 def test_trainAndApply_logCount_withTune_deep():
     def wrapped(learner, trainX, trainY, testX, testY, performanceFunction):
         return nimble.trainAndApply(learner, trainX, trainY, testX,
-                                    performanceFunction=performanceFunction,
+                                    tuning=performanceFunction,
                                     k=nimble.Tune([1, 2]))
     back_logCount(wrapped)
 
 @logCountAssertionFactory(12)
 def test_trainAndTest_logCount_withTune_deep():
     def wrapped(learner, trainX, trainY, testX, testY, performanceFunction):
-        return nimble.trainAndTest(learner, trainX, trainY, testX, testY, performanceFunction, k=nimble.Tune([1, 2]))
+        return nimble.trainAndTest(learner, performanceFunction, trainX, trainY, testX, testY, k=nimble.Tune([1, 2]))
     back_logCount(wrapped)
 
 @logCountAssertionFactory(12)
 def test_trainAndTestOnTrainingData_logCount_withTune_deep():
     def wrapped(learner, trainX, trainY, testX, testY, performanceFunction):
-        return nimble.trainAndTestOnTrainingData(learner, trainX, trainY, performanceFunction, k=nimble.Tune([1, 2]))
+        return nimble.trainAndTestOnTrainingData(learner, performanceFunction, trainX, trainY, k=nimble.Tune([1, 2]))
     back_logCount(wrapped)
 
 @logCountAssertionFactory(2)
@@ -651,8 +606,7 @@ def test_train_logCount_withTune_noDeep():
     nimble.settings.set('logger', 'enableDeepLogging', 'False')
     def wrapped(learner, trainX, trainY, testX, testY, performanceFunction):
         return nimble.train(learner, trainX, trainY,
-                            performanceFunction=performanceFunction,
-                            k=nimble.Tune([1, 2]))
+                            tuning=performanceFunction, k=nimble.Tune([1, 2]))
     back_logCount(wrapped)
 
 @logCountAssertionFactory(2)
@@ -660,7 +614,7 @@ def test_trainAndApply_logCount_withTune_noDeep():
     nimble.settings.set('logger', 'enableDeepLogging', 'False')
     def wrapped(learner, trainX, trainY, testX, testY, performanceFunction):
         return nimble.trainAndApply(learner, trainX, trainY, testX,
-                                    performanceFunction=performanceFunction,
+                                    tuning=performanceFunction,
                                     k=nimble.Tune([1, 2]))
     back_logCount(wrapped)
 
@@ -668,14 +622,14 @@ def test_trainAndApply_logCount_withTune_noDeep():
 def test_trainAndTest_logCount_withTune_noDeep():
     nimble.settings.set('logger', 'enableDeepLogging', 'False')
     def wrapped(learner, trainX, trainY, testX, testY, performanceFunction):
-        return nimble.trainAndTest(learner, trainX, trainY, testX, testY, performanceFunction, k=nimble.Tune([1, 2]))
+        return nimble.trainAndTest(learner, performanceFunction, trainX, trainY, testX, testY, k=nimble.Tune([1, 2]))
     back_logCount(wrapped)
 
 @logCountAssertionFactory(2)
 def test_trainAndTestOnTrainingData_logCount_withTune_noDeep():
     nimble.settings.set('logger', 'enableDeepLogging', 'False')
     def wrapped(learner, trainX, trainY, testX, testY, performanceFunction):
-        return nimble.trainAndTestOnTrainingData(learner, trainX, trainY, performanceFunction, k=nimble.Tune([1, 2]))
+        return nimble.trainAndTestOnTrainingData(learner, performanceFunction, trainX, trainY, k=nimble.Tune([1, 2]))
     back_logCount(wrapped)
 
 @assertCalled(nimble.core.interfaces.TrainedLearner, '_validTestData')
@@ -716,8 +670,8 @@ def test_trainAndTest_testXValidation():
     perfFunc = nimble.calculate.fractionIncorrect
     # Expected outcomes
     # trainY is ID, testX does not contain labels; test int
-    out = nimble.trainAndTest(learner, trainObj, trainObjLabels, testObjData,
-                              testObjLabels, perfFunc)
+    out = nimble.trainAndTest(learner, perfFunc, trainObj, trainObjLabels, testObjData,
+                              testObjLabels)
 
 @assertCalled(nimble.core.interfaces.TrainedLearner, '_validTestData')
 def test_TL_apply_testXValidation():
@@ -759,7 +713,7 @@ def test_TL_test_testXValidation():
     # Expected outcomes
     # trainY is ID, testX does not contain labels; test int
     tl = nimble.train(learner, trainObj, trainObjLabels)
-    out = tl.test(testObjData, testObjLabels, perfFunc)
+    out = tl.test(perfFunc, testObjData, testObjLabels)
 
 @assertCalled(nimble.core.interfaces.TrainedLearner, '_validTestData')
 def test_TL_getScores_testXValidation():
@@ -803,10 +757,12 @@ def test_trainAndTestOneVsOne():
 
     metricFunc = fractionIncorrect
 
-    results1 = trainAndTest('nimble.KNNClassifier', trainObj1, trainY=3, testX=testObj1, testY=3,
-                            performanceFunction=metricFunc, multiClassStrategy='OneVsOne')
-    results2 = trainAndTest('nimble.KNNClassifier', trainObj2, trainY=3, testX=testObj2, testY=3,
-                            performanceFunction=metricFunc, multiClassStrategy='OneVsOne')
+    results1 = trainAndTest('nimble.KNNClassifier', metricFunc, trainObj1,
+                            trainY=3, testX=testObj1, testY=3,
+                            multiClassStrategy='OneVsOne')
+    results2 = trainAndTest('nimble.KNNClassifier', metricFunc, trainObj2,
+                            trainY=3, testX=testObj2, testY=3,
+                            multiClassStrategy='OneVsOne')
 
     assert results1 == 0.0
     assert results2 == 0.25
@@ -830,10 +786,12 @@ def test_trainAndTestOneVsAll():
 
     metricFunc = fractionIncorrect
 
-    results1 = trainAndTest('nimble.KNNClassifier', trainObj1, trainY=3, testX=testObj1, testY=3,
-                            performanceFunction=metricFunc, multiClassStrategy='OneVsAll')
-    results2 = trainAndTest('nimble.KNNClassifier', trainObj2, trainY=3, testX=testObj2, testY=3,
-                            performanceFunction=metricFunc, multiClassStrategy='OneVsAll')
+    results1 = trainAndTest('nimble.KNNClassifier', metricFunc, trainObj1,
+                            trainY=3, testX=testObj1, testY=3,
+                            multiClassStrategy='OneVsAll')
+    results2 = trainAndTest('nimble.KNNClassifier', metricFunc, trainObj2,
+                            trainY=3, testX=testObj2, testY=3,
+                            multiClassStrategy='OneVsAll')
 
     assert results1 == 0.0
     assert results2 == 0.25
@@ -850,7 +808,7 @@ def test_trainAndApplyOneVsAll():
     testObj1 = nimble.data(source=testData1)
 
     results1 = trainAndApply('nimble.KNNClassifier', trainObj1, trainY=3,
-                             testX=testObj1, scoreMode='label', multiClassStrategy='OneVsAll')
+                             testX=testObj1, multiClassStrategy='OneVsAll')
     results2 = trainAndApply('nimble.KNNClassifier', trainObj1, trainY=3,
                              testX=testObj1, scoreMode='bestScore', multiClassStrategy='OneVsAll')
     results3 = trainAndApply('nimble.KNNClassifier', trainObj1, trainY=3,
@@ -873,7 +831,7 @@ def test_trainAndApplyOneVsOne():
     testObj1 = nimble.data(source=testData1)
 
     results1 = trainAndApply('nimble.KNNClassifier', trainObj1, trainY=3,
-                             testX=testObj1, scoreMode='label', multiClassStrategy='OneVsOne')
+                             testX=testObj1, multiClassStrategy='OneVsOne')
     results2 = trainAndApply('nimble.KNNClassifier', trainObj1, trainY=3,
                              testX=testObj1, scoreMode='bestScore', multiClassStrategy='OneVsOne')
     results3 = trainAndApply('nimble.KNNClassifier', trainObj1, trainY=3,
@@ -916,7 +874,8 @@ def test_trainAndTest_scoreModes():
     testY = nimble.data([0, 0, 1, 1, 2]).T
 
     # with bestScore
-    @performanceFunction('min', 0, requires1D=False, sameFtCount=False)
+    @performanceFunction('min', 0, 'bestScore', requires1D=False,
+                         sameFtCount=False)
     def votesWhenIncorrect(knownValues, predictedValues):
         incorrect = 0
         for true, best in zip(knownValues, predictedValues.points):
@@ -925,12 +884,13 @@ def test_trainAndTest_scoreModes():
         return incorrect
 
     performance = nimble.trainAndTest(
-        'nimble.KNNClassifier', trainX, trainY, testX, testY,
-        votesWhenIncorrect, scoreMode='bestScore', k=3)
+        'nimble.KNNClassifier', votesWhenIncorrect, trainX, trainY, testX,
+        testY, k=3)
     assert performance == 2 # 1 incorrect label receiving 2 votes
 
     # with allScores
-    @performanceFunction('max', 1, requires1D=False, sameFtCount=False)
+    @performanceFunction('max', 1, 'allScores', requires1D=False,
+                         sameFtCount=False)
     def correctVoteRatio(knownValues, predictedValues):
         cumulative = 0
         totalVotes = 0
@@ -944,6 +904,6 @@ def test_trainAndTest_scoreModes():
     testX = nimble.data([[0, 0], [1, 1], [2, 2], [1, 1], [-1, -2]])
     testY = nimble.data([0, 0, 1, 1, 2]).T
     performance = nimble.trainAndTest(
-        'nimble.KNNClassifier', trainX, trainY, testX, testY, correctVoteRatio,
-        scoreMode='allScores', k=3)
+        'nimble.KNNClassifier', correctVoteRatio, trainX, trainY, testX, testY,
+        k=3)
     assert performance == 0.8 # 12/15 votes correct

--- a/tests/tune/testValidators.py
+++ b/tests/tune/testValidators.py
@@ -32,7 +32,6 @@ def test_Validator(X, Y):
     assert gv.X == X
     assert gv.Y == Y
     assert gv.performanceFunction == fractionIncorrect
-    assert gv.performanceFunction.optimal == 'min'
     assert gv.randomSeed is not None
     assert gv.useLog is False
     gv.validate(foo='high')
@@ -66,10 +65,6 @@ def test_Validator(X, Y):
                    + 'performanceFunction=fractionCorrect, randomSeed=23, '
                    + 'bar="baz")')
 
-    with raises(InvalidArgumentValue):
-        gv = GenericValidator("test.Learner", X, None, fractionCorrect, None,
-                              False)
-
     with raises(InvalidArgumentValueCombination):
         gv = GenericValidator("test.Learner", X, Y.points[5:], fractionCorrect,
                               None, False)
@@ -82,6 +77,8 @@ class CountingPerformance:
     """
     def __init__(self, optimal, argCount, folds=None):
         self.optimal = optimal
+        self.best = None
+        self.predict = lambda tl, X, args: tl.apply(X, args, useLog=False)
         if folds is None:
             num = argCount
             self.div = 1


### PR DESCRIPTION
Added support for unsupervised performance functions and for testing functions to accommodate unsupervised cases.

- Expanded the `performanceFunction` decorator factory to include a `predict` parameter. This parameter defines how the testing function will generate the predictedValues for the decorated function. When `None`, `'bestScore'`, or `'allScores'`, this uses `TrainedLearner.apply`. For unsupervised learning, the predictedValues can be complex to define and cannot be generated with `apply` so these require a custom function. The function has access to the `TrainedLearner`, knownValues, and function arguments, which should allow for the construction of any predictions.
- Modified parameters for the `train*` functions
  - The `trainY`, `testX`, `testY` were made optional in the `trainAndTest*` functions. This necessitated moving the required `performanceFunction` parameter.
  - `performanceFunction` was removed in `train` and `trainAndApply`, because it is only needed for tuning. Previously, setting the `performanceFunction` served as a shortcut for setting it manually within a `Tuning` instance. Instead, the `tuning` parameter can be set to a performanceFunction to accomplish this same thing with one less parameter. For the `trainAndTest*` functions, the performanceFunction can still be inherited for tuning.
  - The `scoreMode` parameter was removed from `train` and the `trainAndTest*` functions. The use-case for this is now handled by the `predict` function of the performanceFunction as described above. The default `scoreMode` in the apply functions was also changed to `None`. 
  - The default `multiClassStrategy` was changed to `None`. This better represents that no specialized strategy is employed unless this value is set.
  - The `output` parameter was removed in all functions and the output will match that of the `trainX` object.