### PR TITLE
unifyingType function inside features.report() to provide data types of features in report.

### DIFF
--- a/nimble/core/data/features.py
+++ b/nimble/core/data/features.py
@@ -2355,8 +2355,8 @@ class Features(ABC):
         return self._unique()
 
     @limitedTo2D
-    def report(self, basicStatistics=True, extraStatisticFunctions=(), *,
-               useLog=None, dtypes=False):
+    def report(self, basicStatistics=True, extraStatisticFunctions=(), 
+               dtypes=False, *, useLog=None):
         """
         Report containing a summary and statistics for each feature.
 
@@ -2378,6 +2378,10 @@ class Features(ABC):
             A list of functions to include in the report. Functions must
             accept a feature view as the only input and output a single
             value.
+        dtypes : bool
+            True will add an additional column to the features report
+            which would include the data type of each feature in the
+            dataset.
         useLog : bool, None
             Local control for whether to send object creation to the
             logger. If None (default), use the value as specified in the

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -3100,17 +3100,19 @@ class QueryBackend(DataTestObject):
                                featureNames=fnames)
         
         ret = obj.features.report(dtypes=True)
-        
         assert 'dataType' in ret.features.getNames()
-        expFeatureTypes = ['int64', 'object', 'float64']
-
-        if type(obj) is nimble.core.data.matrix.Matrix or type(obj) is nimble.core.data.sparse.Sparse:
-            assert list(ret.features['dataType']) == ['object', 'object', 'object']
-        elif type(obj) is nimble.core.data.list.List:
-            assert list(ret.features['dataType']) == ['object', 'object', 'object']
+        reportDtypes = list(ret.features['dataType']) 
+        expDtypes = [np.integer, np.object_, np.float]
+        
+        if type(obj) in [nimble.core.data.matrix.Matrix, nimble.core.data.sparse.Sparse, 
+                         nimble.core.data.list.List]:
+            for i in range(len(reportDtypes)):
+              assert np.issubdtype(reportDtypes[i], np.object_) 
         elif type(obj) is nimble.core.data.dataframe.DataFrame:
-            assert list(ret.features['dataType']) == expFeatureTypes
-      
+            for i in range(len(reportDtypes)):
+              assert np.issubdtype(reportDtypes[i], expDtypes[i]) 
+        
+        
     ##########
     # report #
     ##########


### PR DESCRIPTION
The commits as they are provide the desired functionality, an additional single feature nimble data object is created within ```features.report()``` and appended. ```features.report()``` now has an additional parameter ```dtype=False``` by default. The reason for this is due to the number of features expected in the ```features.report()```  and comparisons (e.g. ```ApproximatelyEqual```  in numerous tests. 

There are a few considerations:
List Objects:  
- When a nimble data object is created from some source data, even if it was previously a list, Nimble keeps a data frame for an underlying data structure.
- Also, since this is currently a ‘features.report()’ component, it makes sense that there is no particular provision for a list since the only time we expect to use Lists are in rare cases, and in those cases where the data type in columns is not consistent. This would by itself negate the idea of a data type for a column for a list object. 
- Due to the above points,  I have not put in place a useful way to pull out any data from List objects if they somehow find their way to the  ```unifyingType``` function.

Tests:
- In query_backend.py I have commented out code starting from line 3097 which is meant to test this. It does use the object constructors found in the same file and thus creates the same test for the four nimble data types and their views. This test only works for the DataFrame and DataFrameView objects at the moment. 
- What would be the smoothest way to test this feature?  

Base.Report: 
- From my observation, what is typically provided by base report is very much an overview of and I think this makes sense for this only existing in features.report only. 



