### PR TITLE
Add parameter to apply filter to a query for axis structural methods

### DIFF
--- a/nimble/core/data/features.py
+++ b/nimble/core/data/features.py
@@ -299,7 +299,7 @@ class Features(ABC):
     @limitedTo2D
     @prepLog
     def copy(self, toCopy=None, start=None, end=None, number=None,
-             randomize=False, *,
+             randomize=False, points=None, *,
              useLog=None): # pylint: disable=unused-argument
         """
         Copy certain features of this object.
@@ -343,6 +343,11 @@ class Features(ABC):
             False, the chosen features are determined by feature order,
             otherwise it is uniform random across the space of possible
             features.
+        points : None, identifier, list of identifiers
+            Only apply the target function to a selection of points in
+            each feature. May be a single point name or index, an
+            iterable, container of point names and/or indices. None
+            indicates application to all points.
         useLog : bool, None
             Local control for whether to send object creation to the
             logger. If None (default), use the value as specified in the
@@ -444,12 +449,12 @@ class Features(ABC):
         --------
         duplicate, replicate, clone
         """
-        return self._copy(toCopy, start, end, number, randomize)
+        return self._copy(toCopy, start, end, number, randomize, points)
 
     @limitedTo2D
     @prepLog
     def extract(self, toExtract=None, start=None, end=None, number=None,
-                randomize=False, *,
+                randomize=False, points=None, *,
                 useLog=None): # pylint: disable=unused-argument
         """
         Move certain features of this object into their own object.
@@ -493,6 +498,11 @@ class Features(ABC):
             False, the chosen features are determined by feature order,
             otherwise it is uniform random across the space of possible
             features.
+        points : None, identifier, list of identifiers
+            Only apply the target function to a selection of points in
+            each feature. May be a single point name or index, an
+            iterable, container of point names and/or indices. None
+            indicates application to all points.
         useLog : bool, None
             Local control for whether to send object creation to the
             logger. If None (default), use the value as specified in the
@@ -670,12 +680,12 @@ class Features(ABC):
         --------
         move, pull, separate, withdraw, cut, vsplit
         """
-        return self._extract(toExtract, start, end, number, randomize)
+        return self._extract(toExtract, start, end, number, randomize, points)
 
     @limitedTo2D
     @prepLog
     def delete(self, toDelete=None, start=None, end=None, number=None,
-               randomize=False, *,
+               randomize=False, points=None, *,
                useLog=None): # pylint: disable=unused-argument
         """
         Remove certain features from this object.
@@ -719,6 +729,11 @@ class Features(ABC):
             False, the chosen features are determined by feature order,
             otherwise it is uniform random across the space of possible
             features.
+        points : None, identifier, list of identifiers
+            Only apply the target function to a selection of points in
+            each feature. May be a single point name or index, an
+            iterable, container of point names and/or indices. None
+            indicates application to all points.
         useLog : bool, None
             Local control for whether to send object creation to the
             logger. If None (default), use the value as specified in the
@@ -836,12 +851,12 @@ class Features(ABC):
         --------
         remove, drop, exclude, eliminate, destroy, cut
         """
-        self._delete(toDelete, start, end, number, randomize)
+        self._delete(toDelete, start, end, number, randomize, points)
 
     @limitedTo2D
     @prepLog
     def retain(self, toRetain=None, start=None, end=None, number=None,
-               randomize=False, *,
+               randomize=False, points=None, *,
                useLog=None): # pylint: disable=unused-argument
         """
         Keep only certain features of this object.
@@ -885,6 +900,11 @@ class Features(ABC):
             False, the chosen features are determined by feature order,
             otherwise it is uniform random across the space of possible
             features.
+        points : None, identifier, list of identifiers
+            Only apply the target function to a selection of points in
+            each feature. May be a single point name or index, an
+            iterable, container of point names and/or indices. None
+            indicates application to all points.
         useLog : bool, None
             Local control for whether to send object creation to the
             logger. If None (default), use the value as specified in the
@@ -1002,16 +1022,17 @@ class Features(ABC):
         --------
         keep, hold, maintain, preserve, remove
         """
-        self._retain(toRetain, start, end, number, randomize)
+        self._retain(toRetain, start, end, number, randomize, points)
 
     @limitedTo2D
-    def count(self, condition):
+    def count(self, condition, points=None):
         """
         The number of features which satisfy the condition.
 
         Parameters
         ----------
         condition : function, query
+
             * function - accepts a feature as its only argument and
               returns a boolean value to indicate if the feature should
               be counted
@@ -1020,6 +1041,12 @@ class Features(ABC):
               OPERATOR is separated from the POINTNAME and VALUE by
               whitespace characters. See ``nimble.match.QueryString``
               for string requirements.
+
+        points : None, identifier, list of identifiers
+            Only apply the condition function to a selection of points
+            in each feature. May be a single point name or index, an
+            iterable, container of point names and/or indices. None
+            indicates application to all points.
 
         Returns
         -------
@@ -1049,7 +1076,7 @@ class Features(ABC):
         --------
         number, counts, tally
         """
-        return self._count(condition)
+        return self._count(condition, points)
 
     @limitedTo2D
     @prepLog

--- a/nimble/core/data/points.py
+++ b/nimble/core/data/points.py
@@ -291,7 +291,7 @@ class Points(ABC):
     #########################
     @prepLog
     def copy(self, toCopy=None, start=None, end=None, number=None,
-             randomize=False, *,
+             randomize=False, features=None, *,
              useLog=None): # pylint: disable=unused-argument
         """
         Copy certain points of this object.
@@ -335,6 +335,11 @@ class Points(ABC):
             False, the chosen points are determined by point order,
             otherwise it is uniform random across the space of possible
             points.
+        features : None, identifier, list of identifiers
+            Only apply the target function to a selection of features in
+            each point. May be a single feature name or index, an
+            iterable, container of feature names and/or indices. None
+            indicates application to all features.
         useLog : bool, None
             Local control for whether to send object creation to the
             logger. If None (default), use the value as specified in the
@@ -419,11 +424,11 @@ class Points(ABC):
         --------
         duplicate, replicate, clone
         """
-        return self._copy(toCopy, start, end, number, randomize)
+        return self._copy(toCopy, start, end, number, randomize, features)
 
     @prepLog
     def extract(self, toExtract=None, start=None, end=None, number=None,
-                randomize=False, *,
+                randomize=False, features=None, *,
                 useLog=None): # pylint: disable=unused-argument
         """
         Move certain points of this object into their own object.
@@ -467,6 +472,11 @@ class Points(ABC):
             False, the chosen points are determined by point order,
             otherwise it is uniform random across the space of possible
             points.
+        features : None, identifier, list of identifiers
+            Only apply the target function to a selection of features in
+            each point. May be a single feature name or index, an
+            iterable, container of feature names and/or indices. None
+            indicates application to all features.
         useLog : bool, None
             Local control for whether to send object creation to the
             logger. If None (default), use the value as specified in the
@@ -623,11 +633,12 @@ class Points(ABC):
         --------
         move, pull, separate, withdraw, cut, hsplit
         """
-        return self._extract(toExtract, start, end, number, randomize)
+        return self._extract(toExtract, start, end, number, randomize,
+                             features)
 
     @prepLog
     def delete(self, toDelete=None, start=None, end=None, number=None,
-               randomize=False, *,
+               randomize=False, features=None, *,
                useLog=None): # pylint: disable=unused-argument
         """
         Remove certain points from this object.
@@ -671,6 +682,11 @@ class Points(ABC):
             False, the chosen points are determined by point order,
             otherwise it is uniform random across the space of possible
             points.
+        features : None, identifier, list of identifiers
+            Only apply the target function to a selection of features in
+            each point. May be a single feature name or index, an
+            iterable, container of feature names and/or indices. None
+            indicates application to all features.
         useLog : bool, None
             Local control for whether to send object creation to the
             logger. If None (default), use the value as specified in the
@@ -777,11 +793,11 @@ class Points(ABC):
         --------
         remove, drop, exclude, eliminate, destroy, cut
         """
-        self._delete(toDelete, start, end, number, randomize)
+        self._delete(toDelete, start, end, number, randomize, features)
 
     @prepLog
     def retain(self, toRetain=None, start=None, end=None, number=None,
-               randomize=False, *,
+               randomize=False, features=None, *,
                useLog=None): # pylint: disable=unused-argument
         """
         Keep only certain points of this object.
@@ -825,6 +841,11 @@ class Points(ABC):
             False, the chosen points are determined by point order,
             otherwise it is uniform random across the space of possible
             points.
+        features : None, identifier, list of identifiers
+            Only apply the target function to a selection of features in
+            each point. May be a single feature name or index, an
+            iterable, container of feature names and/or indices. None
+            indicates application to all features.
         useLog : bool, None
             Local control for whether to send object creation to the
             logger. If None (default), use the value as specified in the
@@ -929,16 +950,17 @@ class Points(ABC):
          'a' │ 1 0 0
         >
         """
-        self._retain(toRetain, start, end, number, randomize)
+        self._retain(toRetain, start, end, number, randomize, features)
 
     @limitedTo2D
-    def count(self, condition):
+    def count(self, condition, features=None):
         """
         The number of points which satisfy the condition.
 
         Parameters
         ----------
         condition : function, query
+
             * function - accepts a point as its only argument and
               returns a boolean value to indicate if the point should
               be counted
@@ -947,6 +969,12 @@ class Points(ABC):
               OPERATOR is separated from the FEATURENAME and VALUE by
               whitespace characters. See ``nimble.match.QueryString``
               for string requirements.
+
+        features : None, identifier, list of identifiers
+            Only apply the condition function to a selection of features
+            in each point. May be a single feature name or index, an
+            iterable, container of feature names and/or indices. None
+            indicates application to all features.
 
         Returns
         -------
@@ -976,7 +1004,7 @@ class Points(ABC):
         --------
         number, counts, tally
         """
-        return self._count(condition)
+        return self._count(condition, features)
 
     @prepLog
     def sort(self, by=None, reverse=False, *,

--- a/nimble/core/data/views.py
+++ b/nimble/core/data/views.py
@@ -278,17 +278,17 @@ class PointsView(Points, metaclass=ABCMeta):
 
     @pointsExceptionDoc
     def extract(self, toExtract=None, start=None, end=None, number=None,
-                randomize=False, *, useLog=None):
+                randomize=False, features=None, *, useLog=None):
         readOnlyException('extract')
 
     @pointsExceptionDoc
     def delete(self, toDelete=None, start=None, end=None, number=None,
-               randomize=False, *, useLog=None):
+               randomize=False, features=None, *, useLog=None):
         readOnlyException('delete')
 
     @pointsExceptionDoc
     def retain(self, toRetain=None, start=None, end=None, number=None,
-               randomize=False, *, useLog=None):
+               randomize=False, features=None, *, useLog=None):
         readOnlyException('retain')
 
     @pointsExceptionDoc
@@ -367,17 +367,17 @@ class FeaturesView(Features, metaclass=ABCMeta):
 
     @featuresExceptionDoc
     def extract(self, toExtract=None, start=None, end=None, number=None,
-                randomize=False, *, useLog=None):
+                randomize=False, points=None, *, useLog=None):
         readOnlyException('extract')
 
     @featuresExceptionDoc
     def delete(self, toDelete=None, start=None, end=None, number=None,
-               randomize=False, *, useLog=None):
+               randomize=False, points=None, *, useLog=None):
         readOnlyException('delete')
 
     @featuresExceptionDoc
     def retain(self, toRetain=None, start=None, end=None, number=None,
-               randomize=False, *, useLog=None):
+               randomize=False, points=None, *, useLog=None):
         readOnlyException('retain')
 
     @featuresExceptionDoc

--- a/tests/data/structure_backend.py
+++ b/tests/data/structure_backend.py
@@ -1239,6 +1239,26 @@ class StructureDataSafe(StructureShared):
     def test_points_copy_range_numberGreaterThanTargeted(self):
         self.back_structural_range_numberGreaterThanTargeted('copy', 'point')
 
+    def test_points_copy_featureLimited(self):
+        data = [[1, 2, 3], [None, 11, None], [None, 11, 15], [7, 8, None]]
+        ftNames = ['a', 'b', 'c']
+        toTest = self.constructor(data, featureNames=ftNames)
+        expTest = self.constructor(data, featureNames=ftNames)
+        ret = toTest.points.copy(match.anyMissing, features=['c', 'b'])
+        expRet = self.constructor([[None, 11, None], [7, 8, None]],
+                                  featureNames=ftNames)
+        assert toTest == expTest
+        assert ret == expRet
+
+        data = [[11, 2, 3], [None, 11, None], [None, 11, 15], [7, 8, None]]
+        toTest = self.constructor(data, featureNames=ftNames)
+        expTest = self.constructor(data, featureNames=ftNames)
+        ret = toTest.points.copy(lambda pt: 11 in pt, features=['c', 'b'])
+        expRet = self.constructor([[None, 11, None], [None, 11, 15]],
+                                  featureNames=ftNames)
+        assert toTest == expTest
+        assert ret == expRet
+
     ### using match module ###
 
     def test_points_copy_match_missing(self):
@@ -1937,6 +1957,25 @@ class StructureDataSafe(StructureShared):
     @raises(InvalidArgumentValue)
     def test_features_copy_range_numberGreaterThanTargeted(self):
         self.back_structural_range_numberGreaterThanTargeted('copy', 'feature')
+
+    def test_features_copy_pointLimited(self):
+        data = [[1, 2, 3], [None, 11, None], [None, 11, 15], [7, None, 9]]
+        ptNames = ['a', 'b', 'c', 'd']
+        toTest = self.constructor(data, pointNames=ptNames)
+        expTest = toTest.copy()
+        ret = toTest.features.copy(match.anyMissing, points=[1, 2])
+        expRet = self.constructor([[1, 3], [None, None], [None, 15], [7, 9]],
+                                  pointNames=ptNames)
+        assert toTest == expTest
+        assert ret == expRet
+
+        data = [[11, 2, 3], [None, 11, None], [None, 11, 15], [7, None, 9]]
+        toTest = self.constructor(data, pointNames=ptNames)
+        expTest = toTest.copy()
+        ret = toTest.features.copy(lambda ft: 11 in ft, points=['b', 'c'])
+        expRet = self.constructor([[2], [11], [11], [None]], pointNames=ptNames)
+        assert toTest == expTest
+        assert ret == expRet
 
     ### using match module ###
 
@@ -4123,6 +4162,24 @@ class StructureModifying(StructureShared):
     def test_points_extract_range_numberGreaterThanTargeted(self):
         self.back_structural_range_numberGreaterThanTargeted('extract', 'point')
 
+    def test_points_extract_featureLimited(self):
+        data = [[1, 2, 3], [None, 11, None], [None, 11, 15], [7, 8, None]]
+        ftNames = ['a', 'b', 'c']
+        toTest = self.constructor(data, featureNames=ftNames)
+        ret = toTest.points.extract(match.anyMissing, features=[2, 1])
+        expTest = self.constructor([[1, 2, 3], [None, 11, 15]], featureNames=ftNames)
+        expRet = self.constructor([[None, 11, None], [7, 8, None]], featureNames=ftNames)
+        assert toTest == expTest
+        assert ret == expRet
+
+        data = [[11, 2, 3], [None, 11, None], [None, 11, 15], [7, 8, None]]
+        toTest = self.constructor(data, featureNames=ftNames)
+        ret = toTest.points.extract(lambda pt: 11 in pt, features=[2, 1])
+        expTest = self.constructor([[11, 2, 3], [7, 8, None]], featureNames=ftNames)
+        expRet = self.constructor([[None, 11, None], [None, 11, 15]], featureNames=ftNames)
+        assert toTest == expTest
+        assert ret == expRet
+
     ### using match module ###
 
     def test_points_extract_match_missing(self):
@@ -4778,6 +4835,26 @@ class StructureModifying(StructureShared):
     def test_features_extract_range_numberGreaterThanTargeted(self):
         self.back_structural_range_numberGreaterThanTargeted('extract', 'feature')
 
+    def test_features_extract_pointLimited(self):
+        data = [[1, 2, 3], [None, 11, None], [None, 11, 15], [7, None, 9]]
+        ptNames = ['a', 'b', 'c', 'd']
+        toTest = self.constructor(data, pointNames=ptNames)
+        ret = toTest.features.extract(match.anyMissing, points=[1, 2])
+        expTest = self.constructor([[2], [11], [11], [None]], pointNames=ptNames)
+        expRet = self.constructor([[1, 3], [None, None], [None, 15], [7, 9]],
+                                  pointNames=ptNames)
+        assert toTest == expTest
+        assert ret == expRet
+
+        data = [[11, 2, 3], [None, 11, None], [None, 11, 15], [7, None, 9]]
+        toTest = self.constructor(data, pointNames=ptNames)
+        ret = toTest.features.extract(lambda ft: 11 in ft, points=['b', 'c'])
+        expTest = self.constructor([[11, 3], [None, None], [None, 15], [7, 9]],
+                                   pointNames=ptNames)
+        expRet = self.constructor([[2], [11], [11], [None]], pointNames=ptNames)
+        assert toTest == expTest
+        assert ret == expRet
+
     ### using match module ###
 
     def test_features_extract_match_missing(self):
@@ -5259,6 +5336,20 @@ class StructureModifying(StructureShared):
     @raises(InvalidArgumentValue)
     def test_points_delete_range_numberGreaterThanTargeted(self):
         self.back_structural_range_numberGreaterThanTargeted('delete', 'point')
+
+    def test_points_delete_featureLimited(self):
+        data = [[1, 2, 3], [None, 11, None], [None, 11, 15], [7, 8, None]]
+        ftNames = ['a', 'b', 'c']
+        toTest = self.constructor(data, featureNames=ftNames)
+        toTest.points.delete(match.anyMissing, features=['b', 'c'])
+        exp = self.constructor([[1, 2, 3], [None, 11, 15]], featureNames=ftNames)
+        assert toTest == exp
+
+        data = [[11, 2, 3], [None, 11, None], [None, 11, 15], [7, 8, None]]
+        toTest = self.constructor(data, featureNames=ftNames)
+        toTest.points.delete(lambda pt: 11 in pt, features=['b', 'c'])
+        exp = self.constructor([[11, 2, 3], [7, 8, None]], featureNames=ftNames)
+        assert toTest == exp
 
     ### using match module ###
 
@@ -5860,6 +5951,21 @@ class StructureModifying(StructureShared):
     def test_features_delete_range_numberGreaterThanTargeted(self):
         self.back_structural_range_numberGreaterThanTargeted('delete', 'feature')
 
+    def test_features_delete_pointLimited(self):
+        data = [[1, 2, 3], [None, 11, None], [None, 11, 15], [7, None, 9]]
+        ptNames = ['a', 'b', 'c', 'd']
+        toTest = self.constructor(data, pointNames=ptNames)
+        ret = toTest.features.delete(match.anyMissing, points=[1, 2])
+        expTest = self.constructor([[2], [11], [11], [None]], pointNames=ptNames)
+        assert toTest == expTest
+
+        data = [[11, 2, 3], [None, 11, None], [None, 11, 15], [7, None, 9]]
+        toTest = self.constructor(data, pointNames=ptNames)
+        ret = toTest.features.delete(lambda ft: 11 in ft, points=['b', 'c'])
+        expTest = self.constructor([[11, 3], [None, None], [None, 15], [7, 9]],
+                                   pointNames=ptNames)
+        assert toTest == expTest
+
     ### using match module ###
 
     def test_features_delete_match_missing(self):
@@ -6352,6 +6458,22 @@ class StructureModifying(StructureShared):
     def test_points_retain_range_numberGreaterThanTargeted(self):
         self.back_structural_range_numberGreaterThanTargeted('retain', 'point')
 
+    def test_points_retain_featureLimited(self):
+        data = [[1, 2, 3], [None, 11, None], [None, 11, 15], [7, 8, None]]
+        ftNames = ['a', 'b', 'c']
+        toTest = self.constructor(data, featureNames=ftNames)
+        ret = toTest.points.retain(match.anyMissing, features=[1, 2])
+        expTest = self.constructor([[None, 11, None], [7, 8, None]],
+                                   featureNames=ftNames)
+        assert toTest == expTest
+
+        data = [[11, 2, 3], [None, 11, None], [None, 11, 15], [7, 8, None]]
+        toTest = self.constructor(data, featureNames=ftNames)
+        ret = toTest.points.retain(lambda pt: 11 in pt, features=[1, 2])
+        expTest = self.constructor([[None, 11, None], [None, 11, 15]],
+                                   featureNames=ftNames)
+        assert toTest == expTest
+
     ### using match module ###
 
     def test_points_retain_match_missing(self):
@@ -6364,6 +6486,12 @@ class StructureModifying(StructureShared):
         toTest = self.constructor([[None, None, None], [None, 11, None], [7, 11, None], [7, 8, 9]], featureNames=['a', 'b', 'c'])
         ret = toTest.points.retain(match.allMissing)
         expTest = self.constructor([[None, None, None]])
+        expTest.features.setNames(['a', 'b', 'c'])
+        assert toTest == expTest
+
+        toTest = self.constructor([[1, 2, 3], [None, 11, None], [7, 11, None], [7, 8, 9]], featureNames=['a', 'b', 'c'])
+        ret = toTest.points.retain(match.anyMissing)
+        expTest = self.constructor([[None, 11, None], [7, 11, None]])
         expTest.features.setNames(['a', 'b', 'c'])
         assert toTest == expTest
 
@@ -6975,6 +7103,21 @@ class StructureModifying(StructureShared):
     @raises(InvalidArgumentValue)
     def test_features_retain_range_numberGreaterThanTargeted(self):
         self.back_structural_range_numberGreaterThanTargeted('retain', 'feature')
+
+    def test_features_retain_pointLimited(self):
+        data = [[1, 2, 3], [None, 11, None], [None, 11, 15], [7, None, 9]]
+        ptNames = ['a', 'b', 'c', 'd']
+        toTest = self.constructor(data, pointNames=ptNames)
+        ret = toTest.features.retain(match.anyMissing, points=[1, 2])
+        expTest = self.constructor([[1, 3], [None, None], [None, 15], [7, 9]],
+                                   pointNames=ptNames)
+        assert toTest == expTest
+
+        data = [[11, 2, 3], [None, 11, None], [None, 11, 15], [7, None, 9]]
+        toTest = self.constructor(data, pointNames=ptNames)
+        ret = toTest.features.retain(lambda ft: 11 in ft, points=['b', 'c'])
+        expTest = self.constructor([[2], [11], [11], [None]], pointNames=ptNames)
+        assert toTest == expTest
 
     ### using match module ###
 


### PR DESCRIPTION
Add a parameter to the structural axis methods (copy, extract, delete, retain) that limits the scope of the target function. For `Points`, a `features` parameter was added and for `Features` a `points` parameter was added. When not `None`, the `target` function will only receive those points/features. This is convenient, easier to read, and more powerful than requiring the function to apply a filter of the points/features.

For example, if our data has 10 features but our extract function is based only on the first 3 features we can now do this:
```python
myObj.points.extract(match.allPositive, features=[0, 1, 2])
``` 
The changes allow `match.allPositive` to be used as the function and `features` applies the filter. This is a better solution than the current ways to accomplish this:
```python
def first3Positive(pt):
    return match.allPositive(pt[[0, 1, 2]])

myObj.points.extract(first3Positive)
```
or
```python
myObj.points.extract(lambda pt: match.allPositive(pt[[0, 1, 2]]))
```
`first3Positive` solves a very specific problem whereas `match.allPositive` is capable of determining the positivity of any selection of features from the point.  It is also slightly less characters than an equivalent to `first3Positive` using a `lambda` function
