### PR TITLE
Fixes for failures in testLoggingFlags.py

### DIFF
--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -4287,7 +4287,6 @@ class Base(ABC):
 
     def _genericMergeFrontend(self, other, point, feature, onFeature):
         # validation
-
         bothPtNamesCreated = (self.points._namesCreated()
                               and other.points._namesCreated())
         if onFeature is None and not bothPtNamesCreated:

--- a/nimble/core/data/sparse.py
+++ b/nimble/core/data/sparse.py
@@ -594,8 +594,6 @@ class Sparse(Base):
 
     def _merge_implementation(self, other, point, feature, onFeature,
                               matchingFtIdx):
-        #import pdb; pdb.set_trace()
-
         self._sortInternal('feature')
         other._sortInternal('feature')
         tempFtsL = len(self.features)

--- a/tests/logger/testLoggingFlags.py
+++ b/tests/logger/testLoggingFlags.py
@@ -2,7 +2,6 @@
 Group of tests which checks that use controlled local and global
 mechanisms for controlling logging are functioning as expected.
 """
-from functools import wraps, partial
 
 import tempfile
 
@@ -105,7 +104,6 @@ def runAndCheck(toCall, useLog):
 
 def backend(toCall, validator, **kwargs):
     # for each combination of local and global, call and check
-    # import pdb; pdb.set_trace()
     nimble.settings.set('logger', 'enabledByDefault', 'True')
 
     (start, end) = validator(toCall, useLog=True, **kwargs)
@@ -288,11 +286,9 @@ def test_Deep_trainAndTestOnTrainingData_CVError():
     backendDeep(wrapped, runAndCheck)
 
 def prepAndCheck(toCall, constructor, useLog):
-
     data = [[12, 1, 1], [12, 1, 1], [12, 1, 1], [12, 1, 1], [12, 1, 1], [12, 1, 1],
-        [23, 2, 2], [23, 2, 2], [23, 2, 2], [23, 2, 2], [23, 2, 2], [23, 2, 2],
-        [34, 3, 3], [34, 3, 3], [34, 3, 3], [34, 3, 3], [34, 3, 3], [34, 3, 3]]
-    
+            [23, 2, 2], [23, 2, 2], [23, 2, 2], [23, 2, 2], [23, 2, 2], [23, 2, 2],
+            [34, 3, 3], [34, 3, 3], [34, 3, 3], [34, 3, 3], [34, 3, 3], [34, 3, 3]]
     pNames = ['p' + str(i) for i in range(18)]
     fNames = ['f0', 'f1', 'f2']
     # nimble.data not logged
@@ -423,7 +419,6 @@ def test_merge():
 
     for constructor in nonViewConstructors:
         backend(wrapped, prepAndCheck, constructor=constructor)
-
 
 def test_transformElements():
     def wrapped(obj, useLog):


### PR DESCRIPTION
Fixes failures from the change in Scipy updates that make our Sparse data objects invalid if built on a numpy dtype=object array. A mix of editing the data in some tests and explicitly adjusting the implementation of a few structural methods like merge and insert in the Sparse/SparseAxis files. 

Tests for `features.SplitByParsing` and `points.splitByCollapsingFeatures ` were interesting, I have bypassed sparse constructors for them. It appears they probably never should be used for Sparse data because of they are geared towards ordering/manipulating the presentation of string information. 