### PR TITLE
Change Supervised Learning example to have correct model

### DIFF
--- a/tests/landingPage/supervised_learning_output.txt
+++ b/tests/landingPage/supervised_learning_output.txt
@@ -2,7 +2,7 @@ REGEX: sklearn.LinearRegression error: 1[78][0-9]{2}\.[0-9]+
 REGEX: sklearn.Ridge error: 1[78][0-9]{2}\.[0-9]+
 REGEX: sklearn.Lasso error: 1[78][0-9]{2}\.[0-9]+
 REGEX: sklearn.KNeighborsRegressor error: [78][0-9]{2}\.[0-9]+
-REGEX: sklearn.GradientBoostingRegressor error: 5[1-5][0-9]\.[0-9]+
+REGEX: sklearn.HistGradientBoostingRegressor error: 3[1-5][0-9]\.[0-9]+
 algorithm
 leaf_size
 metric
@@ -20,35 +20,35 @@ REGEX: n_neighbors    \d+
 REGEX: p              \d+
 REGEX: weights        '\w+'
 REGEX: 8[0-9]{2}\.[0-9]+ \{'n_neighbors': 3\}
-REGEX: 8[0-9]{2}\.[0-9]+ \{'n_neighbors': 5\}
-REGEX: 8[0-9]{2}\.[0-9]+ \{'n_neighbors': 7\}
-REGEX: 4[0-9]{2}\.[0-9]+ \{'learning_rate': 1\}
-REGEX: sklearn.GradientBoostingRegressor learning_rate=1 error 3[789][0-9]\.[0-9]+
+REGEX: 30[0-9]\.[0-9]+ \{'learning_rate': 0.5\}
+REGEX: 3[0-9][0-9]\.[0-9]+ \{'learning_rate': 0.1\}
+REGEX: 3[0-9][0-9]\.[0-9]+ \{'learning_rate': 1\}
+REGEX: sklearn.HistGradientBoostingRegressor learning_rate=0.5 error [2-3][0|9][0-9]\.[0-9]+
 Traffic Volume Predictions
 24pt x 2ft
      'volume' 'hour'
    ┌────────────────
-REGEX:  0 │ 8[0-9]{2}\.[0-9]{3}  0.000
-REGEX:  1 │ 5[0-9]{2}\.[0-9]{3}  1.000
+REGEX:  0 │ 7[0-9]{2}\.[0-9]{3}  0.000
+REGEX:  1 │ 4[0-9]{2}\.[0-9]{3}  1.000
 REGEX:  2 │ 3[0-9]{2}\.[0-9]{3}  2.000
-REGEX:  3 │ 3[0-9]{2}\.[0-9]{3}  3.000
-REGEX:  4 │ [67][0-9]{2}\.[0-9]{3}  4.000
+REGEX:  3 │ 4[0-9]{2}\.[0-9]{3}  3.000
+REGEX:  4 │ 7[0-9]{2}\.[0-9]{3}  4.000
 REGEX:  5 │ 2[0-9]{3}\.[0-9]{3} 5.000
 REGEX:  6 │ 5[0-9]{3}\.[0-9]{3} 6.000
-REGEX:  7 │ [56][0-9]{3}\.[0-9]{3} 7.000
+REGEX:  7 │ 5[0-9]{3}\.[0-9]{3} 7.000
 REGEX:  8 │ 5[0-9]{3}\.[0-9]{3} 8.000
 REGEX:  9 │ 4[0-9]{3}\.[0-9]{3} 9.000
 REGEX: 10 │ 4[0-9]{3}\.[0-9]{3} 10.000
 REGEX: 11 │ 4[0-9]{3}\.[0-9]{3} 11.000
-REGEX: 12 │ [45][0-9]{3}\.[0-9]{3} 12.000
-REGEX: 13 │ [45][0-9]{3}\.[0-9]{3} 13.000
+REGEX: 12 │ 4[0-9]{3}\.[0-9]{3} 12.000
+REGEX: 13 │ 5[0-9]{3}\.[0-9]{3} 13.000
 REGEX: 14 │ 5[0-9]{3}\.[0-9]{3} 14.000
-REGEX: 15 │ [56][0-9]{3}\.[0-9]{3} 15.000
-REGEX: 16 │ [56][0-9]{3}\.[0-9]{3} 16.000
+REGEX: 15 │ 5[0-9]{3}\.[0-9]{3} 15.000
+REGEX: 16 │ 6[0-9]{3}\.[0-9]{3} 16.000
 REGEX: 17 │ 5[0-9]{3}\.[0-9]{3} 17.000
 REGEX: 18 │ 4[0-9]{3}\.[0-9]{3} 18.000
 REGEX: 19 │ 3[0-9]{3}\.[0-9]{3} 19.000
-REGEX: 20 │ [23][0-9]{3}\.[0-9]{3} 20.000
+REGEX: 20 │ 2[0-9]{3}\.[0-9]{3} 20.000
 REGEX: 21 │ 2[0-9]{3}\.[0-9]{3} 21.000
 REGEX: 22 │ 2[0-9]{3}\.[0-9]{3} 22.000
-REGEX: 23 │ [12][0-9]{3}\.[0-9]{3} 23.000
+REGEX: 23 │ 1[0-9]{3}\.[0-9]{3} 23.000


### PR DESCRIPTION
The GradientBoostingRegressor ensemble estimator was only meant for data sets of less than 10k points, and in the 1.1.0 SKL version, code modifications made the efficiency for larger datasets particularly bad. The example now uses the HistGradientBoostingRegressor as suggested by the user guide, which allows for reasonable run-times regardless of version.

This changed some of the script outputs, so not only did the unit test regex comparison need to be changed, but some of the explanatory text no longer matched the displayed behavior. Other small edits to the text were also added.