### PR TITLE
Fix to remove randomness from layer creation in keras test

### DIFF
--- a/tests/interfaces/keras_interface_test.py
+++ b/tests/interfaces/keras_interface_test.py
@@ -285,8 +285,8 @@ def testKerasAPIRegression():
 
     layer0 = nimble.Init('Dense', units=16, kernel_initializer="zeros")
     layer0Raw = Dense(units=16, kernel_initializer="zeros")
-    layer1 = nimble.Init('Dense', units=1)
-    layer1Raw = Dense(units=1)
+    layer1 = nimble.Init('Dense', units=1, kernel_initializer="zeros")
+    layer1Raw = Dense(units=1, kernel_initializer="zeros")
     layers = [layer0, layer1]
     layersRaw = [layer0Raw, layer1Raw]
 


### PR DESCRIPTION
There is an upcoming fix for regaining general control over random initialization, which will fix the error in testKerasReproducibility, but that change won't affect the requirement of keeping consistency between the in-nimble layers and the raw layers we're checking against in this test.