### PR TITLE
URL v Path Evaluation

### DIFF
--- a/nimble/core/_createHelpers.py
+++ b/nimble/core/_createHelpers.py
@@ -40,6 +40,7 @@ import numbers
 import itertools
 import time
 from collections.abc import Sequence
+from urllib.parse import urlparse
 
 import numpy as np
 
@@ -2152,6 +2153,14 @@ def createDataFromFile(
             with open(source, 'rb', newline=None) as f:
                 content = f.read()
             path = source
+        # Valid UNIX-style path
+        elif (source.startswith('/') or source.startswith('~') 
+              or source.startswith('..')):
+            path = source
+        # Valid UNIX-style path
+        elif re.match(r'^[A-Za-z]:\\', source):
+            path = source
+        
         else: # webpage
             source, database = _urlSourceProcessor(source)
             try:

--- a/nimble/core/_createHelpers.py
+++ b/nimble/core/_createHelpers.py
@@ -2157,11 +2157,17 @@ def createDataFromFile(
         elif (source.startswith('/') or source.startswith('~') 
               or source.startswith('..')):
             path = source
+            raise ValueError(f"Cannot find local file at '{source}' location.")
         # Valid UNIX-style path
         elif re.match(r'^[A-Za-z]:\\', source):
             path = source
-        
+            raise ValueError(f"Cannot find local file at '{source}' location.")
+
         else: # webpage
+            parsed_url = urlparse(source)
+            if not parsed_url.netloc:
+                raise ValueError(f"Unrecognized as valid path or URL: '{source}'")
+            
             source, database = _urlSourceProcessor(source)
             try:
                 urlManager = _DirectURLManager(source, False)


### PR DESCRIPTION
The code pushed takes care of just the different local file paths atm. 

I've been doing this in an interpreter outside our code because of the myriad of local helpers wrt to finding the correct URL.
Currently locally working to correctly add in the remaining code for URL finding that doesn't interfer with our existing webpage detection. This is what is taking a little longer to do correctly.

`"docs.python.org/3/library/urllib.parse.html" `and `"www.nimbledata.org"` not currently being caught on my own urllib.parse jungle (done outside this branch). 