### PR TITLE
Preperation and corrects for version 0.4.3

### DIFF
--- a/.github/workflows/buildSite.yml
+++ b/.github/workflows/buildSite.yml
@@ -43,6 +43,13 @@ jobs:
       - name: install dependency for wheel manipulation
         run: pip install wheel
 
+      - name: validate wheel presence
+        # test -z checks if the input is a zero length string.
+        # The results of the find operation are packed into a string;
+        # if not wheels are found, abort this action so we don't
+        # build and deploy an empty site.
+        run: if test -z "$(find . -maxdepth 1 -name "*.whl")"; then exit 1; fi
+
       - name: remove source scripts for all wheels
         # small bash loop to run the script for each file that satisfies
         # the glob

--- a/.github/workflows/buildWheels.yml
+++ b/.github/workflows/buildWheels.yml
@@ -15,23 +15,19 @@ on:
       saveName:
         required: true
         type: string
-  workflow_dispatch:
-    inputs:
-      # The name of the artifact to be saved
-      saveName:
-        required: true
-        type: string
 
 jobs:
   build_wheels:
-    name: Build wheels on ${{ matrix.os}}
+    name: ${{ matrix.pyVer}} for ${{ matrix.os}}
     # This will automatically split off concurrent jobs running-on each value
     runs-on: ${{ matrix.os}}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-#        os: [ubuntu-latest]
-
+        os: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        #os: ["ubuntu-latest"]
+        pyVer: ["cp3*"]
+        #pyVer: ["cp3*", "cp39", "cp310", "cp311"]
+        #pyVer: ["cp310"]
 
     steps:
       - uses: actions/checkout@v3
@@ -51,10 +47,13 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.14.1
         # Allows us to specify cibuildwheel specific environment variables.
-        # Included in the comment was something helpful to limit the build
-        # output during trialing.
-#        env:
-#          CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9, <3.10"
+        env:
+          # Using the input to specifify the matrix, we will either build all
+          # python versions for this OS sequentially (default), or build
+          # the specified versions in parallel. Can also be used to limit o
+          # only a specific version
+          CIBW_BUILD: ${{ matrix.pyVer}}-*
+          #CIBW_PROJECT_REQUIRES_PYTHON: ">=3.9, <3.11"
         with:
           output-dir: wheelhouse
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,14 +8,16 @@ on:
 
 jobs:
   build-wheels:
-#    uses: ./.github/workflows/dummy_buildWheels.yml
     uses: ./.github/workflows/buildWheels.yml
     with:
       saveName: built_wheels
 
   build-site:
-    uses: ./.github/workflows/buildSite.yml
+    # try to build the site regardless of how much of the previous job
+    # matrix completed. There are additional sanity checks within.
+    if: ${{ always() }}
     needs: [build-wheels]
+    uses: ./.github/workflows/buildSite.yml
     with:
       saveName: built_wheels
 

--- a/documentation/add_wheels_install.py
+++ b/documentation/add_wheels_install.py
@@ -39,7 +39,7 @@ def rowsPerOS(osName, wheelNames):
     # the span to combine to one cell in the OS column,
     # but only if it is actually spanning multiple lines
     ret = "  * - "
-    if spanNum > 1:
+    if spanNum > 0:
         ret += f":rspan:`{spanNum}` "
     ret += f"{osName}\n"
 
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     targets = map(lambda x: x.parts[-1], targets)
     targets = map(os.fspath, targets)
 
-    # wheel names in the form: "nimble-version-pyVersion-pyVersion-os_arch.whl"
+    # wheel names in the form: "nimble-version-pyTag-pyABITag-os_arch.whl"
     # So first we sort by the python version, then they are partitioned into
     # lists per each OS
     verSorted = sorted(targets, key=lambda x: int(x.split('-')[2][2:]))
@@ -99,9 +99,10 @@ if __name__ == "__main__":
     # name given within the file name.
     #
     # dict.get used to accomodate cases where we have more or less
-    # key values than expected; but as of this comment, the three
+    # key values than expected; but as of this comment, the four
     # given should cover all built wheels.
-    displayName = {'linux':"Linux", "macosx":"MacOS", "win":"Windows"}
+    displayName = {'manylinux':"Linux", "manylinux2014":"Linux",
+                   "linux":"Linux", "macosx":"MacOS", "win":"Windows"}
     for key, val in byOS.items():
         toWrite += rowsPerOS(displayName.get(key, key), val)
 

--- a/documentation/source/wheels/.gitignore
+++ b/documentation/source/wheels/.gitignore
@@ -1,0 +1,8 @@
+# We want this folder to be present since it is the location
+# hard coded for wheel storage in CI/CD, but we don't want to
+# include any files here in the repo because they are supposed
+# to be generated.
+#
+# We accomplish this by ignoring all files except this one.
+*
+!.gitignore

--- a/nimble/__init__.py
+++ b/nimble/__init__.py
@@ -70,4 +70,4 @@ core.logger.initLoggerAndLogConfig()
 
 __all__ = _setAll(vars(), includeModules=True, ignore=['core'])
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,10 +106,6 @@ version = {attr = "nimble.__version__"}
 # No 32 bit builds, no pypy builds, no musl linux builds
 skip = ["*-win32", "*-manylinux_i686", "pp*", "*-musllinux_*"]
 
-[tool.cibuildwheel.macos]
-# make sure mac wheels include capability to install on arm
-archs = ["universal2"]
-
 # script to remove .py and .c files from wheel
 #repair-wheel-command = "python remove_source.py {dest_dir} {wheel}"
 # we don't want the extra bundling to occur via auditwheel / delocate
@@ -120,3 +116,6 @@ repair-wheel-command = ""
 #test-extras = ['all']
 #test-command = "pytest {project}/tests/landingPage || true"
 
+[tool.cibuildwheel.macos]
+# make sure mac wheels include capability to install on arm
+archs = ["universal2"]


### PR DESCRIPTION
Critical corrections:
- add a .gitignore file in documentation/source/wheels in order to ensure that this fixed location used in Github Actions is present in the repo. Without containing any file, it was missing when bash commands expected it to already be present.
- correct the placement of the universal arch tag for macos so that it isn't accidentally redefining the section of the repair-wheel-command.

Other improvements:
- change to allow building the site even if all prior jobs don't complete.
- check before building the site to ensure that at least some prior job successfully produced a wheel.
- change to buildWheels.yml to include finer control of which and how wheels are built. Can specify all platforms and version tags, or limit those to specific ones. And depending on how the python tag is specified, the wheels for a platform will be built sequentially or in parallel (if you need a change to the website in 20 minutes instead of 90)
- correct bug so that table spanning for the wheel downloads works as desired for the case of two wheels for an OS.
- future proof table names to include manylinux tags.

