### PR TITLE
Updated base.py for conditional label name check

### DIFF
--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -1529,6 +1529,14 @@ class Base(ABC):
                     raise InvalidArgumentValue(msg) from e
                 trainY = labels.points.copy(order[:splitIndex], useLog=False)
                 testY = labels.points.copy(order[splitIndex:], useLog=False)
+                if self.features._namesCreated() and labels.features._namesCreated(): 
+                    featureNamesList = [featureName.lower() for featureName in self.features.getNames()]
+                    labelNameList = labels.features.getNames() 
+                    labelName = labelNameList[0].lower()
+                    if labelName in featureNamesList:
+                        labelIndex = featureNamesList.index(labelName)
+                        trainY = trainX.features.extract(labelIndex, useLog=False)
+                        testY = testX.features.extract(labelIndex, useLog=False)    
             else:
                 if len(self._dims) > 2:
                     msg = "labels parameter must be None when the data has "


### PR DESCRIPTION
For label data object passed to 'base.trainAndTests' , checks to see if the label name (feature/column) exists in the general data. If it does find a match, it does the train and test split along with extracting the assumed label from the train data.