### PR TITLE
Small followup corrections related to the removal of setName

### DIFF
--- a/nimble/core/data/features.py
+++ b/nimble/core/data/features.py
@@ -136,8 +136,9 @@ class Features(ABC):
               {name:index}
             * None - remove names from this object.
         oldIdentifiers : str, int, iterable, None
-            * iterable - The names of features to be renamed.
             * str - The name of a feature to be renamed.
+            * int - The index of a feature to be renamed.
+            * iterable - The names or indices of features to be renamed.
             * None - The default when assigning names to all features in the
               data.
         useLog : bool, None

--- a/nimble/core/data/points.py
+++ b/nimble/core/data/points.py
@@ -129,8 +129,9 @@ class Points(ABC):
               {name:index}
             * None - remove names from this object.
         oldIdentifiers : str, int, iterable, None
-            * iterable - The names of points to be renamed.
             * str - The name of a point to be renamed.
+            * int - The index of a point to be renamed
+            * iterable - The names or indices of points to be renamed.
             * None - The default when assigning names to all points in the
               data.
         useLog : bool, None

--- a/tests/logger/testLoggingCount.py
+++ b/tests/logger/testLoggingCount.py
@@ -140,7 +140,7 @@ base_tested = list(map(prefixAdder('Base'), base_funcs))
 features_logged = [
     'append', 'calculate', 'copy', 'delete', 'extract', 'fillMatching',
     'insert', 'matching', 'normalize', 'permute', 'repeat','replace', 'report',
-    'retain', 'setName', 'setNames', 'sort', 'transform', 'splitByParsing',
+    'retain', 'setNames', 'sort', 'transform', 'splitByParsing',
     ]
 features_notLogged = [
     'count', 'getIndex', 'getIndices', 'getName', 'getNames', 'hasName',
@@ -153,7 +153,7 @@ features_tested = list(map(prefixAdder('Features'), features_funcs))
 points_logged = [
     'append', 'calculate', 'copy', 'delete', 'extract', 'fillMatching',
     'insert', 'mapReduce', 'matching', 'permute', 'repeat', 'replace',
-    'retain', 'setName', 'setNames', 'sort', 'transform',
+    'retain', 'setNames', 'sort', 'transform',
     'combineByExpandingFeatures', 'splitByCollapsingFeatures',
     ]
 points_notLogged = [
@@ -183,7 +183,14 @@ USER_FACING_TESTED = (nimble_tested + calculate_tested + exceptions_tested
 ##############
 
 def testAllUserFacingLoggingTested():
-    """Ensure that all user facing functions are tested for logging"""
+    """
+    Ensure that all user facing functions are tested for logging.
+
+    Checks consistency by a hand maintained list of methods the developers
+    have confirmed are tested for the presence of absence of logging side
+    effects against a list of user accessible methods that has been
+    programatically generated.
+    """
     if not sorted(USER_FACING_TESTED) == sorted(ALL_USER_FACING):
         missing = [f for f in ALL_USER_FACING if f not in USER_FACING_TESTED]
         removed = [f for f in USER_FACING_TESTED if f not in ALL_USER_FACING]

--- a/tests/logger/testLoggingIO.py
+++ b/tests/logger/testLoggingIO.py
@@ -665,18 +665,6 @@ def testPrepTypeFunctionsUseLog():
     checkLogContents('points.combineByExpandingFeatures', dataObj.logID,
                      {'featureWithFeatureNames': 'dist', 'featuresWithValues': 'time'})
 
-    # # points.setName
-    # dataObj = nimble.data(data, returnType='Matrix', useLog=False)
-    # dataObj.points.setNames('newPtName', oldIdentifiers=0)
-    # checkLogContents('points.setNames', dataObj.logID, {'oldIdentifiers': 0,
-    #                                               'assignments': 'newPtName'})
-
-    # # features.setName
-    # dataObj = nimble.data(data, returnType='Matrix', useLog=False)
-    # dataObj.features.setNames('newFtName', oldIdentifiers=0)
-    # checkLogContents('features.setNames', dataObj.logID, {'oldIdentifiers': 0,
-    #                                                 'assignments': 'newFtName'})
-
     # points.setNames
     dataObj = nimble.data(data, returnType='Matrix', useLog=False)
     newPtNames = ['point' + str(i) for i in range(18)]


### PR DESCRIPTION
* Addition and reordering of docstring for 'oldIdentifiers'
* Correct testLoggingCount test failure (see expanded docstring)
* Removal of commented testLoggingIO setName tests