### PR TITLE
Keras reproducibility general fix

### DIFF
--- a/nimble/core/interfaces/_interface_helpers.py
+++ b/nimble/core/interfaces/_interface_helpers.py
@@ -164,8 +164,11 @@ def checkClassificationStrategy(interface, learnerName, trainArgs, scoreArgs,
         tlObj = interface.train(learnerName, xObj, yObj, arguments=trainArgs,
                                 randomSeed=seed)
         applyResults = tlObj.apply(testObj, arguments=scoreArgs, useLog=False)
-        (_, _, testTrans, _) = interface._inputTransformation(
-        learnerName, None, None, testObj, trainArgs, tlObj._customDict)
+
+        transformer = interface._inputTransformation
+        (_, _, testTrans, _) =  transformer(learnerName, None, None, testObj,
+                                            None, trainArgs, tlObj._customDict)
+
         rawScores = interface._getScores(tlObj.learnerName, tlObj._backend,
                                          testTrans, scoreArgs,
                                          tlObj._transformedArguments,

--- a/nimble/core/interfaces/autoimpute_interface.py
+++ b/nimble/core/interfaces/autoimpute_interface.py
@@ -131,7 +131,7 @@ To install autoimpute
         return self._searcher.findInPackage(None, name)
 
     def _inputTransformation(self, learnerName, trainX, trainY, testX,
-                             arguments, customDict):
+                             randomSeed, arguments, customDict):
 
         def dtypeConvert(dataframe):
             for idx, ser in dataframe.items():

--- a/nimble/core/interfaces/custom_learner.py
+++ b/nimble/core/interfaces/custom_learner.py
@@ -119,7 +119,7 @@ class CustomLearnerInterface(UniversalInterface):
         raise InvalidArgumentValue(msg)
 
     def _inputTransformation(self, learnerName, trainX, trainY, testX,
-                             arguments, customDict):
+                             randomSeed, arguments, customDict):
         retArgs = None
         if arguments is not None:
             retArgs = copy.copy(arguments)

--- a/nimble/core/interfaces/scikit_learn_interface.py
+++ b/nimble/core/interfaces/scikit_learn_interface.py
@@ -340,7 +340,7 @@ class _SciKitLearnAPI(PredefinedInterfaceMixin):
 
     @abc.abstractmethod
     def _inputTransformation(self, learnerName, trainX, trainY, testX,
-                             arguments, customDict):
+                             randomSeed, arguments, customDict):
         pass
 
     @abc.abstractmethod
@@ -480,7 +480,7 @@ To install scikit-learn
             return None
 
     def _inputTransformation(self, learnerName, trainX, trainY, testX,
-                             arguments, customDict):
+                             randomSeed, arguments, customDict):
 
         mustCopyTrainX = ['PLSRegression']
         if trainX is not None:

--- a/tests/interfaces/keras_interface_test.py
+++ b/tests/interfaces/keras_interface_test.py
@@ -12,6 +12,7 @@ import pytest
 import sys
 import os
 import PIL
+import datetime
 
 import nimble
 from nimble.core.interfaces.keras_interface import Keras
@@ -499,11 +500,11 @@ def testKerasReproducibility(optimizer):
         layer1 = nimble.Init('Dropout', rate=0.5)
         layer2 = nimble.Init('Dense', units=numClasses, activation='sigmoid')
         layers = [layer0, layer1, layer2]
-        mym = nimble.train('keras.Sequential', trainX=x_train, trainY=y_train, optimizer=optimizer,
+        mym1 = nimble.train('keras.Sequential', trainX=x_train, trainY=y_train, optimizer=optimizer,
                            layers=layers, loss='sparse_categorical_crossentropy', metrics=['accuracy'],
                            epochs=20, batch_size=128, useLog=False)
 
-        applied1 = mym.apply(testX=x_train, useLog=False)
+        applied1 = mym1.apply(testX=x_train, useLog=False)
 
 
         nimble.random.setSeed(1234, useLog=False)
@@ -511,11 +512,11 @@ def testKerasReproducibility(optimizer):
         layer1 = nimble.Init('Dropout', rate=0.5)
         layer2 = nimble.Init('Dense', units=numClasses, activation='sigmoid')
         layers = [layer0, layer1, layer2]
-        mym = nimble.train('keras.Sequential', trainX=x_train, trainY=y_train, optimizer=optimizer,
+        mym2 = nimble.train('keras.Sequential', trainX=x_train, trainY=y_train, optimizer=optimizer,
                            layers=layers, loss='sparse_categorical_crossentropy', metrics=['accuracy'],
                            epochs=20, batch_size=128, useLog=False)
 
-        applied2 = mym.apply(testX=x_train, useLog=False)
+        applied2 = mym2.apply(testX=x_train, useLog=False)
 
         assert applied1 == applied2
 

--- a/tests/interfaces/universal_integration_test.py
+++ b/tests/interfaces/universal_integration_test.py
@@ -75,7 +75,7 @@ def test__getScoresFormat():
                             continue
                         raise VE
                     (transTrainX, _, transTestX, _) = interface._inputTransformation(
-                        lName, trainX, None, testX, {}, tl._customDict)
+                        lName, trainX, None, testX, 42, {}, tl._customDict)
                     try:
                         scores = interface._getScores(
                             lName, tl._backend, transTestX, {},

--- a/tests/interfaces/universal_test.py
+++ b/tests/interfaces/universal_test.py
@@ -99,7 +99,7 @@ class TestPredefinedInterface(PredefinedInterfaceMixin):
     def getCanonicalName(cls):
         return "Test"
 
-    def _inputTransformation(self, learnerName, trainX, trainY, testX, arguments, customDict):
+    def _inputTransformation(self, learnerName, trainX, trainY, testX, randomSeed, arguments, customDict):
         return (trainX, trainY, testX, arguments)
 
     def _outputTransformation(self, learnerName, outputValue, transformedInputs, outputType, outputFormat, customDict):
@@ -316,7 +316,7 @@ class AlwaysWarnInterface(UniversalInterface):
     def getCanonicalName(cls):
         return "AlwaysWarn"
 
-    def _inputTransformation(self, learnerName, trainX, trainY, testX, arguments, customDict):
+    def _inputTransformation(self, learnerName, trainX, trainY, testX, randomSeed, arguments, customDict):
         self.issueWarnings()
         return (trainX, trainY, testX, arguments)
 


### PR DESCRIPTION
Extends the keras interface so that it will construct parameter subobjects in such a way that the seed for that learner call can be passed in during object initialization.
    
_inputTransformation was changed for all interfaces so that it is aware of the learner call's seed. In keras, that is then passed down into a specialized helper that looks through the potential sub-objects of each provided argument to see if it is referring to something that takes a seed (currently only Initializer objects), and if so, provides it and generates the specified object. Some tests have been modified to avoid the issue entirely as well.

This should take care of the test failures in the keras test file, and not introduce any further outside of it.

There are some known downsides to this particular implementation that will require further work:
- every initializer is using the same seed, so there will be no bias or weight randomness across layers
- the logger displays the in-keras constructed object in the train log, instead of what would be needed to specify it again by the user.