### PR TITLE
sligiht edit to base.show's maxColumnWidth info

### DIFF
--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -2402,8 +2402,10 @@ class Base(ABC):
             The number of significant digits to display in the output.
         maxColumnWidth : int
             A bound on the maximum number of characters allowed for the
-            width of single column (feature) in each line.
-
+            width of single column (feature) in each line. 
+            If the column text is too long for the set bound, 3 characters
+            will be used up for the ellipses during truncation.
+            
         Keywords
         --------
         print, representation, visualize, out, stdio, visualize, output,


### PR DESCRIPTION
I considered adding a few words on 'MaxWidth' saying 'look below for maxColumnWidth' if you want to extend the column width specifically. [I decided against it.]

I realize my initial confusion with this from the User Trials came because I didn't scroll down to the bottom of available parameters.