### PR TITLE
Correct easy warnings in pytest output + py3.8 import error

### DIFF
--- a/nimble/_dependencies.py
+++ b/nimble/_dependencies.py
@@ -4,7 +4,7 @@ Store dependency versions requirements.
 Also includes helpers for validating optional dependency versions at
 runtime.
 """
-import importlib
+import importlib.metadata
 import tomli
 import os
 import inspect

--- a/nimble/core/interfaces/scikit_learn_interface.py
+++ b/nimble/core/interfaces/scikit_learn_interface.py
@@ -371,12 +371,13 @@ class SciKitLearn(_SciKitLearnAPI):
         def mockWalkPackages(*args, **kwargs):
             packages = walkPackages(*args, **kwargs)
             ret = []
-            # ignore anything that imports libraries that are not installed
-            # each pkg is a tuple (importer, moduleName, isPackage)
+            # ignore anything that imports libraries that are not installed,
+            # test modules, and experimental modules.
             for pkg in packages:
+                # each pkg is a tuple (importer, moduleName, isPackage)
                 module = pkg[1]
                 # no need to search tests and can fail in unexpected ways
-                if 'tests' in module.split('.'):
+                if 'tests' in module or 'experimental' in module:
                     continue
                 try:
                     _ = importlib.import_module(module)

--- a/nimble/random/randomness.py
+++ b/nimble/random/randomness.py
@@ -185,7 +185,7 @@ def data(numPoints, numFeatures, sparsity, pointNames='automatic',
                 # The feature value is determined by counting the offset from
                 # each point edge.
                 featureIndices = nzLocation % numFeatures
-                randData = scipy.sparse.coo.coo_matrix(
+                randData = scipy.sparse.coo_matrix(
                     (dataVector, (pointIndices, featureIndices)),
                     (numPoints, numFeatures))
             else:

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,7 @@ python_files = test*.py *test.py *Test.py *tests.py *Tests.py
 addopts = --doctest-modules
 norecursedirs = documentation
 testpaths = nimble tests
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+filterwarnings =
+    ignore: .*matrix subclass.*:PendingDeprecationWarning

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -1357,7 +1357,7 @@ class QueryBackendSparseSafe(DataTestObject):
             retSplit = ret.split('\n')[:-1]
             sepRow = int((mh - 2) / 2) + 2
             assert len(retSplit) == mh
-            rowSepPattern = re.compile(u'[\s\u2502] +')
+            rowSepPattern = re.compile(u'[\\s\u2502] +')
             assert re.match(rowSepPattern, retSplit[sepRow])
         # height 11 can accommodate all data
         # 2 header lines, 8 data lines, 1 blankline
@@ -1578,8 +1578,8 @@ class QueryBackendSparseSafe(DataTestObject):
                 assert defaults == 'all' # validates defaults value
                 assert name in fNames
 
-        assert re.match(u'\s*\u250C\u2500+$', retSplit[2])
-        dataMatch = re.compile(u"( +| +[0-9]+| +'[pf]t[0-9]+'| +\u2502) \u2502($| [-0-9\. \u2502\u2500]+)")
+        assert re.match(u'\\s*\u250C\u2500+$', retSplit[2])
+        dataMatch = re.compile(u"( +| +[0-9]+| +'[pf]t[0-9]+'| +\u2502) \u2502($| [-0-9\\. \u2502\u2500]+)")
         for line in retSplit[3:-1]:
             assert re.match(dataMatch, line)
             pName = line.split(u'\u2502')[0].strip()
@@ -1606,7 +1606,7 @@ class QueryBackendSparseSafe(DataTestObject):
         else:
             assert retSplit[-1] == '>'
 
-        addIdxMatch = re.compile(u' [ 0-9\u2502]+? \u2502( +\u2502?| +[pf]t[0-9]+) \u2502($| [-0-9\. \u2502\u2500]+)')
+        addIdxMatch = re.compile(u' [ 0-9\u2502]+? \u2502( +\u2502?| +[pf]t[0-9]+) \u2502($| [-0-9\\. \u2502\u2500]+)')
         for axis, length in [(data.points, numPts), (data.features, numFts)]:
             axRepr = repr(axis)
             axSplit = axRepr.split('\n')


### PR DESCRIPTION
1) the `'slow'` mark is now properly registered with pytest
2) the specific `PendingDeprecationWarning` for using np.matrix in testing is now ignored in the test configuration, we can reassess our tests when it is switched to a true `DeprecationWarning`
3) correct pending api change for `scipy.sparse`
4) correct escape sequencing for regex defined in unicode strings; currently it's only a warning, but it will be escalated to error in future python versions
5) avoid a `UserWarning` when searching for learners in SKL by avoiding modules with `'experimental'` in the name (which we didn't want anyways)

The `importlib.metadata` submodule, while available in python 3.8, was sometimes not directly accessible when running the tests. It is now imported explicitly in _dependencies.py