### PR TITLE
Correct Keras loss lookup to avoid un-related import exceptions

### DIFF
--- a/nimble/core/interfaces/keras_interface.py
+++ b/nimble/core/interfaces/keras_interface.py
@@ -20,7 +20,7 @@ from ._interface_helpers import PythonSearcher
 from ._interface_helpers import modifyImportPathAndImport
 from ._interface_helpers import collectAttributes
 from ._interface_helpers import removeFromTailMatchedLists
-from ._interface_helpers import noLeading__, notCallable, notABCAssociated
+from ._interface_helpers import notCallable, notABCAssociated
 from ._interface_helpers import checkArgsForRandomParam
 
 
@@ -475,13 +475,24 @@ To install keras
 
     def _getAttributes(self, learnerBackend):
         obj = learnerBackend
-        generators = None
-        checkers = []
-        checkers.append(noLeading__)
-        checkers.append(notCallable)
-        checkers.append(notABCAssociated)
+        checkers = [notCallable, notABCAssociated]
 
-        ret = collectAttributes(obj, generators, checkers)
+        def wrappedDir(obj):
+            ret = {}
+            keys = dir(obj)
+            func = lambda n: not n.startswith("_") and n != "submodules"
+            acceptedKeys = filter(func, keys)
+            for k in acceptedKeys:
+                try:
+                    val = getattr(obj, k)
+                    ret[k] = val
+                # safety against any sort of error someone may have in their
+                # property code.
+                except (AttributeError, ValueError):
+                    pass
+            return ret
+
+        ret = collectAttributes(obj, [wrappedDir], checkers)
         return ret
 
     def _optionDefaults(self, option):

--- a/tests/interfaces/keras_interface_test.py
+++ b/tests/interfaces/keras_interface_test.py
@@ -313,3 +313,18 @@ def testKerasReproducibility(optimizer):
 def testLearnerTypes():
     learners = ['keras.' + l for l in nimble.learnerNames('keras')]
     assert all(lt == 'undefined' for lt in nimble.learnerType(learners))
+
+@keraSkipDec
+def testLossCoverage():
+    kerasInt = nimble.core._learnHelpers.findBestInterface('keras')
+    lts = nimble.core.interfaces.keras_interface.LEARNERTYPES
+    fullLossList = lts["classification"] + lts["regression"]
+
+    # For all Loss classes (which should cover all possiblilities that Keras
+    # provides), check to see that it is represented in the LEARNERTYPES
+    # constant.
+    for n in dir(kerasInt.package.losses):
+        val = getattr(kerasInt.package.losses, n)
+        if type(val) is type and issubclass(val, kerasInt.package.losses.Loss):
+            if not (val is kerasInt.package.losses.Loss):
+                assert val.__name__ in fullLossList


### PR DESCRIPTION
For certain early Keras versions, when getting any attribute off of a Sequential object, all would have to be grabbed and checked. This was causing some unneeded importing side effects and possible failures. `getAttributes` now filters at the name level, so the bad, unneeded cases are avoided.

Also includes tests to confirm all available loss classes are represented in the `learnerType` lookup.