### PR TITLE
Nini/queryStringError,  InvalidArgumentType vs InvalidArgumentValue 

### DIFF
--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -979,7 +979,7 @@ class Base(ABC):
         if not callable(matchArg):
             try:
                 func = QueryString(matchArg, elementQuery=True)
-            except InvalidArgumentType: # because invalid argument value is not being caught
+            except (InvalidArgumentValue, InvalidArgumentType) : 
                 # if not a query string, element must equal matchArg
                 matchVal = matchArg
                 func = lambda elem: elem == matchVal

--- a/nimble/match/query.py
+++ b/nimble/match/query.py
@@ -106,6 +106,7 @@ class QueryString:
         if not isinstance(string, str):
             msg = 'string for QueryString is not a string'
             raise InvalidArgumentType(msg)
+        self.string = string
         # elementQuery can be True or False when QueryStrings are constructed
         # to indicate whether the operation part of the string is expected at
         # the beginning (elementwise) or the middle (axiswise) to eliminate

--- a/tests/data/high_level_backend.py
+++ b/tests/data/high_level_backend.py
@@ -2243,6 +2243,8 @@ class HighLevelDataSafe(DataTestObject):
         assert matches[1, 2] is False or matches[1, 2] is np.bool_(False)
 
     def test_matchingElements_valueInput(self):
+        # import pdb
+        # pdb.set_trace()
         raw = [[1, 2, 3], [-1, -2, -3], [0, 'a', 0]]
         obj = self.constructor(raw)
         match1 = obj.matchingElements(lambda x: x == 0)


### PR DESCRIPTION
This became a task when it was decided while looking at an error trace where 'InvalidArgumentType' was deemed more appropriate than 'InvalidArgumentValue' in QueryString in query.py and in the countElements function in base.py 

Looking over it on a video call, it seemed that a couple interchanges of both Error classes would improve the clarity in the error trace. In particular, preventing an invalidArgumentType error message from rising to the top of an error in using the countElements function which obscured the (seemingly more approriate) reference to the elementwise-nature of the requirements as seen in the QueryString class. 

However none of the interchanges have made the error message from QueryString more visible in the error trace, and in addition a number of other tests have been failing.I'd be happy if you could look at this with me once you have the time for it, I might have completely forgotten/missed something from the initial video call.

Currently tests failing are 'MatchingElements' related,  8 of them (caused by swapping out an InvalidArgumentValue for an InvalidArgumentType).

#NOT GOOD TO GO