### PR TITLE
Adjust cleaning data expected output to be more general

### DIFF
--- a/tests/landingPage/cleaning_data_output.txt
+++ b/tests/landingPage/cleaning_data_output.txt
@@ -1,4 +1,4 @@
-['/home/tpburns/nimbleData/archive.ics.uci.edu/static/public/492/Metro_Interstate_Traffic_Volume.csv.gz']
+REGEX: .+?nimbleData.+?Metro_Interstate_Traffic_Volume.+?
 Raw traffic data
 45647pt x 9ft
            holiday       temp   rain_1h  snow_1h  ──  weather_description       date_time       traffic_volume


### PR DESCRIPTION
Now matching some line including 'nimbleData' and the data's file name, with some characters between and at the ends. This ought to work for unix and windows regardless of the path format or the how the string is printed.