### PR TITLE
Removed Printing of Path in base objects.

### DIFF
--- a/nimble/core/create.py
+++ b/nimble/core/create.py
@@ -216,7 +216,7 @@ def data(source, pointNames='automatic', featureNames='automatic',
        ┌────────
      0 │ 1  2  3
      1 │ 4  5  6
-     path=...simpleData.csv>
+    >
 
     Adding point and feature names.
 

--- a/nimble/core/data/base.py
+++ b/nimble/core/data/base.py
@@ -2653,10 +2653,10 @@ class Base(ABC):
         indent = ' '
         # remove leading and trailing newlines
         ret += self._show(indent=indent)
-        if self.path is not None:
-            ret += indent + "path=" + self.path + '>'
-        else:
-            ret += '>'
+        # if self.path is not None:
+        #     ret += indent + "path=" + self.path + '>'
+        # else:
+        ret += '>'
 
         return ret
     def show(self, description=None, points=None, features=None,

--- a/tests/data/query_backend.py
+++ b/tests/data/query_backend.py
@@ -1766,9 +1766,6 @@ class QueryBackendSparseSafe(DataTestObject):
     def test_repr_notTruncated(self):
         self.back_reprOutput(9, 9)
 
-    def test_repr_withPath(self):
-        self.back_reprOutput(9, 9, addPath=True)
-
     def test_repr_truncated(self):
         self.back_reprOutput(40, 20, truncated=True)
 


### PR DESCRIPTION
Base objects created with a path/link will not show that at the bottom when the object is viewed anymore.