### PR TITLE
base.calculateFunction speed up for NaN results.

### DIFF
--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -5968,6 +5968,7 @@ class Base(ABC):
         baseVector = self.copy()
         baseVector.flatten(useLog=False)
         return baseVector
+        # return self 
 
     def max(self):
         """
@@ -6001,7 +6002,8 @@ class Base(ABC):
         >>> X.mean()
         9.0
         """
-        return nimble.calculate.mean(self._vectorize())
+        # return nimble.calculate.mean(self._vectorize())
+        return nimble.calculate.mean(self)
 
     def median(self):
         """
@@ -6018,7 +6020,8 @@ class Base(ABC):
         >>> X.median()
         13.5
         """
-        return nimble.calculate.median(self._vectorize())
+        #return nimble.calculate.median(self._vectorize())
+        return nimble.calculate.median(self)
 
     def min(self):
         """

--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -34,6 +34,9 @@ import shutil
 import re
 
 import numpy as np
+import pandas as pd 
+from scipy.sparse import coo_matrix
+
 
 import nimble
 from nimble import match
@@ -86,6 +89,41 @@ def hashCodeFunc(elementValue, pointNum, featureNum):
     Generate hash code.
     """
     return ((math.sin(pointNum) + math.cos(featureNum)) / 2.0) * elementValue
+
+def checkNumericListType(listData):
+    '''
+    Function dedicated to seeing if list of lists that make up
+    base._data contains entirely numeric data or not.
+    '''
+    if isinstance(listData, list):
+      for item in listData:
+        if isinstance(item, list):
+            if not all(isinstance(sub_item, (int, float)) for sub_item in item):
+                return False
+        else:
+            if not isinstance(item, (int, float)):
+                return False
+      return True
+    return False
+
+def isNumeric(base):
+    '''
+    Helper for certain stats methods to know if feature columns contain invalid
+    values.
+    '''
+    def is_numeric_column(column):
+        return pd.api.types.is_numeric_dtype(column)
+
+    if isinstance(base._data, pd.DataFrame):
+        return all(is_numeric_column(column) for column in base._data.dtypes)
+    elif isinstance(base._data, np.ndarray):
+        return np.issubdtype(base._data.dtype, np.number)
+    elif isinstance(base._data, coo_matrix):
+        return base._data.dtype.kind in 'ifc'
+    elif isinstance(base._data, list):
+        return checkNumericListType(base._data)
+    else:
+        raise ValueError("Unsupported data type")
 
 class Base(ABC):
     """
@@ -5968,7 +6006,6 @@ class Base(ABC):
         baseVector = self.copy()
         baseVector.flatten(useLog=False)
         return baseVector
-        # return self 
 
     def max(self):
         """
@@ -5985,6 +6022,9 @@ class Base(ABC):
         >>> X.max()
         22
         """
+        if not isNumeric(self):
+            return(np.nan)   
+        
         return nimble.calculate.maximum(self._vectorize())
 
     def mean(self):
@@ -6002,8 +6042,10 @@ class Base(ABC):
         >>> X.mean()
         9.0
         """
-        # return nimble.calculate.mean(self._vectorize())
-        return nimble.calculate.mean(self)
+        if not isNumeric(self):
+            return(np.nan) 
+        return nimble.calculate.mean(self._vectorize())
+        #return nimble.calculate.mean(self)
 
     def median(self):
         """
@@ -6020,8 +6062,10 @@ class Base(ABC):
         >>> X.median()
         13.5
         """
-        #return nimble.calculate.median(self._vectorize())
-        return nimble.calculate.median(self)
+        if not isNumeric(self):
+            return(np.nan) 
+        return nimble.calculate.median(self._vectorize())
+        #return nimble.calculate.median(self)
 
     def min(self):
         """
@@ -6038,6 +6082,8 @@ class Base(ABC):
         >>> X.min()
         0
         """
+        if not isNumeric(self):
+            return(np.nan) 
         return nimble.calculate.minimum(self._vectorize())
 
     def uniqueCount(self):
@@ -6051,6 +6097,8 @@ class Base(ABC):
         >>> X.uniqueCount()
         5
         """
+        if not isNumeric(self):
+            return(np.nan) 
         return nimble.calculate.uniqueCount(self._vectorize())
 
     def proportionMissing(self):
@@ -6065,6 +6113,8 @@ class Base(ABC):
         >>> X.proportionMissing()
         0.5
         """
+        if not isNumeric(self):
+            return(np.nan) 
         return nimble.calculate.proportionMissing(self._vectorize())
 
     def proportionZero(self):
@@ -6079,6 +6129,8 @@ class Base(ABC):
         >>> X.proportionZero()
         0.5
         """
+        if not isNumeric(self):
+            return(np.nan) 
         return nimble.calculate.proportionZero(self._vectorize())
     
     def mode(self):
@@ -6105,6 +6157,8 @@ class Base(ABC):
         >>> X.sum()
         8
         """
+        if not isNumeric(self):
+            return(np.nan) 
         return nimble.calculate.sum(self._vectorize())
     
     def variance(self):
@@ -6118,6 +6172,8 @@ class Base(ABC):
         >>> X.variance()
         3.866666666666667
         """
+        if not isNumeric(self):
+            return(np.nan) 
         return nimble.calculate.variance(self._vectorize())
     
     def medianAbsoluteDeviation(self):
@@ -6132,6 +6188,8 @@ class Base(ABC):
         >>> X.medianAbsoluteDeviation()
         0.5
         """
+        if not isNumeric(self):
+            return(np.nan) 
         return nimble.calculate.medianAbsoluteDeviation(self._vectorize())
     
     def quartiles(self):
@@ -6146,4 +6204,6 @@ class Base(ABC):
         >>> X.quartiles()
         (0.0, 0.5, 1.75)
         """
+        if not isNumeric(self):
+            return(np.nan) 
         return nimble.calculate.quartiles(self._vectorize())

--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -6115,7 +6115,8 @@ class Base(ABC):
         """
         if not isNumeric(self):
             calcListByFeature = list(self.features.proportionMissing())
-            return sum(calcListByFeature)/len(self.features)
+            propMissing = sum(calcListByFeature)/len(self.features)
+            return round(propMissing, 3)
         return nimble.calculate.proportionMissing(self._vectorize())
 
     def proportionZero(self):
@@ -6132,7 +6133,8 @@ class Base(ABC):
         """
         if not isNumeric(self):
             calcListByFeature = list(self.features.proportionZero())
-            return sum(calcListByFeature)/len(self.features)
+            propZero = sum(calcListByFeature)/len(self.features)
+            return round(propZero, 3)
         return nimble.calculate.proportionZero(self._vectorize())
     
     def mode(self):

--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -6114,7 +6114,8 @@ class Base(ABC):
         0.5
         """
         if not isNumeric(self):
-            return(np.nan) 
+            calcListByFeature = list(self.features.proportionMissing())
+            return sum(calcListByFeature)/len(self.features)
         return nimble.calculate.proportionMissing(self._vectorize())
 
     def proportionZero(self):
@@ -6130,7 +6131,8 @@ class Base(ABC):
         0.5
         """
         if not isNumeric(self):
-            return(np.nan) 
+            calcListByFeature = list(self.features.proportionZero())
+            return sum(calcListByFeature)/len(self.features)
         return nimble.calculate.proportionZero(self._vectorize())
     
     def mode(self):


### PR DESCRIPTION
This takes care of the time delay when `base.calculateFunction() `operation is done. It works by checking if the underlying data structure responsible for the base object  (`base._data`) is entirely numeric or not. If numeric it goes about with the operation that uses vectorize, if not, it doesn't waste time to do that but returns `np.nan`.

The only calculate function that does not have this applied is `base.mode`.

I however wonder if this ought to be necessary for `proportionMissing() `and `proportionZero()`. I believe that both do not need to discriminate object columns, but i might be wrong. I did notice that both also took too long to compute against csv when they handled a combination of numeric and object data. Unfortunately on this machine it seems to go on forever.