### PR TITLE
Eliminating setName() by adding the functionality to setNames()

### DIFF
--- a/nimble/core/data/axis.py
+++ b/nimble/core/data/axis.py
@@ -262,14 +262,19 @@ class Axis(ABC):
             self.names = names
             self.namesInverse = reverseMap # needs to accomodate all inverses, including incomplete dicts
         else:
+            if type(assignments) in [int, str]:
+                assignments = [assignments]
+            if type(oldIdentifiers) in [int, str, None]:
+                oldIdentifiers = [oldIdentifiers]
             if len(assignments) <= count and len(assignments) == len(oldIdentifiers):
-                
                 indices = []
                 oldNames = []
+                if self.names is None:
+                    self._setAllDefault()
                 for name in oldIdentifiers:
                     index = self._getIndex(name)
                     indices.append(index)
-                    if name in self.names: 
+                    if name in self.names:
                         oldName = name
                     else:
                         oldName = self.namesInverse[index]

--- a/nimble/core/data/features.py
+++ b/nimble/core/data/features.py
@@ -156,7 +156,7 @@ class Features(ABC):
 
 
     @prepLog
-    def setNames(self, assignments, *,
+    def setNames(self, assignments, *, oldIdentifiers=None,
                  useLog=None): # pylint: disable=unused-argument
         """
         Set or rename all of the feature names of this object.
@@ -197,7 +197,7 @@ class Features(ABC):
         --------
         columns, titles, headers, headings, attributes, identifiers
         """
-        self._setNames(assignments)
+        self._setNames(assignments, oldIdentifiers)
 
     def getIndex(self, identifier):
         """
@@ -2686,7 +2686,7 @@ class Features(ABC):
         pass
 
     @abstractmethod
-    def _setNames(self, assignments):
+    def _setNames(self, assignments, oldIdentifiers=None):
         pass
 
     @abstractmethod

--- a/nimble/core/data/points.py
+++ b/nimble/core/data/points.py
@@ -149,7 +149,7 @@ class Points(ABC):
 
 
     @prepLog
-    def setNames(self, assignments, *,
+    def setNames(self, assignments,  *, oldIdentifiers=None,
                  useLog=None): # pylint: disable=unused-argument
         """
         Set or rename all of the point names of this object.
@@ -190,7 +190,7 @@ class Points(ABC):
         --------
         rows, keys, indexes, indices, headers, headings, identifiers
         """
-        self._setNames(assignments)
+        self._setNames(assignments, oldIdentifiers)
 
     def getIndex(self, identifier):
         """
@@ -2604,7 +2604,7 @@ class Points(ABC):
         pass
 
     @abstractmethod
-    def _setNames(self, assignments):
+    def _setNames(self, assignments, oldIdentifiers=None):
         pass
 
     @abstractmethod

--- a/tests/tune/testTopLevel.py
+++ b/tests/tune/testTopLevel.py
@@ -229,7 +229,7 @@ def test_Tuning_tune():
 
     bfLogo = Tuning(selection="bruteforce", validation="leaveonegroupout",
                     foldFeature="groups")
-    X.features.setName(2, "groups", useLog=False)
+    X.features.setNames("groups", oldIdentifiers=2, useLog=False)
     bfLogo.tune("nimble.KNNClassifier", X, Y, {}, fractionIncorrect, None,
                 False)
     assert bfLogo._selector is BruteForce


### PR DESCRIPTION

The function `setNames()` has been modified to include the functionality of `setName()` as well as taking care of feature/point name setting cases where new name assignments are more than one but not the full list of the axis. 

At this moment,  `setName()` and its associated tests still remain in the code base. 

This is merely a checkpoint, the next steps are:
- Replace all uses of setName() with setNames()
-  Remove all setNames() tests 
- Add new / modify existing tests for the new functionality of setNames()   