### PR TITLE
Corrections to tests relating to decorator status for new methods / tests

### DIFF
--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -5801,9 +5801,6 @@ class Base(ABC):
         """
         return nimble.calculate.proportionZero(self._vectorize())
     
-    def count(self):
-        return nimble.calculate.count(self._vectorize())
-    
     def mode(self):
         return nimble.calculate.mode(self._vectorize())
     

--- a/tests/data/high_dimension_backend.py
+++ b/tests/data/high_dimension_backend.py
@@ -703,7 +703,8 @@ class HighDimensionModifyingSparseSafe(DataTestObject):
             'checkInvariants', 'containsZero', 'save', 'toString', 'show',
             'copy', 'flatten', 'unflatten',
             'min', 'max', 'mean', 'median', 'uniqueCount',
-            'proportionMissing', 'proportionZero'
+            'proportionMissing', 'proportionZero',
+            'mode', 'quartiles', 'medianAbsoluteDeviation', 'sum', 'variance',
             ))
         baseDisallowed = baseUser.difference(baseAllowed)
 

--- a/tests/logger/testLoggingCount.py
+++ b/tests/logger/testLoggingCount.py
@@ -134,7 +134,8 @@ base_notLogged = [
     'plotFeatureGroupMeans', 'plotFeatureGroupStatistics', 'pointView',
     'save', 'show', 'solveLinearSystem', 'toString', 'checkInvariants', 'view',
     'max', 'min', 'mean', 'median', 'uniqueCount', 'proportionMissing',
-    'proportionZero'
+    'proportionZero',
+    'mode', 'medianAbsoluteDeviation', 'variance', 'sum', 'quartiles',
     ]
 base_funcs = base_logged + base_notLogged
 base_tested = list(map(prefixAdder('Base'), base_funcs))
@@ -148,7 +149,8 @@ features_notLogged = [
     'count', 'getIndex', 'getIndices', 'getName', 'getNames', 'hasName',
     'plot', 'plotMeans', 'plotStatistics', 'similarities', 'statistics',
     'unique', 'max', 'min', 'mean', 'median', 'uniqueCount', 'proportionMissing',
-    'proportionZero', 'standardDeviation', 'populationStandardDeviation'
+    'proportionZero', 'standardDeviation', 'populationStandardDeviation',
+    'mode', 'medianAbsoluteDeviation', 'variance', 'sum', 'quartiles',
     ]
 features_funcs = features_logged + features_notLogged
 features_tested = list(map(prefixAdder('Features'), features_funcs))
@@ -163,7 +165,8 @@ points_notLogged = [
     'count', 'getIndex', 'getIndices', 'getName', 'getNames', 'hasName',
     'plot', 'plotMeans', 'plotStatistics', 'similarities', 'statistics',
     'unique', 'max', 'min', 'mean', 'median', 'uniqueCount', 'proportionMissing',
-    'proportionZero', 'standardDeviation', 'populationStandardDeviation'
+    'proportionZero', 'standardDeviation', 'populationStandardDeviation',
+    'mode', 'medianAbsoluteDeviation', 'variance', 'sum', 'quartiles',
     ]
 points_funcs = points_logged + points_notLogged
 points_tested = list(map(prefixAdder('Points'), points_funcs))


### PR DESCRIPTION
The added stats methods are listed as not logged in testLoggingCount, and the tests are already decorated accordingly. They are also, for Base, listed as being multi-dimensional allowed, while for points and features they are already decorated as limited to 2d.
The count method was removed from Base as per previous discussion.

I am seeing a handful of other test failures on this branch in certain environments, but they all seem related to things unrelated to these changes; possibly from something else already on dev.