### PR TITLE
Correct scipy access; enable as dependency for safety

### DIFF
--- a/conda_recipe/meta.yaml
+++ b/conda_recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - numpy>=1.14
     - packaging>=20.0
     - tomli>=2.0
+    - scipy>=1.1
 
 outputs:
   - name: nimble

--- a/nimble/core/_createHelpers.py
+++ b/nimble/core/_createHelpers.py
@@ -1020,7 +1020,7 @@ def _replaceMissingData(rawData, treatAsMissing, replaceMissingWith, copied):
                 rawData = rawData.copy()
                 copied = True
             rawData = replaceNumpyValues(rawData, replaceLocs)
-    elif scipy.sparse.issparse(rawData):
+    elif scipy.nimbleAccessible() and scipy.sparse.issparse(rawData):
         replaceLocs = getNumpyReplaceLocations(rawData.data)
         if replaceLocs.any():
             if not copied:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dynamic = ['version']
 dependencies = [
         'numpy>=1.14',
         'packaging>=20.0',
-        'tomli>=2.0'
+        'tomli>=2.0',
+        'scipy>=1.1'
         ]
 
 


### PR DESCRIPTION
Manual check was successful. A look through some grep results suggested that this was probably if not the only such case in the code, very nearly the only case. Regardless, scipy added as a true dependency until more structured verification can occur.