### PR TITLE
Corrections for recent python and dependency versions

### DIFF
--- a/nimble/calculate/utility.py
+++ b/nimble/calculate/utility.py
@@ -472,9 +472,9 @@ def performanceFunction(optimal, best=None, predict=None, validate=True,
     ...
     >>> X = nimble.data([[0, 0], [4, 0], [0, 4], [4, 4]] * 25)
     >>> X += nimble.random.data(100, 2, 0, randomSeed=1) # add noise
-    >>> nimble.trainAndTest('skl.KMeans', averageDistanceToCenter, X,
-    ...                     n_clusters=4, randomSeed=1)
-    1.3493987354974297
+    >>> round(nimble.trainAndTest('skl.KMeans', averageDistanceToCenter, X,
+    ...                     n_clusters=4, randomSeed=1), 6)
+    1.349399
     """
     if optimal not in ['min', 'max']:
         raise InvalidArgumentValue('optimal must be "min" or "max"')

--- a/nimble/core/interfaces/autoimpute_interface.py
+++ b/nimble/core/interfaces/autoimpute_interface.py
@@ -25,7 +25,6 @@ import types
 import logging
 import importlib
 import numpy as np
-from numpy.distutils import system_info as npdusi
 from packaging.version import Version
 
 import nimble
@@ -89,7 +88,9 @@ class Autoimpute(_SciKitLearnAPI):
         # for >= v1.22. Since it causes an attribute error during import,
         # we perform a patch to present the info irrespective of the
         # potential pymc3 version.
-        if Version("1.22") <= Version(np.__version__):
+        npVer = Version(np.__version__)
+        if Version("1.22") <= npVer and npVer < Version("1.26"):
+            from numpy.distutils import system_info as npdusi
             patchValue = npdusi.get_info("blas_opt", 0)
             np.distutils.__config__.blas_opt_info = patchValue
 

--- a/tests/customLearners/custom_learner_test.py
+++ b/tests/customLearners/custom_learner_test.py
@@ -488,10 +488,10 @@ class RandomControl(CustomLearner):
     learnerType = 'undefined'
 
     def train(self, trainX, trainY):
-        self.rand = nimble.random.pythonRandom.randint(0, 1e15)
+        self.rand = nimble.random.pythonRandom.randint(0, int(1e15))
 
     def incrementalTrain(self, trainX, trainY):
-        self.rand = nimble.random.pythonRandom.randint(0, 1e15)
+        self.rand = nimble.random.pythonRandom.randint(0, int(1e15))
 
     def apply(self, testX):
         return [v * self.rand for v in testX]

--- a/tests/interfaces/scikit_learn_interface_test.py
+++ b/tests/interfaces/scikit_learn_interface_test.py
@@ -575,6 +575,10 @@ def testSciKitLearnTransformationLearners():
             # in question, so we use in instead of ==
             target = "fit() missing 1 required positional argument: 'y'"
             assert target in str(TE).lower()
+        except ValueError as VE:
+            # Similar to above, yet the param is provided as None
+            target = "estimator requires y to be passed, but the target y is None"
+            assert target in str(VE)
 
 
 @sklSkipDec


### PR DESCRIPTION
Includes:

- doc adjustment for float handling difference in new version
- avoid `numpy` patching issue given `distutils` deprecation
- explicit int inputs for `randint`
- `sklean` testing robustness modification