### PR TITLE
Keras bug fixes and regression test

### DIFF
--- a/documentation/source/examples/neural_networks.py
+++ b/documentation/source/examples/neural_networks.py
@@ -72,7 +72,7 @@ trainX, trainY, testX, testY = images.trainAndTestSets(testFraction=0.25,
 ## with any keyword arguments. So we can avoid extra imports (i.e., `from
 ## keras.layers import  Dense, Dropout`) and there is no need to recall the
 ## package's module names that contain the objects we want to use.
-layer0 = nimble.Init('Dense', units=64, activation='relu', input_dim=256)
+layer0 = nimble.Init('Dense', units=64, activation='relu')
 layer1 = nimble.Init('Dropout', rate=0.5)
 layer2 = nimble.Init('Dense', units=10, activation='softmax')
 layers = [layer0, layer1, layer2]
@@ -125,8 +125,9 @@ print('testX.shape', testX.shape, 'testX.dimensions', testX.dimensions)
 ## above, we can use `nimble.Init` to instantiate these objects without
 ## directly importing them from Keras.
 layersCNN = []
+layersCNN.append(nimble.Init("Input", shape=(16, 16, 1)))
 layersCNN.append(nimble.Init('Conv2D', filters=64, kernel_size=3,
-                             activation='relu', input_shape=(16, 16, 1)))
+                             activation='relu', ))
 layersCNN.append(nimble.Init('Conv2D', filters=32, kernel_size=3,
                              activation='relu'))
 layersCNN.append(nimble.Init('Dropout', rate=0.2))

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -78,7 +78,7 @@ def generateClassificationData(labels, pointsPer, featuresPer, testSizePerLabel=
 
 
 # TODO: polish and relocate to random module
-def generateRegressionData(labels, pointsPer, featuresPer):
+def generateRegressionData(labels, pointsPer, featuresPer, testSizePerLabel=1):
     """
     Randomly generate sensible data for a regression problem. Returns a
     tuple of tuples, where the first value is a tuple containing
@@ -90,7 +90,7 @@ def generateRegressionData(labels, pointsPer, featuresPer):
         labels, pointsPer, featuresPer, addFeatureNoise=True,
         addLabelNoise=True, addLabelColumn=False)
     regressorTestData, testLabels, _ = generateClusteredPoints(
-        labels, 1, featuresPer, addFeatureNoise=True, addLabelNoise=True,
+        labels, testSizePerLabel, featuresPer, addFeatureNoise=True, addLabelNoise=True,
         addLabelColumn=False)
 
     return ((regressorTrainData, trainLabels), (regressorTestData, testLabels))


### PR DESCRIPTION
Number of semi-related bugfixes and testing extensions.

* keras will now recursively initialize `nimble.Init` objects.
* keras will copy iterable input values (such as the `layers` list), so they can be safely reused by the user in subsequent calls.
* Subsequently, tests were modified to correct the accidental usage of that side effect.
* keras layer objects will now report their `__init__` parameters, instead of the default `__new__`
* Subsequently, implicitly allowed keyword args (such as `input_shape`) are no longer considered acceptable parameters for layers. This is OK because they can always be automatically discovered, or specified with an `Input` layer.
* A test demonstrating successful usage for a regression problem through a variety of our learner functions has been added. Unlike classification, which has more possibilities of outputs, we only check one loss type, which should be equivalent to the other possibilities.
* A few style changes, for variable name clarity and to satisfy the linter.

This is built over top of the changes in PR 471 - once that has been accepted this will be force updated to be rebased off of the new dev head. Until then, the diff shown by github will include the 471 changes as well.