### PR TITLE
Deprecated iteritems() replaced by items()

### DIFF
--- a/nimble/_utility.py
+++ b/nimble/_utility.py
@@ -341,7 +341,7 @@ def pandasDataFrameToList(pdDataFrame):
     """
     Transform a pandas DataFrame into a 2D list.
     """
-    return list(map(list, zip(*(col for _, col in pdDataFrame.iteritems()))))
+    return list(map(list, zip(*(col for _, col in pdDataFrame.items()))))
 
 def removeDuplicatesNative(cooObj):
     """

--- a/nimble/core/_createHelpers.py
+++ b/nimble/core/_createHelpers.py
@@ -928,7 +928,7 @@ def elementTypeConvert(data, convertToType):
                     data.data[colMask] = feature
                 data.data[colMask] = data.data[colMask].astype(convType)
         elif _isPandasDataFrame(data):
-            for i, (idx, ft) in enumerate(data.iteritems()):
+            for i, (idx, ft) in enumerate(data.items()):
                 convType = convertToType[i]
                 if convType is None:
                     continue

--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -274,7 +274,7 @@ class Base(ABC):
         Keywords
         --------
         columns, variables, dimensions, attributes, predictors, iterate,
-        iteritems
+        items
         """
         return self._features
 

--- a/nimble/core/data/dataframe.py
+++ b/nimble/core/data/dataframe.py
@@ -555,7 +555,7 @@ class DataFrame(Base):
             if len(self._data.dtypes) != len(tuple(dtypes)):
                 msg = 'A dtype must be specified for each feature'
                 raise InvalidArgumentValue(msg)
-            for (i, col), dtype in zip(self._data.iteritems(), dtypes):
+            for (i, col), dtype in zip(self._data.items(), dtypes):
                 if col.dtype !=  dtype:
                     self._data[i] = col.astype(dtype)
 

--- a/nimble/core/data/dataframeAxis.py
+++ b/nimble/core/data/dataframeAxis.py
@@ -110,14 +110,14 @@ class DataFrameAxis(Axis, metaclass=ABCMeta):
     def _repeat_implementation(self, totalCopies, copyVectorByVector):
         repeated = {}
         if self._isPoint:
-            for i, series in self._base._data.iteritems():
+            for i, series in self._base._data.items():
                 if copyVectorByVector:
                     repeated[i] = np.repeat(series, totalCopies)
                 else:
                     repeated[i] = np.tile(series, totalCopies)
             ret = pd.DataFrame(repeated).reset_index(drop=True)
         else:
-            for i, series in self._base._data.iteritems():
+            for i, series in self._base._data.items():
                 if copyVectorByVector:
                     for idx in range(totalCopies):
                         repeated[i * totalCopies + idx] = series
@@ -214,7 +214,7 @@ class DataFramePoints(DataFrameAxis, Points):
 
     def _combineByExpandingFeatures_implementation(
         self, uniqueDict, namesIdx, valuesIdx, uniqueNames, numRetFeatures):
-        uncombined = [dtype for i, dtype in self._base._data.dtypes.iteritems()
+        uncombined = [dtype for i, dtype in self._base._data.dtypes.items()
                       if i not in valuesIdx + [namesIdx]]
         combined = list(self._base._data.dtypes.iloc[valuesIdx])
         dtypes = (uncombined[:namesIdx]
@@ -227,7 +227,7 @@ class DataFramePoints(DataFrameAxis, Points):
 
         self._base._data = pd.DataFrame(tmpData)
         if tuple(self._base._data.dtypes) != tuple(dtypes):
-            for (i, col), dtype in zip(self._base._data.iteritems(), dtypes):
+            for (i, col), dtype in zip(self._base._data.items(), dtypes):
                 if col.dtype !=  dtype:
                     self._base._data[i] = col.astype(dtype)
 

--- a/nimble/core/interfaces/autoimpute_interface.py
+++ b/nimble/core/interfaces/autoimpute_interface.py
@@ -119,7 +119,7 @@ To install autoimpute
                              arguments, customDict):
 
         def dtypeConvert(dataframe):
-            for idx, ser in dataframe.iteritems():
+            for idx, ser in dataframe.items():
                 try:
                     dataframe.loc[:, idx] = ser.astype(float)
                 except ValueError:


### PR DESCRIPTION
Here the use of now deprecated pandas function `df.iteritems()` has been replaced by `df.items()`. 