### PR TITLE
Changes to Points.mapReduce

### DIFF
--- a/nimble/core/data/points.py
+++ b/nimble/core/data/points.py
@@ -1598,9 +1598,11 @@ class Points(ABC):
     def mapReduce(self, mapper, reducer, *,
                   useLog=None): # pylint: disable=unused-argument
         """
-        Apply a mapper and reducer function to the Points in this object.
+        Transforms each point in this object using a specified mapper
+        function and then aggregates the data using the specified reducer
+        function.
 
-        Return a new object containing the results of the given mapper
+        Returns a new object containing the aggregated results of the given mapper
         and reducer functions along the Points axis.
 
         Parameters
@@ -1638,14 +1640,15 @@ class Points(ABC):
         >>> X = nimble.data(travelData, featureNames=fts)
         >>> X
         <DataFrame 5pt x 3ft
-                 'STATE'  'HOURS' 'MPH'
-              ┌─────────────────────────
-            0 │    Iowa   0.500    19
-            1 │ Maryland  1.500    48
-            2 │ Maryland  2.000    40
-            3 │   Texas   3.200    50
-            4 │   Texas   3.000    45
-        >    
+             'STATE'  'HOURS' 'MPH'
+           ┌───────────────────────
+         0 │   Iowa    0.500    19
+         1 │ Maryland  1.500    48
+         2 │ Maryland  2.000    40
+         3 │  Texas    3.200    50
+         4 │  Texas    3.000    45
+        >
+        
         >>> X.points.mapReduce(distanceMapper, distanceReducer)
         <DataFrame 3pt x 2ft
                 0        1


### PR DESCRIPTION
This PR includes strictly doc changes. One change to the text definition of the method for better clarity hopefully. The other change is to the example, I displayed the nimble data object to be transformed before the mapper and reducer are applied. I believe visually seeing the data before and after transformation would help with giving an intuition for what is happening or why someone might want to use this method. 
 