### PR TITLE
Distutils removal / setup.py clean command removal

### DIFF
--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        pyVer: ["3.8", "3.9", "3.10", "3.11"]
+        pyVer: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ authors = [
         ]
 description = "Interfaces and tools for data science."
 readme = {file="README.md", content-type="text/markdown"}
-requires-python = ">=3.8, <3.12"
+requires-python = ">=3.8, <=3.12"
 license = {text = "Apache 2.0"}
 classifiers = [
         'Development Status :: 3 - Alpha',
@@ -24,6 +24,7 @@ classifiers = [
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Operating System :: OS Independent',
         'License :: OSI Approved :: Apache Software License',
         ]

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,6 @@ clean - remove setup generated directories and files. By default, clean
 import os
 import glob
 
-from distutils import log
-from distutils.command.clean import clean
-from distutils.dir_util import remove_tree
 from setuptools import setup, Distribution
 from setuptools.extension import Extension
 
@@ -95,23 +92,6 @@ class NimbleDistribution(Distribution):
             # re-init with ext_modules
             super().__init__(attrs)
 
-
-class CleanCommand(clean):
-    """
-    Custom clean command to tidy up the project root.
-    """
-    def run(self):
-        super().run()
-        if self.all:
-            for directory in ['build', 'nimble.egg-info']:
-                if os.path.exists(directory):
-                    remove_tree(directory, dry_run=self.dry_run)
-            for f in getCFiles():
-                if not self.dry_run:
-                    os.remove(f)
-                log.info('removing %s', os.path.relpath(f))
-
-
 class EmptyConfigFile:
     """
     Provide empty configuration.ini file for the distribution.
@@ -143,6 +123,5 @@ class EmptyConfigFile:
 if __name__ == '__main__':
     with EmptyConfigFile():
         setupKwargs = {}
-        setupKwargs['cmdclass'] = {'clean': CleanCommand}
         setupKwargs['distclass'] = NimbleDistribution
         setup(**setupKwargs)


### PR DESCRIPTION
The deprecated distutils will no longer block building the project in python 3.12 and greater. The testing scripts and pyproject.toml have been changed to match.