### PR TITLE
Remove pytest dependency from nimble

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -15,13 +15,11 @@ requirements:
     - numpy>=1.14
     - packaging>=20.0
     - tomli
-    - pytest
   run:
     - python {{ python }}
     - numpy>=1.14
     - packaging>=20.0
     - tomli
-    - pytest
 
 outputs:
   - name: nimble

--- a/conftest.py
+++ b/conftest.py
@@ -34,21 +34,6 @@ def addNimble(doctest_namespace):
     """
     doctest_namespace["nimble"] = nimble
 
-@pytest.fixture
-def tmpDataToFileFixture():
-    """
-    Used for doctests which write out a file in the cwd. This will change
-    the cwd temporarily so that this doctest will not polute the filesystem
-    """
-    backupCWD = os.getcwd()
-    with tempfile.TemporaryDirectory() as tmpdirForCSV:
-        try:
-            os.chdir(tmpdirForCSV)
-            yield
-        finally:
-            os.chdir(backupCWD)
-
-
 class DictSessionConfig(SessionConfiguration):
     """
     Use a dictionary instead of configuration file for config settings.

--- a/nimble/core/create.py
+++ b/nimble/core/create.py
@@ -3,7 +3,6 @@ Module the user-facing data creation functions for the top level
 nimble import.
 """
 import numpy as np
-import pytest
 
 import nimble
 from nimble.exceptions import InvalidArgumentType, InvalidArgumentValue
@@ -19,8 +18,6 @@ from nimble.core._createHelpers import looksFileLike
 from nimble.core._createHelpers import fileFetcher
 from nimble.core._createHelpers import DEFAULT_MISSING
 
-
-@pytest.mark.usefixtures('tmpDataToFileFixture')
 def data(source, pointNames='automatic', featureNames='automatic',
          returnType=None, name=None, convertToType=None, keepPoints='all',
          keepFeatures='all', treatAsMissing=DEFAULT_MISSING,


### PR DESCRIPTION
The nimble.data doctest will still write a file into the working directory that the tests are run in, but the previous fixture seemingly wasn't preventing that anyways.