### PR TITLE
Remove environment setting during gh-pages deploy

### DIFF
--- a/.github/workflows/deploySite.yml
+++ b/.github/workflows/deploySite.yml
@@ -20,12 +20,6 @@ jobs:
       contents: read
       pages: write
       id-token: write
-    # This was part of the boilerplate, in order to work within an established
-    # environment for deployment protection stuff. Included for best practices
-    # but as far as I can tell, not really relevant to us currently?
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
There are some out of the box branch protection things that are causing issues with our current workflow setup. Since they don't seem applicable to what we're doing, we can just avoid the problem by avoiding a deployment environment.