### PR TITLE
fixed Base's trainAndTestSets

### DIFF
--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -1514,7 +1514,7 @@ class Base(ABC):
             else:
                 trainX.name = "train"
                 testX.name = "test"
-       
+
         else:
             if isinstance(labels, Base):
                 if len(labels.points) != len(self.points):
@@ -1529,12 +1529,12 @@ class Base(ABC):
                     raise InvalidArgumentValue(msg) from e
                 trainY = labels.points.copy(order[:splitIndex], useLog=False)
                 testY = labels.points.copy(order[splitIndex:], useLog=False)
-            else:    
+            else:
                 if len(self._dims) > 2:
-                    msg = "labels parameter must be None when the data has more "
-                    msg += "than two dimensions"
+                    msg = "labels parameter must be None when the data has "
+                    msg += "more than two dimensions"
                     raise ImproperObjectAction(msg)
-                
+
                 # safety for empty objects
                 toExtract = labels
                 if testXSize == 0:

--- a/tests/data/high_dimension_backend.py
+++ b/tests/data/high_dimension_backend.py
@@ -79,7 +79,7 @@ class HighDimensionSafe(DataTestObject):
 
             with raises(ImproperObjectAction):
                 fourTuple = toTest.trainAndTestSets(0.33, labels=0)
-    
+
     def test_highDimension_trainAndTestSets_dataObject_nimbleLabel(self):
         objectLabel = nimble.data([['dog'], ['cat'], ['cat']])
         for tensor in tensors:
@@ -275,7 +275,7 @@ class HighDimensionSafe(DataTestObject):
                     flattenTensor(pt, store)
 
             return store
-    
+
         for tensor in tensors:
             flatPt = flattenTensor(tensor)
             orig = self.constructor(tensor)
@@ -297,7 +297,7 @@ class HighDimensionSafe(DataTestObject):
             flat = expPt.copy()
             with raises(ImproperObjectAction):
                 flat.unflatten(orig._dims, order='feature')
-                
+
     def test_highDimension_points_iter(self):
         for idx, tensor in enumerate(tensors):
             flattenedLen = 15
@@ -706,5 +706,3 @@ class HighDimensionModifying(DataTestObject):
 
 class HighDimensionAll(HighDimensionSafe, HighDimensionModifying):
     pass
-    # def test_highDimension_trainAndTestSetsSplit(self):
-    #     pass 


### PR DESCRIPTION
Wrote a unit test and altered base.py logic to address base.trainAndTestSets() not splitting for higher dimensional objects.

(P.S: I forgot to checkout to my feature branch all this while and did it on my dev branch, i'll make sure it's a feature branch next time. )