### PR TITLE
 'Not so clear' ValidateAxis Error message.

### DIFF
--- a/tests/data/structure_backend.py
+++ b/tests/data/structure_backend.py
@@ -9308,6 +9308,15 @@ class StructureModifyingSparseSafe(StructureShared):
     ######################
     # points.transform() #
     ######################
+    
+    @raises(InvalidArgumentValue)
+    def test_points_transform_stringReturn(self):
+        orig = self.constructor([[1, 2, 3], [4, 5, 6], [0, 0, 0]])
+        
+        def stringReturn(ft):
+            return "X" * len(ft)
+        
+        orig.points.transform(stringReturn)
 
     @raises(InvalidArgumentType)
     def test_points_transform_exceptionInputNone(self):

--- a/tests/testData.py
+++ b/tests/testData.py
@@ -4628,14 +4628,7 @@ def test_featureNames_assisted_match():
         data.features['rainy-season']
     except KeyError as e:
         assert str(e) == '"The feature name \'rainy-season\' cannot be found. Did you mean \'rainy season\'?"'
-        
-def test_validateAxisMessage():
-    rawData = [[1, 2, 3], [2, 4, 6]]
-    data = nimble.data(rawData)
-    try:
-        data.features.transform()
-    except ValueError as e:
-        assert str(e) == ""
+
 # tests for combination of one name set being specified and one set being
 # in data.
 


### PR DESCRIPTION
PR to make  less vague the error seen in the user trial.  Split error message to have a separate but very similar message for strings and iterables. Also added `points.transform` and `features.transform` tests for the raised error for string returned as per our last conversation.