### PR TITLE
Prevent pdf cheatsheet cross page break rendering issues

### DIFF
--- a/documentation/source/_static/cheatsheet.css
+++ b/documentation/source/_static/cheatsheet.css
@@ -41,16 +41,19 @@ div.body .new-row {
   margin-bottom: -3px;
   clear: both;
   line-height: 7px;
+  page-break-inside: avoid;
 }
 
 div.body .col {
   float: left;
   margin: 2px;
   padding: 0;
+  page-break-inside: avoid;
 }
 
 div.body .clear {
   clear: both;
+  page-break-inside: avoid;
 }
 
 div.body .text-center {
@@ -65,6 +68,7 @@ div.body .outline {
   border: 1px solid black;
   margin-bottom: 1px;
   padding-bottom: 2px;
+  page-break-inside: avoid;
 }
 
 div.body .bordered {
@@ -109,6 +113,7 @@ div.body .code {
   padding-top: 1px;
   margin: 1px;
   padding-left: 1px;
+  page-break-inside: avoid;
 }
 
 div.body .highlighter {
@@ -137,6 +142,7 @@ div.body .pad {
   margin-top: 0;
   padding-top: 2px;
   padding-bottom: 2px;
+  page-break-inside: avoid;
 }
 
 div.body .lower {


### PR DESCRIPTION
This is accomplished by adding an option to avoid that to a bundle of the css elements that are near the page break. Not sure exactly which one was the issue, but since we don't want ANY of those things spanning pages I put it in a lot of places.

Unfortunately, this does not include extending the cheatsheet to include a section on stats or similarity functions as planned; this will be the extent of changes to the cheatsheet in the short term.